### PR TITLE
docs: state repo map and crate table as current fact (KEL-91)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ is `docs/architecture/01-overview.md` §1.
 
 | Crate | Role |
 |---|---|
-| keld-core | Event loop, windows, lifecycle — spec 01 |
+| keld-core | Hello window + lifecycle session; TARGET event loop integration, window registry — spec 01 |
 | keld-wv | WebEngine; wkwebview/webview2/webkitgtk; TARGET cef — spec 05; `AGENTS.md` |
 | keld-ipc | kipc framing/codecs; TARGET channel registry + shm — spec 02; `AGENTS.md` |
 | keld-guard | Capabilities, manifest, scopes — spec 03; `AGENTS.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,13 +64,17 @@ distinction would otherwise be ambiguous.
 
 ## Repo map
 
+Role is what the crate **is** today. `TARGET` marks specified destination scope that is
+not implemented; `SKELETON` marks a name-only module surface. Per-crate current status
+is `docs/architecture/01-overview.md` §1.
+
 | Crate | Role |
 |---|---|
 | keld-core | Event loop, windows, lifecycle — spec 01 |
-| keld-wv | WebEngine; wkwebview/webview2/webkitgtk/cef — spec 05; `AGENTS.md` |
-| keld-ipc | kipc framing/codecs/channels/shm — spec 02; `AGENTS.md` |
+| keld-wv | WebEngine; wkwebview/webview2/webkitgtk; TARGET cef — spec 05; `AGENTS.md` |
+| keld-ipc | kipc framing/codecs; TARGET channel registry + shm — spec 02; `AGENTS.md` |
 | keld-guard | Capabilities, manifest, scopes — spec 03; `AGENTS.md` |
-| keld-native | menu/tray/dialog/process/PTY brokers; guard-checked — spec 05 |
+| keld-native | guard-checked brokers; `fs` live, rest SKELETON — spec 05 |
 | keld-runtime | Bun child-role supervisor — spec 06 |
 | keld-update | bsdiff+zstd, signed manifests — spec 06 |
 | keld-pack | Installers, signing, cross-compile — spec 06 |
@@ -137,7 +141,7 @@ expansion, and an invalid `matrix.os` guard fails the workflow file so rustc nev
 
 ## Rust
 - Lints: workspace `Cargo.toml` — `clippy::pedantic`, `missing_docs` warn (CI denies). A new `allow` MUST have an inline justification.
-- `unsafe` MUST appear only in `keld-wv` backends + `keld-ipc` shm; `#![deny(unsafe_op_in_unsafe_fn)]`, `// SAFETY:` proof. Else = human review.
+- `unsafe` MUST appear only in `keld-wv` backends (and in `keld-ipc` shm once that module exists; it does not today); `#![deny(unsafe_op_in_unsafe_fn)]`, `// SAFETY:` proof. Else = human review.
 - Agents MUST NOT add `unwrap`/`expect`/`panic!` in libs. Typed errors: hand-rolled `Display` + `KELD-*` codes (not `thiserror`). `expect` MAY appear in tests + `keld-cli` top-level (state invariant).
 - Errors MUST state the fix — see `docs/architecture/07-agent-experience.md` §2; model `DenyReason`.
 - Hot paths (kipc, event-loop, guard): callbacks/state machines. Agents MUST NOT add an async runtime or steady-state alloc there. Async MAY appear only in cold tooling (cli/pack/update).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ tempfile = "3"
 # Purpose: CSPRNG for the kipc v2 HELLO session token. `std::random` is
 #   unstable on 1.93 (rust-lang/rust#130703). `/dev/urandom` is Unix-only;
 #   Windows ProcessPrng would be `unsafe` in Keld code (forbidden outside
-#   keld-wv backends / keld-ipc shm).
+#   keld-wv backends; keld-ipc shm once that module exists).
 # Alternatives rejected: (a) getrandom 0.2 — older `getrandom()` API; 0.4 is
 #   current (`fill`), MSRV 1.85 ≤ 1.93; (b) `rand` — extra surface; (c)
 #   `uuid` — 16 bytes, wrong type; (d) `HashMap` `RandomState` — not a CSPRNG
