### PR TITLE
docs(arch): caveat Windows first-paint budget with the WebView2 engine floor

### DIFF
--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -197,6 +197,18 @@ Windows laptop. They are not current product measurements or live CI gates.
 evidence in `docs/engineering/budget-scoreboard.md` are measurements. Once the harness
 lands, valid regressions greater than 5% fail the PR or require a written waiver.
 
+Windows/WebView2 cold start → first paint currently misses its ≤ 300 ms row by ~1.6x
+(~470–510 ms measured), and that gap is not Keld's own cost: `CreateCoreWebView2Controller`
+boots a Chromium process and is, per Microsoft, "the bulk of starting a WebView2 control"
+(WebView2Feedback #1536) — Keld's attributable overhead is 3–6 ms (environment creation).
+A controlled same-session A/B isolated and refuted the one remaining Keld-owned hypothesis
+(wry's IPC-bridge injection); the direct-COM backend ties or leads Tauri on the identical
+engine. Full attribution chain and raw numbers: KEL-62; direct-COM measurement:
+`docs/engineering/budget-scoreboard.md` § "Windows first paint on the direct-COM backend".
+The only supported lever past this floor is hidden-webview prewarm + `put_ParentWindow`
+reparent — a memory-for-latency trade with no payoff for a bare hello window, deferred to
+KEL-83 pending a real concurrent-init consumer (Bun boot) to overlap it against.
+
 ## 6. What Keld is not (v1 non-goals)
 
 - Not a mobile framework (architecture reserves the seam — `keld-wv` backends — but no

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1003,6 +1003,18 @@ Windows laptop. They are not current product measurements or live CI gates.
 evidence in `docs/engineering/budget-scoreboard.md` are measurements. Once the harness
 lands, valid regressions greater than 5% fail the PR or require a written waiver.
 
+Windows/WebView2 cold start → first paint currently misses its ≤ 300 ms row by ~1.6x
+(~470–510 ms measured), and that gap is not Keld's own cost: `CreateCoreWebView2Controller`
+boots a Chromium process and is, per Microsoft, "the bulk of starting a WebView2 control"
+(WebView2Feedback #1536) — Keld's attributable overhead is 3–6 ms (environment creation).
+A controlled same-session A/B isolated and refuted the one remaining Keld-owned hypothesis
+(wry's IPC-bridge injection); the direct-COM backend ties or leads Tauri on the identical
+engine. Full attribution chain and raw numbers: KEL-62; direct-COM measurement:
+`docs/engineering/budget-scoreboard.md` § "Windows first paint on the direct-COM backend".
+The only supported lever past this floor is hidden-webview prewarm + `put_ParentWindow`
+reparent — a memory-for-latency trade with no payoff for a bare hello window, deferred to
+KEL-83 pending a real concurrent-init consumer (Bun boot) to overlap it against.
+
 ## 6. What Keld is not (v1 non-goals)
 
 - Not a mobile framework (architecture reserves the seam — `keld-wv` backends — but no


### PR DESCRIPTION
## Summary
- KEL-62's full attribution chain (controller-bounds fix, harness fix, KEL-65's direct-COM A/B) has isolated the remaining Windows cold-start-to-first-paint overage to `CreateCoreWebView2Controller`'s Chromium process boot — an external engine cost, not Keld's own code (Keld's attributable overhead is 3–6 ms).
- `docs/architecture/01-overview.md` §5 stated the ≤300 ms budget with no note that it's currently missed and why, on the one platform where root cause is now fully attributed. This landed the "state why" side of the code/spec-match rule (root `AGENTS.md`): the budget line now cites the evidence chain and the deferred lever (KEL-83, hidden-webview prewarm + reparent) instead of sitting unexplained.
- Docs-only; no code, no behavior change.

## Spec refs
`docs/architecture/01-overview.md` §5. Evidence: KEL-62, KEL-65, `docs/engineering/budget-scoreboard.md` § "Windows first paint on the direct-COM backend (2026-08-15, controlled A/B, median of 7)".

## Review gates
None (docs-only: no unsafe, public API, permission, dependency, or wire-protocol change).

## Tests
- `rustc --edition=2024 -D warnings tools/llms_docs.rs -o target/llms-docs/llms-docs && target/llms-docs/llms-docs generate .` — regenerated `llms-full.txt`
- `target/llms-docs/llms-docs check .` — passes (generated docs match sources)
- (`just` is not installed on this machine; ran the two `llms`/`llms-check` recipe bodies directly — see `justfile` lines 76–85 for the equivalent recipes.)

## Platforms
Docs only — no platform-specific behavior.

## Perf impact
None (no code changed). The PR documents an existing, already-measured Windows perf gap; it does not change any measured number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented Windows/WebView2 cold-start performance at approximately 470–510 ms, compared with the 300 ms target.
  * Identified browser startup as the primary contributor to initial load time.
  * Recorded testing results showing minimal impact from application environment setup and bridge initialization.
  * Deferred prewarming improvements for future consideration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->