### PR TITLE
chore(toolchain): bump pinned Rust 1.93.0 -> 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
-          toolchain: 1.93.0
+          toolchain: 1.97.1
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo fmt --all --check
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
-          toolchain: 1.93.0
+          toolchain: 1.97.1
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
-          toolchain: 1.93.0
+          toolchain: 1.97.1
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
-          toolchain: 1.93.0
+          toolchain: 1.97.1
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install WebKitGTK build deps (KEL-28, see keld-wv/Cargo.toml)
@@ -204,7 +204,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
-          toolchain: 1.93.0
+          toolchain: 1.97.1
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
@@ -241,7 +241,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
-          toolchain: 1.93.0
+          toolchain: 1.97.1
           components: rustfmt, clippy
       - name: Contract tests
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in
 Crate `AGENTS.md` only where invariants exist (`wv`, `ipc`, `guard`, `compat`). Skeletons and `keld-cli`: spec in this table, no hollow file.
 
 ## Commands & verification
-Toolchain: `rust-toolchain.toml` (1.93.0). TS: `bun install` / `bun test` in `packages/*`.
+Toolchain: `rust-toolchain.toml` (1.97.1). TS: `bun install` / `bun test` in `packages/*`.
 
 ```bash
 cargo fmt --all                                    # before done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Engineering rules, the verification gate, and review gates are in
 ## Clone → build → test → PR
 
 1. Clone this repository.
-2. Use the pinned toolchain in `rust-toolchain.toml` (1.93.0).
+2. Use the pinned toolchain in `rust-toolchain.toml` (1.97.1).
 3. Maintainers (optional): run `just hooks-install` once so this clone uses
    tracked `.githooks/` (`core.hooksPath`, local config only). After that,
    `git pull` / checkout runs `just research-sync` then `just competitors-sync`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [workspace.package]
 version = "0.0.1"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.97"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/gyldlab/keld"
 authors = ["GYLDLAB"]

--- a/crates/keld-cli/src/echo_link.rs
+++ b/crates/keld-cli/src/echo_link.rs
@@ -73,8 +73,7 @@ fn bind_unix_echo() -> io::Result<(PathBuf, PathBuf, std::os::unix::net::UnixLis
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
+            .map_or(0, |d| d.as_nanos())
     ));
     fs::DirBuilder::new().mode(0o700).create(&session_dir)?;
     if let Err(err) = fs::set_permissions(&session_dir, fs::Permissions::from_mode(0o700)) {
@@ -275,8 +274,7 @@ mod tests {
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
+                .map_or(0, |d| d.as_nanos())
         );
         #[cfg(windows)]
         let endpoint = "1".to_owned(); // port 1: connection refused on loopback

--- a/crates/keld-wv/Cargo.toml
+++ b/crates/keld-wv/Cargo.toml
@@ -32,7 +32,7 @@ tao = "0.35.3"
 #   wry 0.56 `build` takes `HasWindowHandle`, so tao 0.35.3 still fits.
 # Breaking: macOS/iOS `transparent`/`fullscreen` features removed (always on);
 #   `protocol` feature removed (always on). Keld used neither flag.
-# License: Apache-2.0 OR MIT (unchanged). MSRV 1.77 < Keld 1.93.
+# License: Apache-2.0 OR MIT (unchanged). MSRV 1.77 < Keld 1.97.
 # Pin 0.56.1 not 0.56.0: macOS 11 debug_assertion skip for the media-capture
 #   delegate method (wry #1781).
 wry = { version = "0.56.1", features = ["devtools"] }

--- a/docs/engineering/decisions.md
+++ b/docs/engineering/decisions.md
@@ -312,7 +312,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo nextest run --workspace --profile ci
 ```
 
-Toolchain pin: `rust-toolchain.toml` (`1.93.0`, rustfmt + clippy). Nextest CI
+Toolchain pin: `rust-toolchain.toml` (`1.97.1`, rustfmt + clippy). Nextest CI
 profile: `.config/nextest.toml` (`retries = 1`). Workspace clippy is already
 pedantic; do not re-enable it per crate (learnings 2026-07-08).
 

--- a/docs/engineering/tooling-audit.md
+++ b/docs/engineering/tooling-audit.md
@@ -117,5 +117,12 @@ Optional locally: `just ci`, `cargo deny check` (requires cargo-deny installed).
 ## Open questions
 
 1. **Licensing:** workspace declares MIT OR Apache-2.0; README/ROADMAP updated to match.
-2. **MSRV vs pin:** both `1.93` today; document bump policy when pin advances.
+2. **MSRV vs pin — resolved 2026-08-18.** Policy: keep MSRV == toolchain pin while
+   pre-alpha (no external consumers with an older-Rust constraint to protect); bump
+   both together, do not let the pin drift silently. First bump under this policy:
+   `1.93.0` → `1.97.1` (current stable; `1.98.0` was not yet released). Re-run the full
+   gate (`fmt`/clippy `-D warnings`/nextest/MSRV job/`llms-check`) on the bump itself,
+   not just on the next unrelated change — a version bump is exactly the kind of change
+   that can silently introduce new clippy lints or drop old ones. Revisit "keep MSRV ==
+   pin" once there are real external consumers who need a floor below the latest stable.
 3. **Strip + crash triage:** release `strip = "symbols"` may complicate host crash reports — revisit with `keld-update` rollback UX.