@@ -97,9 +97,9 @@ sha2 = "0.10"
 [workspace.lints.rust]
 missing_docs = "warn"
 missing_debug_implementations = "warn"
-# `deny` rather than `forbid` so the two sanctioned locations (`keld-wv` platform
-# backends, `keld-ipc::shm`) can opt in with an explicit, reviewable module-scope
-# `#[allow(unsafe_code)]` + `// SAFETY:` proofs, per AGENTS.md.
+# `deny` rather than `forbid` so the sanctioned location (`keld-wv` platform backends
+# today; `keld-ipc::shm` once that module exists) can opt in with an explicit,
+# reviewable module-scope `#[allow(unsafe_code)]` + `// SAFETY:` proof, per AGENTS.md.
 unsafe_code = "deny"
 
 [workspace.lints.clippy]

--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -13,16 +13,17 @@ flowchart LR
       The trusted Rust host owns privileged resources and mediates webview and Bun-role
       requests. The live v0 slice has three webview backends, a guard evaluator, a
       host-owned token-authenticated echo link co-lived with the hello window (KEL-30),
-      and KEL-70's generic supervised Bun child restart loop. Full role-bound app-link
-      identity, guarded role dispatch, native services, and an optional sandboxed
-      native-addon worker remain destination behavior.
+      KEL-70's generic supervised Bun child restart loop, and guard-checked scoped
+      filesystem access (KEL-71). Full role-bound app-link identity, guarded role
+      dispatch, the remaining native services, and an optional sandboxed native-addon
+      worker remain destination behavior.
     }
 
     subgraph Host["Trusted authority process: keld-host / keld-core"]
         Core["PARTIAL LIVE<br/>hello window + lifecycle session<br/>TARGET window registry"]
         Link["PARTIAL LIVE<br/>host-owned hello echo app-link<br/>TARGET role-bound"]
         Guard["PARTIAL LIVE<br/>guard evaluator exists<br/>TARGET guard-before-handler"]
-        Native["SKELETON<br/>guarded native services"]
+        Native["PARTIAL LIVE<br/>fs scoped + guard-checked<br/>TARGET remaining native services"]
         Runtime["PARTIAL LIVE<br/>generic Bun supervisor<br/>TARGET role identity"]
     end
 
@@ -127,7 +128,7 @@ implemented. The per-crate status legend is the §1 diagram above.
 | `keld-core` | host runtime: lifecycle session, hello window; TARGET event loop integration, window registry, plugin host | wv, ipc, guard (TARGET: native, runtime) |
 | `keld-wv` | webview abstraction: live `wkwebview`/`webview2`/`webkitgtk` backends; CEF is a planned opt-in candidate, not a current feature | — |
 | `keld-ipc` | kipc protocol: framing, codecs; TARGET channel registry, shm rings, schema runtime | — |
-| `keld-native` | native APIs: `fs` scoped + guard-checked (live); TARGET menus, tray, dialogs, clipboard, notifications, shortcuts, screen, power, shell, secure storage | guard |
+| `keld-native` | native APIs: `fs` scoped + guard-checked (live); TARGET menus, tray, dialogs, clipboard, notifications, shortcuts, screen, power, shell, secure storage | ipc, guard |
 | `keld-guard` | capability engine: manifest parsing, scope matching, per-window/per-principal grants, audit log | — |
 | `keld-runtime` | app-process-family supervisor: Bun discovery/pinning, named role spawn, health, per-role principal/lifecycle/restart policy, stdio capture | ipc |
 | `keld-update` | updater: manifest polling, bsdiff/zstd patches, signature verification, rollback | — |
