### PR TITLE
docs(engineering): reproducible Windows first-paint numbers, and the Electron row

### DIFF
--- a/docs/engineering/budget-scoreboard.md
+++ b/docs/engineering/budget-scoreboard.md
@@ -319,3 +319,35 @@ reason not to build a claim on that column.
 | Keld beats Tauri on total RSS | **Not meaningfully** — ~3%, inside run-to-run noise. The ~330 MB helper tier is engine-fixed and near-identical across all WebView2 arms. |
 | Electrobun comparison | **No.** Windows `--env=stable` emitted a macOS-shaped bundle and no window opened; the sample is a launcher that never rendered. |
 | Installer-to-installer vs Tauri MSI / NW.js zip | **No.** Keld has no installer; `keld-host --hello` is a host-lane diagnostic and does not spawn Bun. |
+
+
+## Windows first paint, reproducible harness (2026-08-14)
+
+Supersedes the 2026-08-14 ad-hoc first-paint figures above. Those came from a
+throwaway fixed-port beacon that was reverted, so they were not reproducible.
+Re-measured with the committed harness
+[`windows/bench/Measure-FirstPaint.ps1`](https://github.com/gyldlab/keld-benches/blob/e3f65f4/windows/bench/Measure-FirstPaint.ps1)
+at [`gyldlab/keld-benches@e3f65f4`](https://github.com/gyldlab/keld-benches/commit/e3f65f4);
+raw samples (git SHAs, exe SHA-256, versions, exact command) in
+`windows/bench/windows-first-paint.json`. Median of 5, same machine/session.
+
+| Stack | first paint | main RSS | helper RSS | total RSS | procs |
+|---|---|---|---|---|---|
+| **Electron** 43.4.0 | **444 ms** | 87,088 KB | **217,284 KB** | **304,372 KB** | **4** |
+| Tauri 2.11.5 | 688 ms | 24,584 KB | 336,852 KB | 361,436 KB | 7 |
+| **Keld** `keld-host --hello` | **1,289 ms** | **19,860 KB** | 337,192 KB | 357,052 KB | 7 |
+
+### What these rows support
+
+| Claim | Supported? |
+|---|---|
+| Keld has the lowest main-process RSS on Windows | **Yes** — 19,860 KB, lowest of all three, under the ≤ 90 MB idle budget. |
+| Keld has the smallest binary | **Yes** — unchanged; 625,152 B, 13.8x under Tauri. |
+| Keld starts fast | **No. Keld is the slowest arm measured** — 1,289 ms, 1.87x Tauri on the *same* WebView2 engine and 2.9x Electron. Not an engine cost; it is Keld's own startup path. See KEL-62. |
+| Keld meets the ≤ 300 ms cold-start-to-first-paint budget (arch 01 §5) | **No** — 4.3x over. Tauri (2.3x) and Electron (1.5x) also miss it, which is context, not an excuse. |
+| Keld uses less total memory than Electron | **No** — Electron's 4-process tree beats both 7-process WebView2 arms. |
+| Keld beats Tauri on total RSS | **Not meaningfully** — ~1%, inside noise. The ~337 MB helper tier is engine-fixed. |
+
+Absolutes here run higher than the earlier ad-hoc pass (Keld 906 ms, Tauri
+504 ms) on the same machine; the **ratio** is stable at ~1.8x. Compare within a
+session, never across.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2837,6 +2837,38 @@ reason not to build a claim on that column.
 | Electrobun comparison | **No.** Windows `--env=stable` emitted a macOS-shaped bundle and no window opened; the sample is a launcher that never rendered. |
 | Installer-to-installer vs Tauri MSI / NW.js zip | **No.** Keld has no installer; `keld-host --hello` is a host-lane diagnostic and does not spawn Bun. |
 
+
+## Windows first paint, reproducible harness (2026-08-14)
+
+Supersedes the 2026-08-14 ad-hoc first-paint figures above. Those came from a
+throwaway fixed-port beacon that was reverted, so they were not reproducible.
+Re-measured with the committed harness
+[`windows/bench/Measure-FirstPaint.ps1`](https://github.com/gyldlab/keld-benches/blob/e3f65f4/windows/bench/Measure-FirstPaint.ps1)
+at [`gyldlab/keld-benches@e3f65f4`](https://github.com/gyldlab/keld-benches/commit/e3f65f4);
+raw samples (git SHAs, exe SHA-256, versions, exact command) in
+`windows/bench/windows-first-paint.json`. Median of 5, same machine/session.
+
+| Stack | first paint | main RSS | helper RSS | total RSS | procs |
+|---|---|---|---|---|---|
+| **Electron** 43.4.0 | **444 ms** | 87,088 KB | **217,284 KB** | **304,372 KB** | **4** |
+| Tauri 2.11.5 | 688 ms | 24,584 KB | 336,852 KB | 361,436 KB | 7 |
+| **Keld** `keld-host --hello` | **1,289 ms** | **19,860 KB** | 337,192 KB | 357,052 KB | 7 |
+
+### What these rows support
+
+| Claim | Supported? |
+|---|---|
+| Keld has the lowest main-process RSS on Windows | **Yes** — 19,860 KB, lowest of all three, under the ≤ 90 MB idle budget. |
+| Keld has the smallest binary | **Yes** — unchanged; 625,152 B, 13.8x under Tauri. |
+| Keld starts fast | **No. Keld is the slowest arm measured** — 1,289 ms, 1.87x Tauri on the *same* WebView2 engine and 2.9x Electron. Not an engine cost; it is Keld's own startup path. See KEL-62. |
+| Keld meets the ≤ 300 ms cold-start-to-first-paint budget (arch 01 §5) | **No** — 4.3x over. Tauri (2.3x) and Electron (1.5x) also miss it, which is context, not an excuse. |
+| Keld uses less total memory than Electron | **No** — Electron's 4-process tree beats both 7-process WebView2 arms. |
+| Keld beats Tauri on total RSS | **Not meaningfully** — ~1%, inside noise. The ~337 MB helper tier is engine-fixed. |
+
+Absolutes here run higher than the earlier ad-hoc pass (Keld 906 ms, Tauri
+504 ms) on the same machine; the **ratio** is stable at ~1.8x. Compare within a
+session, never across.
+
 ---
 
 ## Source: `docs/engineering/compat-scoreboard.md`


### PR DESCRIPTION
## Summary

Replaces the ad-hoc Windows first-paint figures with numbers produced by a committed, re-runnable harness, and adds the Electron row that was missing.

The previous numbers were measured with a throwaway fixed-port beacon that was reverted afterwards — real measurements, but nobody else could reproduce them. That was the fair criticism in [KEL-64](https://linear.app/gyldlab-keld/issue/KEL-64). The harness now lives at [`windows/bench/`](https://github.com/gyldlab/keld-benches/tree/e3f65f4/windows/bench) in `keld-benches` (`e3f65f4`), with raw per-run samples committed alongside.

**The new numbers are worse for Keld.** That is the point of measuring properly:

| Stack | first paint | main RSS | total RSS | procs |
|---|---|---|---|---|
| **Electron** 43.4.0 | **444 ms** | 87,088 KB | **304,372 KB** | **4** |
| Tauri 2.11.5 | 688 ms | 24,584 KB | 361,436 KB | 7 |
| **Keld** | **1,289 ms** | **19,860 KB** | 357,052 KB | 7 |

Keld is the **slowest arm to first paint** — 1.87x Tauri on the identical WebView2 engine, 2.9x Electron. It keeps main-process RSS and binary size. Every arm misses the arch 01 §5 ≤ 300 ms budget; Keld by 4.3x.

## Spec refs

- `docs/architecture/01-overview.md` §5 (cold start → first paint)
- AGENTS.md § Public benches — fixtures in `keld-benches`, rows link an immutable SHA

## Review gates

None. Documentation and generated corpus only — no `unsafe`, no public API, no permission model, no dependency, no wire protocol.

## Tests

```
cargo fmt --all -- --check          # clean
cargo test --workspace              # 229 passed, 0 failed
llms-docs check .                   # clean
ci-hygiene check .                  # clean
```

Harness negative controls (`windows/bench/Test-Harness.ps1`) — 6/6 pass. They assert a plausibly-broken oracle *fails*: stale nonce rejected, silent arm yields no value rather than 0, abandoned accepts demonstrably swallow the beacon, template parameterises port and nonce and does not use `document.title`.

## Platforms

Windows 11 (10.0.26200), WebView2 Evergreen 151.0.4129.78. macOS/Linux untouched — the harness is Windows-only and the macOS oracle is [KEL-64](https://linear.app/gyldlab-keld/issue/KEL-64) / PR #10.

## Perf impact

None to product code. This changes what we measure and claim, not what ships.

## Notes

Three bugs shaped the design, all found by the measurement failing rather than by reasoning:

1. `document.title` never reaches the native window caption in an embedded webview — the framework owns it. A title-based signal fails silently and *identically* on every arm, so it reads as "nothing painted" rather than "the probe is wrong."
2. `fetch()` is CORS-blocked from the opaque `with_html`/`NavigateToString` origin; an `<img>` GET is not.
3. Draining a listener with repeated `GetContextAsync()` swallows the real beacon — an abandoned accept still consumes the request. This produced a full false-negative sweep before it was found.

Two limits are recorded rather than hidden: the nonce is **per session, not per launch** (every arm bakes HTML in at build time, so per-launch would mean per-launch rebuilds), and the harness patches product sources and relies on the operator restoring them — no committed binary reproduces these exact numbers. Closing that needs runtime-loaded content, which is a different measurement lane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added reproducible Windows first-paint benchmark results for Electron, Tauri, and Keld.
  - Documented median first-paint times, memory usage, helper processes, process counts, and binary sizes.
  - Clarified that Keld has the lowest main-process memory and smallest binary, but the slowest first paint and does not lead in total memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->