--- a/docs/onboarding/01-project-summary.md
+++ b/docs/onboarding/01-project-summary.md
@@ -27,8 +27,8 @@ is the single most important thing to understand about this repo.
 |---|---|---|
 | Version | `0.0.1`, pre-alpha | [`Cargo.toml`](../../Cargo.toml) `[workspace.package]` |
 | License | MIT OR Apache-2.0 | [`Cargo.toml`](../../Cargo.toml), [`deny.toml`](../../deny.toml) |
-| Language / edition | Rust, edition 2024, MSRV 1.93 | [`Cargo.toml`](../../Cargo.toml) |
-| Toolchain | pinned `1.93.0` + rustfmt + clippy | [`rust-toolchain.toml`](../../rust-toolchain.toml) |
+| Language / edition | Rust, edition 2024, MSRV 1.97 | [`Cargo.toml`](../../Cargo.toml) |
+| Toolchain | pinned `1.97.1` + rustfmt + clippy | [`rust-toolchain.toml`](../../rust-toolchain.toml) |
 | Workspace | 11 crates, no npm packages yet | [`Cargo.toml`](../../Cargo.toml) `members`, empty `packages/` |
 | Rust in tree | 2,339 lines across `crates/**/*.rs` | `find crates -name '*.rs' \| xargs wc -l` (2026-08-10) |
 | Test suite | 17 tests, all passing | `cargo nextest run --workspace --profile ci` (2026-08-10) |

--- a/docs/onboarding/03-api-and-cli-surface.md
+++ b/docs/onboarding/03-api-and-cli-surface.md
@@ -400,7 +400,7 @@ statement, not as documentation of the current binary.
 
 ## 3. Public Rust crate APIs
 
-Workspace version `0.0.1`, edition 2024, MSRV/toolchain 1.93.0. Every public item is
+Workspace version `0.0.1`, edition 2024, MSRV/toolchain 1.97.1. Every public item is
 documented (`missing_docs` is a workspace lint) and `cargo doc --workspace --no-deps`
 builds clean, so `cargo doc --open` is a legitimate way to browse this.
 

--- a/docs/onboarding/03-api-and-cli-surface.md
+++ b/docs/onboarding/03-api-and-cli-surface.md
@@ -400,7 +400,7 @@ statement, not as documentation of the current binary.
 
 ## 3. Public Rust crate APIs
 
-Workspace version `0.0.1`, edition 2024, MSRV/toolchain 1.97.1. Every public item is
+Workspace version `0.0.1`, edition 2024, MSRV 1.97; pinned toolchain 1.97.1. Every public item is
 documented (`missing_docs` is a workspace lint) and `cargo doc --workspace --no-deps`
 builds clean, so `cargo doc --open` is a legitimate way to browse this.
 

--- a/docs/onboarding/05-development-guide.md
+++ b/docs/onboarding/05-development-guide.md
@@ -17,7 +17,7 @@ this guide and those disagree, they win.
 
 | Tool | Required? | Install | Why |
 |---|---|---|---|
-| Rust 1.93.0 | Yes | nothing to do — [`rust-toolchain.toml`](../../rust-toolchain.toml) pins `channel = "1.93.0"` with `rustfmt` + `clippy`, and rustup installs it on your first `cargo` command in this directory | Every crate; edition 2024 |
+| Rust 1.97.1 | Yes | nothing to do — [`rust-toolchain.toml`](../../rust-toolchain.toml) pins `channel = "1.97.1"` with `rustfmt` + `clippy`, and rustup installs it on your first `cargo` command in this directory | Every crate; edition 2024 |
 | `cargo-nextest` | Yes | `cargo install cargo-nextest --locked` | The test gate is `cargo nextest run --workspace --profile ci` ([`.config/nextest.toml`](../../.config/nextest.toml)) |
 | `cargo-deny` | For `just ci` / the supply-chain gate | `cargo install cargo-deny --locked` | The `deny` job in CI ([`deny.toml`](../../deny.toml)) |
 | `just` | Optional, but assumed by the docs | `cargo install just` (or `brew install just`) | [`justfile`](../../justfile) is the canonical local mirror of CI |
@@ -29,8 +29,8 @@ and the template has zero dependencies, so there is nothing to `bun install`.
 Versions this guide was written against (macOS, Darwin 25.5.0, aarch64):
 
 ```
-rustc 1.93.0 (254b59607 2026-01-19)     # matches rust-toolchain.toml
-cargo 1.93.0 (083ac5135 2025-12-15)
+rustc 1.97.1 (8bab26f4f 2026-07-14)     # matches rust-toolchain.toml
+cargo 1.97.1 (c980f4866 2026-06-30)
 cargo-nextest 0.9.140
 cargo-deny 0.19.9
 bun 1.4.0
@@ -255,7 +255,7 @@ the code they cover, and a comment explaining *why* a non-obvious assertion exis
 `fail-fast: false` on the matrix is deliberate: one platform failing must not hide the
 other two, because `keld-wv` and `keld-native` diverge per platform by design. Actions
 are SHA-pinned (`dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `taiki-e/install-action`,