@@ -152,8 +153,8 @@ npm packages (TypeScript, in `packages/`):
 
 Rules: crates never depend "upward"; `keld-wv`/`keld-ipc`/`keld-guard` are host-agnostic
 and unit-testable headless; every public item documented; `#![forbid(unsafe_code)]`
-everywhere except `keld-wv` backends and the shm module of `keld-ipc`, where each
-`unsafe` block carries a `// SAFETY:` proof.
+everywhere except `keld-wv` backends today, and the shm module of `keld-ipc` once that
+module exists, where each `unsafe` block carries a `// SAFETY:` proof.
 
 ## 4. Process & thread model
 

--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -118,14 +118,16 @@ Why this shape (each competitor fails differently — see `docs/research/00-land
 
 ## 3. Crate & package topology
 
-Cargo workspace (all crates `keld-*`, lib names `keld_*`):
+Cargo workspace (all crates `keld-*`, lib names `keld_*`). Role and `Depends on` state
+what each crate **is** today; `TARGET` marks specified destination scope that is not
+implemented. The per-crate status legend is the §1 diagram above.
 
 | Crate | Role | Depends on |
 |---|---|---|
-| `keld-core` | host runtime: event loop integration, window registry, lifecycle, plugin host | wv, ipc, guard, native, runtime |
+| `keld-core` | host runtime: lifecycle session, hello window; TARGET event loop integration, window registry, plugin host | wv, ipc, guard (TARGET: native, runtime) |
 | `keld-wv` | webview abstraction: live `wkwebview`/`webview2`/`webkitgtk` backends; CEF is a planned opt-in candidate, not a current feature | — |
-| `keld-ipc` | kipc protocol: framing, codecs, channel registry, shm rings, schema runtime | — |
-| `keld-native` | native APIs: menus, tray, dialogs, clipboard, notifications, shortcuts, screen, power, shell, fs-scoped, secure storage | guard |
+| `keld-ipc` | kipc protocol: framing, codecs; TARGET channel registry, shm rings, schema runtime | — |
+| `keld-native` | native APIs: `fs` scoped + guard-checked (live); TARGET menus, tray, dialogs, clipboard, notifications, shortcuts, screen, power, shell, secure storage | guard |
 | `keld-guard` | capability engine: manifest parsing, scope matching, per-window/per-principal grants, audit log | — |
 | `keld-runtime` | app-process-family supervisor: Bun discovery/pinning, named role spawn, health, per-role principal/lifecycle/restart policy, stdio capture | ipc |
 | `keld-update` | updater: manifest polling, bsdiff/zstd patches, signature verification, rollback | — |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -925,14 +925,16 @@ Why this shape (each competitor fails differently — see `docs/research/00-land
 
 ## 3. Crate & package topology
 
-Cargo workspace (all crates `keld-*`, lib names `keld_*`):
+Cargo workspace (all crates `keld-*`, lib names `keld_*`). Role and `Depends on` state
+what each crate **is** today; `TARGET` marks specified destination scope that is not
+implemented. The per-crate status legend is the §1 diagram above.
 
 | Crate | Role | Depends on |
 |---|---|---|
-| `keld-core` | host runtime: event loop integration, window registry, lifecycle, plugin host | wv, ipc, guard, native, runtime |
+| `keld-core` | host runtime: lifecycle session, hello window; TARGET event loop integration, window registry, plugin host | wv, ipc, guard (TARGET: native, runtime) |
 | `keld-wv` | webview abstraction: live `wkwebview`/`webview2`/`webkitgtk` backends; CEF is a planned opt-in candidate, not a current feature | — |
-| `keld-ipc` | kipc protocol: framing, codecs, channel registry, shm rings, schema runtime | — |
-| `keld-native` | native APIs: menus, tray, dialogs, clipboard, notifications, shortcuts, screen, power, shell, fs-scoped, secure storage | guard |
+| `keld-ipc` | kipc protocol: framing, codecs; TARGET channel registry, shm rings, schema runtime | — |
+| `keld-native` | native APIs: `fs` scoped + guard-checked (live); TARGET menus, tray, dialogs, clipboard, notifications, shortcuts, screen, power, shell, secure storage | guard |
 | `keld-guard` | capability engine: manifest parsing, scope matching, per-window/per-principal grants, audit log | — |
 | `keld-runtime` | app-process-family supervisor: Bun discovery/pinning, named role spawn, health, per-role principal/lifecycle/restart policy, stdio capture | ipc |
 | `keld-update` | updater: manifest polling, bsdiff/zstd patches, signature verification, rollback | — |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -820,16 +820,17 @@ flowchart LR
       The trusted Rust host owns privileged resources and mediates webview and Bun-role
       requests. The live v0 slice has three webview backends, a guard evaluator, a
       host-owned token-authenticated echo link co-lived with the hello window (KEL-30),
-      and KEL-70's generic supervised Bun child restart loop. Full role-bound app-link
-      identity, guarded role dispatch, native services, and an optional sandboxed
-      native-addon worker remain destination behavior.
+      KEL-70's generic supervised Bun child restart loop, and guard-checked scoped
+      filesystem access (KEL-71). Full role-bound app-link identity, guarded role
+      dispatch, the remaining native services, and an optional sandboxed native-addon
+      worker remain destination behavior.
     }
 
     subgraph Host["Trusted authority process: keld-host / keld-core"]
         Core["PARTIAL LIVE<br/>hello window + lifecycle session<br/>TARGET window registry"]
         Link["PARTIAL LIVE<br/>host-owned hello echo app-link<br/>TARGET role-bound"]
         Guard["PARTIAL LIVE<br/>guard evaluator exists<br/>TARGET guard-before-handler"]
