### PR TITLE
fix(agents): route unexpected memory recall (KEL-67)

### DIFF
--- a/docs/onboarding/06-documentation-map.md
+++ b/docs/onboarding/06-documentation-map.md
@@ -158,10 +158,11 @@ cite the polished numbered doc that consumed it.
 
 [`.agents/index.md`](../../.agents/index.md) is the router. Load only the rows matching
 the task; a topic playbook is not a second always-on root rules file. In particular,
-[`.agents/memory.md`](../../.agents/memory.md) applies only when configuring, using,
-reviewing, upgrading, or removing an **approved external** contributor-memory service.
-It does not apply to ordinary Keld work and does not authorize installing, starting, or
-authenticating such a service.
+[`.agents/memory.md`](../../.agents/memory.md) applies when configuring, using, reviewing,
+upgrading, or removing an **approved external** contributor-memory service, and whenever
+recalled material or a memory result appears unexpectedly. Ordinary Keld work with no
+memory material does not load it. Surprise recall is quarantined and does not expand the
+task; the playbook does not authorize installing, starting, or authenticating a service.
 
 ### The self-improvement rule (mandatory)
 


### PR DESCRIPTION
## Summary
- align the onboarding documentation map with the binding memory router
- load the memory playbook for unexpected recall as well as approved service lifecycle work
- preserve the ordinary-work exclusion, quarantine boundary, and no-install authorization rule

## Spec refs
- `docs/specs/optional-agent-memory-pilot.md` §4.5
- KEL-67 T3 follow-up

## Review gates
1. unsafe: none
2. public API: none
3. permission model: none
4. dependency addition: none
5. wire protocol: none

## Tests
- `git diff --check`
- `just agents-md`
- `just llms-check`
- `just llms-test` (7 passed)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace --profile ci` (229 passed)
- independent trigger-semantics audit: no blocker/high
- CodeRabbit single-file review: zero findings

## Platforms
- documentation-only; workspace gates exercised on macOS

## Perf impact
- none