### PR TITLE
fix(docs): align v0 IPC backpressure with drain-driven writer

### DIFF
--- a/docs/architecture/02-ipc.md
+++ b/docs/architecture/02-ipc.md
@@ -105,7 +105,8 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   anywhere — Electron's frame-starving chatty-IPC failure becomes structurally
   impossible once credit windows ship. **v0:** `FrameKind::Grant` exists in the
   wire schema but has no live sender/receiver; bounded inline `CALL`/`REPLY`
-  and the readiness-driven reader are the current backpressure surface (see §7).
+  and the current drain-driven writer are the v0 backpressure surface; the
+  readiness-driven reader remains destination work (see §7).
 
 ## 3. Bulk plane (measured copies, optional shared memory)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1147,7 +1147,8 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   anywhere — Electron's frame-starving chatty-IPC failure becomes structurally
   impossible once credit windows ship. **v0:** `FrameKind::Grant` exists in the
   wire schema but has no live sender/receiver; bounded inline `CALL`/`REPLY`
-  and the readiness-driven reader are the current backpressure surface (see §7).
+  and the current drain-driven writer are the v0 backpressure surface; the
+  readiness-driven reader remains destination work (see §7).
 
 ## 3. Bulk plane (measured copies, optional shared memory)
 


### PR DESCRIPTION
## Summary
- Correct `docs/architecture/02-ipc.md` v0 backpressure wording: drain-driven writer is current, readiness-driven reader is destination work (CodeRabbit thread on merged #53).
- Regenerate `llms-full.txt` via `just llms`.

## Spec refs
- `docs/architecture/02-ipc.md` (no boundary change; doc accuracy)

## Review gates
none

## Tests
- `just llms-check`

## Platforms
N/A (docs only)

## Perf impact
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the current IPC backpressure behavior, including bounded inline calls and replies.
  * Documented the drain-driven writer and noted that readiness-driven reading remains planned future work.
  * Updated the generated IPC documentation to match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->