### PR TITLE
docs: hedge destination overclaims in update, pack, and ipc (KEL-92)

### DIFF
--- a/crates/keld-pack/src/lib.rs
+++ b/crates/keld-pack/src/lib.rs
@@ -1,9 +1,13 @@
-//! keld-pack — packaging and cross-compilation.
+//! keld-pack — packaging and cross-compilation (destination).
 //!
-//! Because the host ships prebuilt per platform and app code is portable JS,
-//! packaging is data assembly + signing — enabling `keld build --target ...`
-//! for every platform from one machine (pure-Rust installer authoring).
-//! Normative spec: `docs/architecture/06-runtime-and-tooling.md` §3.
+//! **v0:** this crate exports [`Format`] only — no installer authoring,
+//! signing, or cross-target bundling yet. `[dependencies]` is empty.
+//!
+//! **Destination:** because the host ships prebuilt per platform and app code
+//! is portable JS, packaging is data assembly + signing — enabling
+//! `keld build --target ...` for every platform from one machine
+//! (pure-Rust installer authoring). Normative spec:
+//! `docs/architecture/06-runtime-and-tooling.md` §3.
 
 /// Installer formats keld-pack can author.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/keld-update/src/lib.rs
+++ b/crates/keld-update/src/lib.rs
@@ -1,10 +1,13 @@
-//! keld-update — delta updates as a default.
+//! keld-update — signed delta updates (destination).
 //!
-//! bsdiff/zstd patches with BLAKE3 post-conditions and ed25519-signed
-//! manifests, static-host-compatible feeds, atomic swap with N-1 rollback,
-//! on all three platforms. Normative spec:
-//! `docs/architecture/06-runtime-and-tooling.md` §4; threat model lives here
-//! with the code per `docs/architecture/03-security.md` §5.
+//! **v0:** this crate exports [`Channel`] only — no patch engine, manifest
+//! parser, feed client, or signing yet. `[dependencies]` is empty.
+//!
+//! **Destination:** bsdiff/zstd patches with BLAKE3 post-conditions and
+//! ed25519-signed manifests, static-host-compatible feeds, atomic swap with
+//! N-1 rollback on all three platforms. Normative spec:
+//! `docs/architecture/06-runtime-and-tooling.md` §4. Threat model:
+//! `docs/architecture/03-security.md` §5 (implementation lands with the updater).
 
 /// Release channels supported by update feeds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/docs/architecture/02-ipc.md
+++ b/docs/architecture/02-ipc.md
@@ -99,10 +99,13 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   u16 handles resolved at handshake from schema names (string names never travel per-call).
 - **Cancellation**: `STREAM_CANCEL`/`CALL_CANCEL` carry corr id; handlers observe an
   `AbortSignal` in JS, a `CancelToken` in Rust.
-- **Backpressure**: per-channel credit windows granted in `GRANT` frames (SPSC credit
-  counting); senders suspend (JS: promise; Rust: state-machine pause) at zero credit.
-  No unbounded queues anywhere — Electron's frame-starving chatty-IPC failure is
-  structurally impossible.
+- **Backpressure (destination):** per-channel credit windows granted in `GRANT`
+  frames (SPSC credit counting); senders suspend (JS: promise; Rust:
+  state-machine pause) at zero credit. The design goal is no unbounded queues
+  anywhere — Electron's frame-starving chatty-IPC failure becomes structurally
+  impossible once credit windows ship. **v0:** `FrameKind::Grant` exists in the
+  wire schema but has no live sender/receiver; bounded inline `CALL`/`REPLY`
+  and the readiness-driven reader are the current backpressure surface (see §7).
 
 ## 3. Bulk plane (measured copies, optional shared memory)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1141,10 +1141,13 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   u16 handles resolved at handshake from schema names (string names never travel per-call).
 - **Cancellation**: `STREAM_CANCEL`/`CALL_CANCEL` carry corr id; handlers observe an
   `AbortSignal` in JS, a `CancelToken` in Rust.
-- **Backpressure**: per-channel credit windows granted in `GRANT` frames (SPSC credit
-  counting); senders suspend (JS: promise; Rust: state-machine pause) at zero credit.
-  No unbounded queues anywhere — Electron's frame-starving chatty-IPC failure is
-  structurally impossible.
+- **Backpressure (destination):** per-channel credit windows granted in `GRANT`
+  frames (SPSC credit counting); senders suspend (JS: promise; Rust:
+  state-machine pause) at zero credit. The design goal is no unbounded queues
+  anywhere — Electron's frame-starving chatty-IPC failure becomes structurally
+  impossible once credit windows ship. **v0:** `FrameKind::Grant` exists in the
+  wire schema but has no live sender/receiver; bounded inline `CALL`/`REPLY`
+  and the readiness-driven reader are the current backpressure surface (see §7).
 
 ## 3. Bulk plane (measured copies, optional shared memory)
 


### PR DESCRIPTION
## Summary
- Reword `keld-update` and `keld-pack` crate docs to state v0 reality (enum-only skeletons) while retaining destination scope.
- Hedge `docs/architecture/02-ipc.md` §2 backpressure claim to match §7 — `GRANT` frames are wire schema only today.
- Regenerate `llms-full.txt`.

## Spec refs
No boundary change

## Review gates
none

## Tests
- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo nextest run --workspace --profile ci` — 376 passed

## Platforms
Docs-only; no runtime platform exercise.

## Perf impact
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the v0 scope for packaging and updates, including currently available capabilities and planned functionality.
  * Documented packaging destinations and referenced update architecture, specifications, and threat models.
  * Clarified IPC backpressure behavior, distinguishing planned credit-window flow control from the current bounded message and readiness-based implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->