-        Native["SKELETON<br/>guarded native services"]
+        Native["PARTIAL LIVE<br/>fs scoped + guard-checked<br/>TARGET remaining native services"]
         Runtime["PARTIAL LIVE<br/>generic Bun supervisor<br/>TARGET role identity"]
     end
 
@@ -934,7 +935,7 @@ implemented. The per-crate status legend is the §1 diagram above.
 | `keld-core` | host runtime: lifecycle session, hello window; TARGET event loop integration, window registry, plugin host | wv, ipc, guard (TARGET: native, runtime) |
 | `keld-wv` | webview abstraction: live `wkwebview`/`webview2`/`webkitgtk` backends; CEF is a planned opt-in candidate, not a current feature | — |
 | `keld-ipc` | kipc protocol: framing, codecs; TARGET channel registry, shm rings, schema runtime | — |
-| `keld-native` | native APIs: `fs` scoped + guard-checked (live); TARGET menus, tray, dialogs, clipboard, notifications, shortcuts, screen, power, shell, secure storage | guard |
+| `keld-native` | native APIs: `fs` scoped + guard-checked (live); TARGET menus, tray, dialogs, clipboard, notifications, shortcuts, screen, power, shell, secure storage | ipc, guard |
 | `keld-guard` | capability engine: manifest parsing, scope matching, per-window/per-principal grants, audit log | — |
 | `keld-runtime` | app-process-family supervisor: Bun discovery/pinning, named role spawn, health, per-role principal/lifecycle/restart policy, stdio capture | ipc |
 | `keld-update` | updater: manifest polling, bsdiff/zstd patches, signature verification, rollback | — |
@@ -959,8 +960,8 @@ npm packages (TypeScript, in `packages/`):
 
 Rules: crates never depend "upward"; `keld-wv`/`keld-ipc`/`keld-guard` are host-agnostic
 and unit-testable headless; every public item documented; `#![forbid(unsafe_code)]`
-everywhere except `keld-wv` backends and the shm module of `keld-ipc`, where each
-`unsafe` block carries a `// SAFETY:` proof.
+everywhere except `keld-wv` backends today, and the shm module of `keld-ipc` once that
+module exists, where each `unsafe` block carries a `// SAFETY:` proof.
 
 ## 4. Process & thread model
 