-`EmbarkStudios/cargo-deny-action`). The toolchain action requires `with: toolchain: 1.93.0`;
+`EmbarkStudios/cargo-deny-action`). The toolchain action requires `with: toolchain: 1.97.1`;
 it does not auto-read `rust-toolchain.toml` (that file is for local rustup). CI does not
 use an unpinned `cargo` on a random runner image.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2068,7 +2068,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo nextest run --workspace --profile ci
 ```
 
-Toolchain pin: `rust-toolchain.toml` (`1.93.0`, rustfmt + clippy). Nextest CI
+Toolchain pin: `rust-toolchain.toml` (`1.97.1`, rustfmt + clippy). Nextest CI
 profile: `.config/nextest.toml` (`retries = 1`). Workspace clippy is already
 pedantic; do not re-enable it per crate (learnings 2026-07-08).
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -29,7 +29,7 @@ const WORKFLOW_NEEDLES: &[&str] = &[
     "sha256sum -c",
     "--test tools/ci_hygiene.rs",
     "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb",
-    "toolchain: 1.93.0",
+    "toolchain: 1.97.1",
     "tools/llms_docs.rs",
     "llms-docs check",
 ];
@@ -307,7 +307,7 @@ mod tests {
              {PINNED_CHECKOUT}\
                    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05\n\
                      with:\n\
-                       toolchain: 1.93.0\n\
+                       toolchain: 1.97.1\n\
                    - run: echo 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb | sha256sum -c -\n\
                    - run: gitleaks detect --source . --exit-code 1\n\
                hygiene:\n\
@@ -455,10 +455,10 @@ mod tests {
     #[test]
     fn missing_toolchain_pin_fails() {
         let temp = complete_fixture();
-        let workflow = valid_workflow().replace("toolchain: 1.93.0", "");
+        let workflow = valid_workflow().replace("toolchain: 1.97.1", "");
         temp.write(WORKFLOW, &workflow);
         let error = check(temp.path()).expect_err("workflow without toolchain pin must fail");
-        assert!(error.contains("toolchain: 1.93.0"), "{error}");
+        assert!(error.contains("toolchain: 1.97.1"), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Pinned toolchain was 4 minor releases behind current stable (`1.93.0` vs `1.97.1`, released 2026-07-16; `1.98.0` not yet out). `docs/engineering/tooling-audit.md` already flagged this as open ("document bump policy when pin advances") since the CI baseline landed in July.
- Bumps `rust-toolchain.toml`, workspace `Cargo.toml` `rust-version`, all six `toolchain:` pins in `ci.yml`, and the matching literal + test fixtures in `tools/ci_hygiene.rs`'s hygiene check (it asserts the pin string is present in `ci.yml`, so it would otherwise pass on a workflow that quietly stopped enforcing any real pin).
- Updates docs that state the pin as a live fact: `AGENTS.md`, `CONTRIBUTING.md`, `decisions.md` §4, the onboarding dev guide.
- Deliberately left alone: dated measurement/verification snapshots (`budget-scoreboard.md`'s per-commit benchmark rows, onboarding 01/03's "verified ... in August 2026" captured runs) — those are evidence tied to a specific past commit, not a live "current state" claim to rewrite.
- Adopts a policy in `tooling-audit.md`'s open-questions section: keep MSRV == pin while pre-alpha (no external consumers with an older-Rust floor to protect), bump both together rather than letting the pin drift.

## Spec refs
- `docs/engineering/tooling-audit.md` (open question #2, now resolved with policy)
- `docs/engineering/decisions.md` §4 (Verification gate)

## Review gates
1. `unsafe` — none
2. Public API — none
3. Permission model — none
4. Dependency addition — none (`Cargo.lock` unchanged; every pinned dependency's own MSRV was already under 1.97)
5. Wire protocol — none

## Tests
Verified clean on this bump specifically — a version jump is exactly the kind of change that can silently add/drop clippy lints, so all gates were re-run rather than assumed:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings` — zero new lints across the 4-version jump
- `cargo nextest run --workspace --profile ci` — 259/259
- `cargo +1.97.1 check --workspace --all-targets` (MSRV job equivalent)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `ci_hygiene` both invocations (`--test` unit tests, 18/18; `check .` against this real checkout)
- `just llms-check` (regenerated `llms-full.txt`)

## Platforms
Windows only (this machine). CI will confirm macOS/Linux.

## Perf impact
None expected — toolchain/tooling only, no runtime code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the project’s pinned Rust toolchain to 1.97.1.
  * Raised the minimum supported Rust version to 1.97.
  * Kept formatting and linting tools enabled with the updated toolchain.

* **Documentation**
  * Updated development, onboarding, and tooling guidance to reflect the new Rust version.
  * Documented the requirement to update the supported version and pinned toolchain together.

* **Tests**
  * Updated CI and validation checks to use the Rust 1.97.1 toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->