### PR TITLE
fix(wv): bind drop-order tests to backend View types (KEL-95)

### DIFF
--- a/crates/keld-wv/src/view_drop_order.rs
+++ b/crates/keld-wv/src/view_drop_order.rs
@@ -3,11 +3,18 @@
 //! Platform bindings require the webview to release before the host window
 //! closes. Rust drops struct fields in declaration order, so `webview` MUST be
 //! declared before `window` in every `View` struct.
+//!
+//! wry-backed [`View`] types MUST use `#[repr(C)]` so field offsets match
+//! declaration order under the default `repr(Rust)` size optimization (`WebKitGTK`
+//! proved `offset_of!(webview) > offset_of!(window)` with correct source order but
+//! no `repr(C)`).
 
 /// Asserts that `$ty` declares `webview` before `window`.
 ///
 /// Each wry-backed backend MUST call this from a `#[cfg(test)]` module against
-/// its real [`View`] type so swapping fields fails CI on that platform.
+/// its real [`View`] type so swapping fields fails CI on that platform. The
+/// type MUST be `#[repr(C)]` — see module docs.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 macro_rules! assert_wry_view_field_order {
     ($ty:ty) => {
         assert!(
@@ -16,6 +23,7 @@ macro_rules! assert_wry_view_field_order {
         );
     };
 }
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub(crate) use assert_wry_view_field_order;
 
 #[cfg(test)]

--- a/crates/keld-wv/src/view_drop_order.rs
+++ b/crates/keld-wv/src/view_drop_order.rs
@@ -4,10 +4,23 @@
 //! closes. Rust drops struct fields in declaration order, so `webview` MUST be
 //! declared before `window` in every `View` struct.
 
+/// Asserts that `$ty` declares `webview` before `window`.
+///
+/// Each wry-backed backend MUST call this from a `#[cfg(test)]` module against
+/// its real [`View`] type so swapping fields fails CI on that platform.
+macro_rules! assert_wry_view_field_order {
+    ($ty:ty) => {
+        assert!(
+            std::mem::offset_of!($ty, webview) < std::mem::offset_of!($ty, window),
+            "wry View must declare webview before window so drop releases webview first"
+        );
+    };
+}
+pub(crate) use assert_wry_view_field_order;
+
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;
-    use std::mem::offset_of;
     use std::rc::Rc;
 
     struct DropTag(&'static str, Rc<RefCell<Vec<&'static str>>>);
@@ -18,26 +31,23 @@ mod tests {
         }
     }
 
-    /// Mirrors field order required by `wkwebview::View` and `webkitgtk::View`.
-    struct MirrorView {
-        webview: DropTag,
-        window: DropTag,
+    /// Stand-in for any two-field struct; proves Rust's drop-order rule that
+    /// backend `View` layouts rely on — not a substitute for backend tests.
+    #[expect(dead_code, reason = "fields exist only to observe Drop order")]
+    struct TwoFieldStruct {
+        first: DropTag,
+        second: DropTag,
     }
 
     #[test]
-    fn wry_view_drops_webview_before_window() {
+    fn rust_drops_struct_fields_in_declaration_order() {
         let log = Rc::new(RefCell::new(Vec::new()));
         {
-            let _view = MirrorView {
-                webview: DropTag("webview", log.clone()),
-                window: DropTag("window", log.clone()),
+            let _value = TwoFieldStruct {
+                first: DropTag("first", log.clone()),
+                second: DropTag("second", log.clone()),
             };
         }
-        assert_eq!(&*log.borrow(), &["webview", "window"]);
-    }
-
-    #[test]
-    fn mirror_field_order_matches_documented_contract() {
-        assert!(offset_of!(MirrorView, webview) < offset_of!(MirrorView, window));
+        assert_eq!(&*log.borrow(), &["first", "second"]);
     }
 }

--- a/crates/keld-wv/src/webkitgtk/mod.rs
+++ b/crates/keld-wv/src/webkitgtk/mod.rs
@@ -139,6 +139,7 @@ pub fn probe_gpu_stack() -> GpuSafeMode {
 }
 
 /// One live webview and the host window it fills (v0: one per window).
+#[repr(C)]
 struct View {
     webview: wry::WebView,
     window: Window,

--- a/crates/keld-wv/src/webkitgtk/mod.rs
+++ b/crates/keld-wv/src/webkitgtk/mod.rs
@@ -436,4 +436,12 @@ mod tests {
         let err = WvError::UnknownWebview { id: 3 };
         assert!(err.to_string().contains("KELD-WV-007"));
     }
+
+    #[test]
+    fn view_declares_webview_before_window() {
+        use super::View;
+        use crate::view_drop_order::assert_wry_view_field_order;
+
+        assert_wry_view_field_order!(View);
+    }
 }

--- a/crates/keld-wv/src/wkwebview/mod.rs
+++ b/crates/keld-wv/src/wkwebview/mod.rs
@@ -33,6 +33,7 @@ use crate::error::WvError;
 use crate::media::{webview_media_principal, with_guarded_media_permissions};
 
 /// One live webview and the host window it fills (v0: one per window).
+#[repr(C)]
 struct View {
     webview: wry::WebView,
     window: Window,

--- a/crates/keld-wv/src/wkwebview/mod.rs
+++ b/crates/keld-wv/src/wkwebview/mod.rs
@@ -237,3 +237,14 @@ pub fn run_hello(spec: &WebviewSpec) -> Result<(), WvError> {
     engine.create(spec)?;
     engine.run_until_closed()
 }
+
+#[cfg(test)]
+mod view_drop_order_tests {
+    use super::View;
+    use crate::view_drop_order::assert_wry_view_field_order;
+
+    #[test]
+    fn view_declares_webview_before_window() {
+        assert_wry_view_field_order!(View);
+    }
+}


### PR DESCRIPTION
## Summary
- Addresses unresolved CodeRabbit review on #54: drop-order regression tests now assert field order on each backend's real `View` type via `assert_wry_view_field_order!`, not an independent `MirrorView` copy.
- Keeps a generic Rust drop-order semantics test in `view_drop_order.rs` without claiming it mirrors backend layouts.

## Spec refs
No boundary change

## Review gates
none

## Tests
- `cargo fmt --check`
- `cargo clippy -p keld-wv --all-targets -- -D warnings`
- `cargo nextest run -p keld-wv --profile ci` (17 passed on macOS; webkitgtk field-order test compiles on Linux CI)

## Platforms
macOS verified locally; Linux webkitgtk test unverified on this runner (module is `cfg(linux)` only)

## Perf impact
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when closing views across supported platforms by enforcing the required cleanup order.
  * Added safeguards to reduce shutdown-related issues during webview handling.

* **Tests**
  * Added cross-platform checks to verify that view components maintain the required order.
  * Expanded coverage for Linux and macOS webview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->