### PR DESCRIPTION
## Summary

- The root `AGENTS.md` repo map and the `01-overview` §3 crate table described destination roles in the present tense. These are the two tables an agent loads first to decide where work goes, so drift here misroutes work.
- Three claims were false against the tree: `keld-ipc` listed `channels/shm` (no shm code exists anywhere in the crate, and there is no channel registry); `keld-native` listed `menu/tray/dialog/process/PTY brokers` (only `fs` is implemented — `process` and `pty` are not even in the `MODULES` array); and `01-overview:124` claimed `keld-core` depends on `native, runtime` when its `Cargo.toml` declares `ipc, guard, wv` only.
- The `AGENTS.md` `unsafe` rule granted an exception to `keld-ipc` shm, a module that does not exist. Corrected without removing the future allowance.

Destination scope is retained, not deleted — it is now marked. This reuses the `TARGET` / `SKELETON` vocabulary the `01-overview` §1 diagram already defines rather than introducing a second convention, and points both tables at that diagram as the single source of truth for per-crate status.

Notably the *crates* were already honest: `keld-native/src/lib.rs` says "registry skeleton with no module implementation" and `keld-ipc/AGENTS.md` scopes shm as future. The governance docs were the drifting side, which is the direction `AGENTS.md` § Ground truth says must be fixed.

## Spec refs

- `docs/architecture/01-overview.md` §3 (crate & package topology) — the edited table; §1 diagram is the status legend it now defers to.
- Root `AGENTS.md` § Repo map, § Rust.

No boundary change: docs only, zero Rust touched.

## Review gates

`none` — no `unsafe`, no public API, no permission model, no dependency addition, no wire protocol change.

One flag for human review: root `AGENTS.md` is a **single-writer human-owned file** per `docs/agents/workflow.md` § Parallelism rules. This edit was explicitly human-authorized, but it needs a human on the merge.

## Tests

```
cargo fmt --check                                            → pass
cargo clippy --workspace --all-targets -- -D warnings        → pass (exit 0)
cargo nextest run --workspace --profile ci --no-fail-fast    → 364 tests run: 364 passed, 0 skipped
```

Generated-doc freshness (`just` is not installed locally; ran the recipe's underlying commands so the generator is still rebuilt from the working tree, per the rule against trusting a stale generator):

```
rustc --edition=2024 -D warnings --test tools/llms_docs.rs   → 5 passed; 0 failed
llms-docs check .   (before regen) → KELD-DOCS004: llms-full.txt is stale   ← correctly caught this diff
llms-docs generate .
llms-docs check .   (after regen)  → pass
```

`llms.txt` is unchanged (it indexes titles/descriptions only); `llms-full.txt` carries the edited §3 table.

## Platforms

Windows 11 only — this is a docs change with no platform-conditional content. macOS and Linux not exercised and not affected; no `cfg`-gated path is touched.

## Perf impact

none — no code changed.

## Linear

KEL-91. The issue also records seven out-of-scope follow-ups from the same audit (present-tense doc comments on the 19-line `keld-update` and 25-line `keld-pack`; the `keld-guard` "every privileged operation" claim versus one live enforcement path; the `03-security.md` dev-permissive/recorder claim; two missing threat models; the `02-ipc.md` "structurally impossible" backpressure claim against an unreferenced `FrameKind::Grant`; an inverted drop-order comment in two `keld-wv` backends; and a missing `deny(unsafe_op_in_unsafe_fn)` in `wkwebview`). Each needs its own change and is deliberately not bundled here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified which platform components are currently available versus planned.
  * Updated crate and architecture references to distinguish live functionality, target capabilities, and skeleton implementations.
  * Documented guarded, scoped filesystem access as available.
  * Clarified that additional native services, runtime capabilities, and shared-memory support remain planned.
  * Updated lifecycle, IPC framing, codec, and integration status indicators.
  * Refined unsafe-code guidance for current and planned platform components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->