### PR TITLE
fix(wv): align wry View drop order and wkwebview lint (KEL-95)

### DIFF
--- a/crates/keld-wv/src/lib.rs
+++ b/crates/keld-wv/src/lib.rs
@@ -13,6 +13,8 @@ mod engine;
 mod error;
 mod hello;
 mod media;
+#[cfg(test)]
+mod view_drop_order;
 #[cfg(target_os = "linux")]
 pub mod webkitgtk;
 #[cfg(target_os = "windows")]

--- a/crates/keld-wv/src/view_drop_order.rs
+++ b/crates/keld-wv/src/view_drop_order.rs
@@ -1,0 +1,43 @@
+//! Drop-order contract shared by wry-backed [`View`] structs.
+//!
+//! Platform bindings require the webview to release before the host window
+//! closes. Rust drops struct fields in declaration order, so `webview` MUST be
+//! declared before `window` in every `View` struct.
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::mem::offset_of;
+    use std::rc::Rc;
+
+    struct DropTag(&'static str, Rc<RefCell<Vec<&'static str>>>);
+
+    impl Drop for DropTag {
+        fn drop(&mut self) {
+            self.1.borrow_mut().push(self.0);
+        }
+    }
+
+    /// Mirrors field order required by `wkwebview::View` and `webkitgtk::View`.
+    struct MirrorView {
+        webview: DropTag,
+        window: DropTag,
+    }
+
+    #[test]
+    fn wry_view_drops_webview_before_window() {
+        let log = Rc::new(RefCell::new(Vec::new()));
+        {
+            let _view = MirrorView {
+                webview: DropTag("webview", log.clone()),
+                window: DropTag("window", log.clone()),
+            };
+        }
+        assert_eq!(&*log.borrow(), &["webview", "window"]);
+    }
+
+    #[test]
+    fn mirror_field_order_matches_documented_contract() {
+        assert!(offset_of!(MirrorView, webview) < offset_of!(MirrorView, window));
+    }
+}

--- a/crates/keld-wv/src/webkitgtk/mod.rs
+++ b/crates/keld-wv/src/webkitgtk/mod.rs
@@ -140,8 +140,8 @@ pub fn probe_gpu_stack() -> GpuSafeMode {
 
 /// One live webview and the host window it fills (v0: one per window).
 struct View {
-    window: Window,
     webview: wry::WebView,
+    window: Window,
 }
 
 /// The Linux [`WebEngine`] backend.
@@ -310,7 +310,7 @@ impl WebEngine for WebKitGtkEngine {
             .map_err(|e| WvError::Webview(e.to_string()))?;
 
         self.next_id += 1;
-        self.views.insert(id, View { window, webview });
+        self.views.insert(id, View { webview, window });
         Ok(WebviewId(id))
     }
 

--- a/crates/keld-wv/src/wkwebview/mod.rs
+++ b/crates/keld-wv/src/wkwebview/mod.rs
@@ -15,6 +15,7 @@
 // transitive platform calls and future direct objc2 bindings, which must each
 // carry their own `// SAFETY:` proof.
 #![allow(unsafe_code)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -33,8 +34,8 @@ use crate::media::{webview_media_principal, with_guarded_media_permissions};
 
 /// One live webview and the host window it fills (v0: one per window).
 struct View {
-    window: Window,
     webview: wry::WebView,
+    window: Window,
 }
 
 /// The macOS [`WebEngine`] backend.
@@ -173,7 +174,7 @@ impl WebEngine for WkWebViewEngine {
             .map_err(|e| WvError::Webview(e.to_string()))?;
 
         self.next_id += 1;
-        self.views.insert(id, View { window, webview });
+        self.views.insert(id, View { webview, window });
         Ok(WebviewId(id))
     }
 


### PR DESCRIPTION
## Summary
- Reorder `wkwebview` and `webkitgtk` `View` fields so `webview` drops before `window`, matching the documented teardown contract and the explicit `webview2` pattern.
- Add `view_drop_order` regression tests (runtime drop log + `offset_of!` guard).
- Add `#![deny(unsafe_op_in_unsafe_fn)]` to `wkwebview/mod.rs` per crate `AGENTS.md`.

## Spec refs
No boundary change

## Review gates
none

## Tests
- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo nextest run --workspace --profile ci` — 378 passed (includes 2 new `view_drop_order` tests)

## Platforms
macOS compile-only for `wkwebview` changes; no macOS GUI lane exercised. `webkitgtk` field reorder is structural only — Linux GUI smoke not re-run locally on this Darwin host.

## Perf impact
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability when closing webviews and their associated windows.
  * Added safeguards and verification to ensure resources are released in the correct order across supported platforms.

* **Quality Improvements**
  * Strengthened internal safety checks without changing the public API or visible application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->