### PR TITLE
feat(runtime): bounded virtual ports between authenticated roles (KEL-75 T3)

### DIFF
--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -26,6 +26,8 @@ pub mod primary;
 pub mod registry;
 #[cfg(unix)]
 mod unix_role;
+#[cfg(unix)]
+mod virtual_port;
 
 /// How often the supervisor thread polls a running child for exit, and the
 /// granularity at which `shutdown()` is observed.

--- a/crates/keld-runtime/src/registry.rs
+++ b/crates/keld-runtime/src/registry.rs
@@ -2,13 +2,18 @@
 //!
 //! KEL-75 T2: each slot is an independent [`RoleSupervisor`]. A primary crash
 //! or restart MUST NOT revoke, stop, or re-provision the app-bound role, and
-//! the reverse. Window-bound roles, virtual ports, Electron facades, sandbox
-//! admission and bulk mapping are later slices.
+//! the reverse. KEL-75 T3 adds host-owned bounded virtual ports between live
+//! authenticated role generations.
+
+use crate::virtual_port::{PortCapability, VirtualPortError, VirtualPortRegistry};
 
 use crate::RuntimeError;
 
 pub use crate::unix_role::{
     RoleConfig, RoleEvent, RoleGeneration, RoleOwner, RoleRevocationCause, RoleSupervisor,
+};
+pub use crate::virtual_port::{
+    PortDisconnectReason, PortEnd, PortMessage, RolePrincipal, VirtualPortGeneration,
 };
 
 /// Host-owned pair of independently supervised Unix Bun roles.
@@ -16,6 +21,7 @@ pub use crate::unix_role::{
 pub struct RoleRegistry {
     primary: RoleSupervisor,
     app_bound: RoleSupervisor,
+    virtual_ports: VirtualPortRegistry,
 }
 
 impl RoleRegistry {
@@ -45,7 +51,11 @@ impl RoleRegistry {
         }
         let primary = RoleSupervisor::start(primary)?;
         match RoleSupervisor::start(app_bound) {
-            Ok(app_bound) => Ok(Self { primary, app_bound }),
+            Ok(app_bound) => Ok(Self {
+                primary,
+                app_bound,
+                virtual_ports: VirtualPortRegistry::new(),
+            }),
             Err(error) => {
                 primary.shutdown();
                 let _ = primary.wait_for_outcome();
@@ -64,6 +74,37 @@ impl RoleRegistry {
     #[must_use]
     pub fn app_bound(&self) -> &RoleSupervisor {
         &self.app_bound
+    }
+
+    /// Host-owned bounded virtual port registry for authenticated roles.
+    #[must_use]
+    pub fn virtual_ports(&self) -> &VirtualPortRegistry {
+        &self.virtual_ports
+    }
+
+    /// Mutable access to the virtual port registry.
+    #[must_use]
+    pub fn virtual_ports_mut(&mut self) -> &mut VirtualPortRegistry {
+        &mut self.virtual_ports
+    }
+
+    /// Mints a port pair between two authenticated role principals.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VirtualPortError`] when either generation is stale in the
+    /// port registry.
+    pub fn create_role_port_pair(
+        &mut self,
+        owner_a: RolePrincipal,
+        owner_b: RolePrincipal,
+    ) -> Result<(PortCapability, PortCapability), VirtualPortError> {
+        self.virtual_ports.create_pair(owner_a, owner_b)
+    }
+
+    /// Revokes virtual port routes for one role generation.
+    pub fn revoke_role_ports(&mut self, principal: RolePrincipal) {
+        self.virtual_ports.revoke_generation(principal);
     }
 
     /// Stops both roles. Application-session stop, not window close (T4).
@@ -85,7 +126,9 @@ mod tests {
     use std::sync::mpsc;
     use std::time::Duration;
 
-    use super::{RoleConfig, RoleEvent, RoleOwner, RoleRegistry, RoleRevocationCause};
+    use super::{
+        RoleConfig, RoleEvent, RoleOwner, RolePrincipal, RoleRegistry, RoleRevocationCause,
+    };
     use crate::unix_role::fixture::{FamilyFixture, assert_ready_line, connect_with_foreign_token};
     use crate::{RestartPolicy, RuntimeError, SupervisorOutcome};
 
@@ -369,5 +412,65 @@ mod tests {
             Some(other) => panic!("{label}: unexpected queued event {other:?}"),
             None => {}
         }
+    }
+
+    #[test]
+    fn registry_virtual_port_pair_routes_between_bound_roles() {
+        let fixture = FamilyFixture::new();
+        let policy = RestartPolicy {
+            max_crashes: 3,
+            window_secs: 30,
+        };
+        let (primary_probe_tx, primary_probe_rx) = mpsc::channel();
+        let (app_probe_tx, app_probe_rx) = mpsc::channel();
+        let mut registry = RoleRegistry::start(
+            bun_role(
+                RoleConfig::primary("bun"),
+                &fixture,
+                fixture.primary_control_path(),
+                policy,
+            )
+            .with_probe(primary_probe_tx),
+            bun_role(
+                RoleConfig::app_bound("bun"),
+                &fixture,
+                fixture.app_bound_control_path(),
+                policy,
+            )
+            .with_probe(app_probe_tx),
+        )
+        .expect("roles spawn");
+
+        let primary_g1 = recv_probe(&primary_probe_rx, "primary g1");
+        let app_g1 = recv_probe(&app_probe_rx, "app-bound g1");
+        bind_attempt(registry.primary(), &primary_g1, 1, fixture.accept_primary());
+        bind_attempt(registry.app_bound(), &app_g1, 1, fixture.accept_app_bound());
+
+        let primary_principal = RolePrincipal::new(RoleOwner::Primary, primary_g1.generation);
+        let app_principal = RolePrincipal::new(RoleOwner::AppBound, app_g1.generation);
+        let (cap_primary, cap_app) = registry
+            .create_role_port_pair(primary_principal, app_principal)
+            .expect("mint pair");
+
+        registry
+            .virtual_ports_mut()
+            .send(cap_primary, primary_principal, b"ping")
+            .expect("primary send");
+        let msg = registry
+            .virtual_ports_mut()
+            .recv(cap_app, app_principal)
+            .expect("app recv")
+            .expect("payload");
+        assert_eq!(msg.as_bytes(), b"ping");
+
+        registry.revoke_role_ports(primary_principal);
+        let err = registry
+            .virtual_ports_mut()
+            .send(cap_primary, primary_principal, b"stale")
+            .expect_err("stale send");
+        assert!(err.to_string().contains("KELD-RUNTIME-005"), "{err}");
+        registry.shutdown();
+        assert_stopped(registry.primary(), "primary");
+        assert_stopped(registry.app_bound(), "app-bound");
     }
 }

--- a/crates/keld-runtime/src/unix_role.rs
+++ b/crates/keld-runtime/src/unix_role.rs
@@ -101,6 +101,14 @@ impl RoleOwner {
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RoleGeneration(u64);
 
+impl RoleGeneration {
+    /// Creates a generation counter for crate-internal tests.
+    #[cfg(test)]
+    pub(crate) fn from_test_counter(value: u64) -> Self {
+        Self(value)
+    }
+}
+
 impl std::fmt::Debug for RoleGeneration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("RoleGeneration(..)")

--- a/crates/keld-runtime/src/virtual_port.rs
+++ b/crates/keld-runtime/src/virtual_port.rs
@@ -1,0 +1,846 @@
+//! Host-owned bounded virtual port pairs between authenticated roles (KEL-75 T3).
+//!
+//! The host mints each pair, mediates every send and one-shot transfer, and
+//! invalidates routes when a role generation is revoked. There is no direct
+//! peer transport — delivery always passes through [`VirtualPortRegistry`].
+
+use std::collections::VecDeque;
+
+use crate::unix_role::{RoleGeneration, RoleOwner};
+
+/// Default maximum queued messages per port end before send is rejected.
+pub const DEFAULT_PORT_QUEUE_CAPACITY: usize = 64;
+
+/// Maximum inline payload bytes per port message in T3.
+pub const MAX_PORT_MESSAGE_LEN: usize = 4096;
+
+/// Host-minted principal for one authenticated role generation.
+///
+/// A generation is not a PID, socket path, token, or wire field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RolePrincipal {
+    owner: RoleOwner,
+    generation: RoleGeneration,
+}
+
+impl RolePrincipal {
+    /// Creates a principal for one live role generation.
+    #[must_use]
+    pub const fn new(owner: RoleOwner, generation: RoleGeneration) -> Self {
+        Self { owner, generation }
+    }
+
+    /// Lifecycle owner category.
+    #[must_use]
+    pub const fn owner(self) -> RoleOwner {
+        self.owner
+    }
+
+    /// Host-minted generation for this coordinator instance.
+    #[must_use]
+    pub const fn generation(self) -> RoleGeneration {
+        self.generation
+    }
+}
+
+/// Monotonic host-only port-pair generation.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VirtualPortGeneration(u64);
+
+impl std::fmt::Debug for VirtualPortGeneration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("VirtualPortGeneration(..)")
+    }
+}
+
+/// One end of a host-owned port pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PortEnd {
+    /// First end minted for a pair.
+    A,
+    /// Second end minted for a pair.
+    B,
+}
+
+/// Capability referencing one live end of a port pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PortCapability {
+    generation: VirtualPortGeneration,
+    end: PortEnd,
+}
+
+impl PortCapability {
+    /// Pair generation this capability belongs to.
+    #[must_use]
+    pub const fn generation(self) -> VirtualPortGeneration {
+        self.generation
+    }
+
+    /// Which end of the pair this capability names.
+    #[must_use]
+    pub const fn end(self) -> PortEnd {
+        self.end
+    }
+}
+
+/// One bounded inline message routed through the host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortMessage(Vec<u8>);
+
+impl PortMessage {
+    /// Wraps an inline payload copy.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        Self(bytes.to_vec())
+    }
+
+    /// Payload bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Why a port end observed disconnect exactly once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortDisconnectReason {
+    /// The owning principal closed this end.
+    LocalClose,
+    /// The paired end was closed by its owner.
+    PeerClose,
+    /// A role generation owning this end was revoked.
+    GenerationRevoked,
+}
+
+/// Virtual port routing and transfer failures. `KELD-RUNTIME-004`–`KELD-RUNTIME-009`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VirtualPortError {
+    /// The caller does not own the referenced end.
+    NotOwner {
+        /// End that was referenced.
+        capability: PortCapability,
+        /// Principal presented by the caller.
+        presented: RolePrincipal,
+    },
+    /// The presented principal generation is no longer live for this pair.
+    StaleGeneration {
+        /// End that was referenced.
+        capability: PortCapability,
+        /// Principal presented by the caller.
+        presented: RolePrincipal,
+    },
+    /// The end or pair is closed or revoked.
+    Closed {
+        /// End that was referenced.
+        capability: PortCapability,
+    },
+    /// Transfer target is the current owner.
+    SelfTransfer {
+        /// End that was referenced.
+        capability: PortCapability,
+        /// Principal presented as transfer target.
+        target: RolePrincipal,
+    },
+    /// This end was already transferred once.
+    DuplicateTransfer {
+        /// End that was referenced.
+        capability: PortCapability,
+    },
+    /// The original owner attempted transfer after transferring away.
+    SourceTransfer {
+        /// End that was referenced.
+        capability: PortCapability,
+        /// Principal that minted the end but no longer owns it.
+        source: RolePrincipal,
+    },
+    /// The receiver queue is full.
+    QueueFull {
+        /// End whose peer queue is full.
+        capability: PortCapability,
+        /// Configured capacity.
+        capacity: usize,
+    },
+    /// Payload exceeds [`MAX_PORT_MESSAGE_LEN`].
+    InvalidMessageLen {
+        /// Attempted length in bytes.
+        len: usize,
+        /// Maximum permitted length.
+        max: usize,
+    },
+    /// A foreign principal would have received a message or disconnect.
+    ForeignDelivery {
+        /// End that would have received data.
+        capability: PortCapability,
+        /// Principal that attempted receive.
+        presented: RolePrincipal,
+    },
+}
+
+impl std::fmt::Display for VirtualPortError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotOwner { .. } => write!(
+                f,
+                "KELD-RUNTIME-004: virtual port end is not owned by the presented principal. \
+                 Use the capability minted for the live role generation."
+            ),
+            Self::StaleGeneration { .. } => write!(
+                f,
+                "KELD-RUNTIME-005: virtual port principal generation is stale. \
+                 Provision a fresh role generation before routing or transferring ports."
+            ),
+            Self::Closed { .. } => write!(
+                f,
+                "KELD-RUNTIME-006: virtual port end is closed or its pair was revoked. \
+                 Create a new host-owned pair for the live role generations."
+            ),
+            Self::SelfTransfer { .. } => write!(
+                f,
+                "KELD-RUNTIME-007: virtual port transfer target is the current owner. \
+                 Choose a different authenticated role generation."
+            ),
+            Self::DuplicateTransfer { .. } => write!(
+                f,
+                "KELD-RUNTIME-008: virtual port end was already transferred once. \
+                 Port transfer is one-shot per end generation."
+            ),
+            Self::SourceTransfer { .. } => write!(
+                f,
+                "KELD-RUNTIME-009: original virtual port owner cannot transfer after \
+                 relinquishing the end. Use the current owner's capability."
+            ),
+            Self::QueueFull { capacity, .. } => write!(
+                f,
+                "KELD-RUNTIME-010: virtual port queue is full at {capacity} messages. \
+                 Drain the peer or close the end before sending more."
+            ),
+            Self::InvalidMessageLen { len, max } => write!(
+                f,
+                "KELD-RUNTIME-011: virtual port message length {len} exceeds inline limit {max}. \
+                 Split the payload or use a later bulk lane when available."
+            ),
+            Self::ForeignDelivery { .. } => write!(
+                f,
+                "KELD-RUNTIME-004: foreign principal cannot receive on this virtual port end. \
+                 Use the capability minted for the live role generation."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for VirtualPortError {}
+
+/// Host-owned registry of bounded virtual port pairs.
+#[derive(Debug)]
+pub struct VirtualPortRegistry {
+    next_generation: u64,
+    queue_capacity: usize,
+    pairs: Vec<PairState>,
+    revoked_generations: Vec<RolePrincipal>,
+}
+
+#[derive(Debug)]
+struct PairState {
+    generation: VirtualPortGeneration,
+    end_a: EndState,
+    end_b: EndState,
+    revoked: bool,
+}
+
+#[derive(Debug)]
+#[allow(clippy::struct_excessive_bools)] // transfer, close, and disconnect are distinct AC5 states.
+struct EndState {
+    initial_owner: RolePrincipal,
+    owner: RolePrincipal,
+    transferred: bool,
+    closed: bool,
+    disconnect_pending: bool,
+    disconnect_observed: bool,
+    queue: VecDeque<PortMessage>,
+}
+
+impl VirtualPortRegistry {
+    /// Creates a registry with [`DEFAULT_PORT_QUEUE_CAPACITY`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_queue_capacity(DEFAULT_PORT_QUEUE_CAPACITY)
+    }
+
+    /// Creates a registry with a custom per-end queue bound.
+    #[must_use]
+    pub fn with_queue_capacity(queue_capacity: usize) -> Self {
+        Self {
+            next_generation: 1,
+            queue_capacity,
+            pairs: Vec::new(),
+            revoked_generations: Vec::new(),
+        }
+    }
+
+    /// Mints a fresh pair between two authenticated role principals.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VirtualPortError::StaleGeneration`] when either principal's
+    /// generation was previously revoked in this registry.
+    pub fn create_pair(
+        &mut self,
+        owner_a: RolePrincipal,
+        owner_b: RolePrincipal,
+    ) -> Result<(PortCapability, PortCapability), VirtualPortError> {
+        if self.is_generation_revoked(owner_a) || self.is_generation_revoked(owner_b) {
+            return Err(VirtualPortError::StaleGeneration {
+                capability: PortCapability {
+                    generation: VirtualPortGeneration(0),
+                    end: PortEnd::A,
+                },
+                presented: owner_a,
+            });
+        }
+        let generation = self.mint_generation()?;
+        let cap_a = PortCapability {
+            generation,
+            end: PortEnd::A,
+        };
+        let cap_b = PortCapability {
+            generation,
+            end: PortEnd::B,
+        };
+        self.pairs.push(PairState {
+            generation,
+            end_a: EndState::new(owner_a, self.queue_capacity),
+            end_b: EndState::new(owner_b, self.queue_capacity),
+            revoked: false,
+        });
+        Ok((cap_a, cap_b))
+    }
+
+    /// Sends one inline message from `from` through the host to the peer end.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VirtualPortError`] when ownership, closure, queue bounds, or
+    /// generation validity fail.
+    pub fn send(
+        &mut self,
+        from: PortCapability,
+        sender: RolePrincipal,
+        payload: &[u8],
+    ) -> Result<(), VirtualPortError> {
+        if self.is_generation_revoked(sender) {
+            return Err(VirtualPortError::StaleGeneration {
+                capability: from,
+                presented: sender,
+            });
+        }
+        if payload.len() > MAX_PORT_MESSAGE_LEN {
+            return Err(VirtualPortError::InvalidMessageLen {
+                len: payload.len(),
+                max: MAX_PORT_MESSAGE_LEN,
+            });
+        }
+        let capacity = self.queue_capacity;
+        let pair_idx = self
+            .pairs
+            .iter()
+            .position(|pair| pair.generation == from.generation)
+            .ok_or(VirtualPortError::Closed { capability: from })?;
+        let pair = &self.pairs[pair_idx];
+        if pair.revoked {
+            return Err(VirtualPortError::Closed { capability: from });
+        }
+        let (from_end, peer_end) = pair.ends_ref(from.end);
+        check_end_owner(from, sender, from_end)?;
+        if from_end.closed || peer_end.closed {
+            return Err(VirtualPortError::Closed { capability: from });
+        }
+        if peer_end.queue.len() >= capacity {
+            return Err(VirtualPortError::QueueFull {
+                capability: from,
+                capacity,
+            });
+        }
+        let pair = &mut self.pairs[pair_idx];
+        let (_, peer_end) = pair.ends(from.end);
+        peer_end.queue.push_back(PortMessage::from_bytes(payload));
+        Ok(())
+    }
+
+    /// Transfers one end once to a host-approved target principal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VirtualPortError`] for duplicate, self, source, closed, or
+    /// stale-generation transfers.
+    pub fn transfer(
+        &mut self,
+        capability: PortCapability,
+        from: RolePrincipal,
+        target: RolePrincipal,
+    ) -> Result<PortCapability, VirtualPortError> {
+        if self.is_generation_revoked(from) {
+            return Err(VirtualPortError::StaleGeneration {
+                capability,
+                presented: from,
+            });
+        }
+        if self.is_generation_revoked(target) {
+            return Err(VirtualPortError::StaleGeneration {
+                capability,
+                presented: target,
+            });
+        }
+        let pair = self.pair_mut(capability.generation)?;
+        if pair.revoked {
+            return Err(VirtualPortError::Closed { capability });
+        }
+        let (end, peer) = match capability.end {
+            PortEnd::A => (&mut pair.end_a, &pair.end_b),
+            PortEnd::B => (&mut pair.end_b, &pair.end_a),
+        };
+        if end.closed || peer.closed {
+            return Err(VirtualPortError::Closed { capability });
+        }
+        if end.owner != from {
+            if end.initial_owner == from {
+                return Err(VirtualPortError::SourceTransfer {
+                    capability,
+                    source: from,
+                });
+            }
+            return Err(VirtualPortError::NotOwner {
+                capability,
+                presented: from,
+            });
+        }
+        if target == end.owner {
+            return Err(VirtualPortError::SelfTransfer { capability, target });
+        }
+        if end.transferred {
+            return Err(VirtualPortError::DuplicateTransfer { capability });
+        }
+        end.owner = target;
+        end.transferred = true;
+        Ok(capability)
+    }
+
+    /// Closes one end owned by `owner`.
+    ///
+    /// The peer observes exactly one disconnect through [`Self::poll_disconnect`].
+    pub fn close(
+        &mut self,
+        capability: PortCapability,
+        owner: RolePrincipal,
+    ) -> Result<(), VirtualPortError> {
+        let pair_idx = self
+            .pairs
+            .iter()
+            .position(|pair| pair.generation == capability.generation)
+            .ok_or(VirtualPortError::Closed { capability })?;
+        let pair = &self.pairs[pair_idx];
+        if pair.revoked {
+            return Err(VirtualPortError::Closed { capability });
+        }
+        let (end, _peer) = pair.ends_ref(capability.end);
+        check_end_owner(capability, owner, end)?;
+        if end.closed {
+            return Err(VirtualPortError::Closed { capability });
+        }
+        let pair = &mut self.pairs[pair_idx];
+        let (end, peer) = pair.ends(capability.end);
+        end.closed = true;
+        if !peer.closed && !peer.disconnect_observed {
+            peer.disconnect_pending = true;
+        }
+        Ok(())
+    }
+
+    /// Receives the next queued message for `owner`, if any.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VirtualPortError::ForeignDelivery`] when `owner` is not the
+    /// live holder of the end.
+    pub fn recv(
+        &mut self,
+        capability: PortCapability,
+        owner: RolePrincipal,
+    ) -> Result<Option<PortMessage>, VirtualPortError> {
+        if self.is_generation_revoked(owner) {
+            return Err(VirtualPortError::StaleGeneration {
+                capability,
+                presented: owner,
+            });
+        }
+        let pair_idx = self
+            .pairs
+            .iter()
+            .position(|pair| pair.generation == capability.generation)
+            .ok_or(VirtualPortError::Closed { capability })?;
+        let pair = &self.pairs[pair_idx];
+        if pair.revoked {
+            return Err(VirtualPortError::Closed { capability });
+        }
+        let end = pair.end_ref(capability.end);
+        check_end_owner(capability, owner, end)?;
+        let pair = &mut self.pairs[pair_idx];
+        Ok(pair.end_mut(capability.end).queue.pop_front())
+    }
+
+    /// Observes disconnect exactly once for `owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VirtualPortError::ForeignDelivery`] when `owner` is not the
+    /// live holder of the end.
+    pub fn poll_disconnect(
+        &mut self,
+        capability: PortCapability,
+        owner: RolePrincipal,
+    ) -> Result<Option<PortDisconnectReason>, VirtualPortError> {
+        if self.is_generation_revoked(owner) {
+            return Err(VirtualPortError::StaleGeneration {
+                capability,
+                presented: owner,
+            });
+        }
+        let pair_idx = self
+            .pairs
+            .iter()
+            .position(|pair| pair.generation == capability.generation)
+            .ok_or(VirtualPortError::Closed { capability })?;
+        let pair = &self.pairs[pair_idx];
+        let revoked = pair.revoked;
+        let end = pair.end_ref(capability.end);
+        check_end_owner(capability, owner, end)?;
+        let pair = &mut self.pairs[pair_idx];
+        let end = pair.end_mut(capability.end);
+        if end.disconnect_observed {
+            return Ok(None);
+        }
+        if revoked {
+            end.disconnect_observed = true;
+            return Ok(Some(PortDisconnectReason::GenerationRevoked));
+        }
+        if end.disconnect_pending {
+            end.disconnect_observed = true;
+            end.disconnect_pending = false;
+            return Ok(Some(PortDisconnectReason::PeerClose));
+        }
+        if end.closed {
+            end.disconnect_observed = true;
+            return Ok(Some(PortDisconnectReason::LocalClose));
+        }
+        Ok(None)
+    }
+
+    /// Revokes every route owned by one role generation.
+    pub fn revoke_generation(&mut self, principal: RolePrincipal) {
+        self.mark_generation_revoked(principal);
+        for pair in &mut self.pairs {
+            if pair.revoked {
+                continue;
+            }
+            for end in [&mut pair.end_a, &mut pair.end_b] {
+                if end.owner == principal {
+                    end.closed = true;
+                }
+                if (end.owner == principal || end.initial_owner == principal)
+                    && !end.disconnect_observed
+                {
+                    end.disconnect_pending = true;
+                }
+            }
+            if pair.end_a.initial_owner == principal
+                || pair.end_b.initial_owner == principal
+                || pair.end_a.owner == principal
+                || pair.end_b.owner == principal
+            {
+                pair.revoked = true;
+            }
+        }
+    }
+
+    fn mint_generation(&mut self) -> Result<VirtualPortGeneration, VirtualPortError> {
+        let generation = VirtualPortGeneration(self.next_generation);
+        self.next_generation =
+            self.next_generation
+                .checked_add(1)
+                .ok_or(VirtualPortError::Closed {
+                    capability: PortCapability {
+                        generation: VirtualPortGeneration(0),
+                        end: PortEnd::A,
+                    },
+                })?;
+        Ok(generation)
+    }
+
+    fn pair_mut(
+        &mut self,
+        generation: VirtualPortGeneration,
+    ) -> Result<&mut PairState, VirtualPortError> {
+        self.pairs
+            .iter_mut()
+            .find(|pair| pair.generation == generation)
+            .ok_or(VirtualPortError::Closed {
+                capability: PortCapability {
+                    generation,
+                    end: PortEnd::A,
+                },
+            })
+    }
+
+    fn is_generation_revoked(&self, principal: RolePrincipal) -> bool {
+        self.revoked_generations.contains(&principal)
+    }
+
+    fn mark_generation_revoked(&mut self, principal: RolePrincipal) {
+        if !self.is_generation_revoked(principal) {
+            self.revoked_generations.push(principal);
+        }
+    }
+}
+
+impl Default for VirtualPortRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EndState {
+    fn new(owner: RolePrincipal, _queue_capacity: usize) -> Self {
+        Self {
+            initial_owner: owner,
+            owner,
+            transferred: false,
+            closed: false,
+            disconnect_pending: false,
+            disconnect_observed: false,
+            queue: VecDeque::new(),
+        }
+    }
+}
+
+impl PairState {
+    fn ends(&mut self, end: PortEnd) -> (&mut EndState, &mut EndState) {
+        match end {
+            PortEnd::A => (&mut self.end_a, &mut self.end_b),
+            PortEnd::B => (&mut self.end_b, &mut self.end_a),
+        }
+    }
+
+    fn ends_ref(&self, end: PortEnd) -> (&EndState, &EndState) {
+        match end {
+            PortEnd::A => (&self.end_a, &self.end_b),
+            PortEnd::B => (&self.end_b, &self.end_a),
+        }
+    }
+
+    fn end_mut(&mut self, end: PortEnd) -> &mut EndState {
+        match end {
+            PortEnd::A => &mut self.end_a,
+            PortEnd::B => &mut self.end_b,
+        }
+    }
+
+    fn end_ref(&self, end: PortEnd) -> &EndState {
+        match end {
+            PortEnd::A => &self.end_a,
+            PortEnd::B => &self.end_b,
+        }
+    }
+}
+
+fn check_end_owner(
+    capability: PortCapability,
+    presented: RolePrincipal,
+    end: &EndState,
+) -> Result<(), VirtualPortError> {
+    if end.owner != presented {
+        return Err(VirtualPortError::ForeignDelivery {
+            capability,
+            presented,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn principal(owner: RoleOwner, generation: u64) -> RolePrincipal {
+        RolePrincipal::new(owner, RoleGeneration::from_test_counter(generation))
+    }
+
+    fn primary(g: u64) -> RolePrincipal {
+        principal(RoleOwner::Primary, g)
+    }
+
+    fn app_bound(g: u64) -> RolePrincipal {
+        principal(RoleOwner::AppBound, g)
+    }
+
+    #[test]
+    fn contract_fixture_ordered_delivery_and_fifo() {
+        let mut registry = VirtualPortRegistry::new();
+        let p1 = primary(1);
+        let a1 = app_bound(1);
+        let (cap_p, cap_a) = registry.create_pair(p1, a1).expect("create pair");
+        registry.send(cap_p, p1, b"one").expect("send one");
+        registry.send(cap_p, p1, b"two").expect("send two");
+        registry.send(cap_p, p1, b"three").expect("send three");
+        let first = registry.recv(cap_a, a1).expect("recv one").expect("one");
+        let second = registry.recv(cap_a, a1).expect("recv two").expect("two");
+        let third = registry
+            .recv(cap_a, a1)
+            .expect("recv three")
+            .expect("three");
+        assert_eq!(first.as_bytes(), b"one");
+        assert_eq!(second.as_bytes(), b"two");
+        assert_eq!(third.as_bytes(), b"three");
+        assert!(
+            registry.recv(cap_a, a1).expect("empty recv").is_none(),
+            "queue drained"
+        );
+    }
+
+    #[test]
+    fn contract_fixture_exactly_once_disconnect_on_peer_close() {
+        let mut registry = VirtualPortRegistry::new();
+        let p1 = primary(1);
+        let a1 = app_bound(1);
+        let (cap_p, cap_a) = registry.create_pair(p1, a1).expect("create pair");
+        registry.close(cap_p, p1).expect("close primary end");
+        let first = registry
+            .poll_disconnect(cap_a, a1)
+            .expect("peer disconnect")
+            .expect("one disconnect");
+        assert_eq!(first, PortDisconnectReason::PeerClose);
+        assert!(
+            registry
+                .poll_disconnect(cap_a, a1)
+                .expect("second poll")
+                .is_none(),
+            "disconnect must be observed exactly once"
+        );
+        assert!(
+            registry
+                .poll_disconnect(cap_a, a1)
+                .expect("third poll")
+                .is_none(),
+            "disconnect must stay exhausted"
+        );
+    }
+
+    #[test]
+    fn contract_fixture_no_foreign_delivery_on_send_or_recv() {
+        let mut registry = VirtualPortRegistry::new();
+        let p1 = primary(1);
+        let a1 = app_bound(1);
+        let (cap_p, cap_a) = registry.create_pair(p1, a1).expect("create pair");
+        let err = registry
+            .send(cap_p, a1, b"hostile")
+            .expect_err("foreign send");
+        assert!(err.to_string().contains("KELD-RUNTIME-004"), "{err}");
+        registry.send(cap_p, p1, b"ok").expect("owner send");
+        let err = registry.recv(cap_a, p1).expect_err("foreign recv");
+        assert!(err.to_string().contains("KELD-RUNTIME-004"), "{err}");
+        let msg = registry.recv(cap_a, a1).expect("owner recv").expect("msg");
+        assert_eq!(msg.as_bytes(), b"ok");
+    }
+
+    #[test]
+    fn transfer_moves_ownership_once_and_rejects_invalid_targets() {
+        let mut registry = VirtualPortRegistry::new();
+        let p1 = primary(1);
+        let a1 = app_bound(1);
+        let p2 = primary(2);
+        let (cap_p, cap_a) = registry.create_pair(p1, a1).expect("create pair");
+        let transferred = registry.transfer(cap_a, a1, p2).expect("transfer to p2");
+        assert_eq!(transferred, cap_a);
+        let err = registry
+            .transfer(cap_a, a1, p2)
+            .expect_err("source transfer after relinquish");
+        assert!(err.to_string().contains("KELD-RUNTIME-009"), "{err}");
+        let err = registry
+            .transfer(cap_a, p2, p1)
+            .expect_err("duplicate transfer");
+        assert!(err.to_string().contains("KELD-RUNTIME-008"), "{err}");
+        let err = registry.transfer(cap_a, p2, p2).expect_err("self transfer");
+        assert!(err.to_string().contains("KELD-RUNTIME-007"), "{err}");
+        registry
+            .send(cap_a, p2, b"after-transfer")
+            .expect("new owner send");
+        let msg = registry
+            .recv(cap_p, p1)
+            .expect("primary recv")
+            .expect("payload");
+        assert_eq!(msg.as_bytes(), b"after-transfer");
+    }
+
+    #[test]
+    fn stale_generation_transfer_and_create_fail_closed() {
+        let mut registry = VirtualPortRegistry::new();
+        let p1 = primary(1);
+        let a1 = app_bound(1);
+        let (cap_p, _) = registry.create_pair(p1, a1).expect("create pair");
+        registry.revoke_generation(p1);
+        let err = registry
+            .transfer(cap_p, p1, app_bound(2))
+            .expect_err("stale transfer");
+        assert!(err.to_string().contains("KELD-RUNTIME-005"), "{err}");
+        let err = registry
+            .create_pair(p1, app_bound(2))
+            .expect_err("stale create");
+        assert!(err.to_string().contains("KELD-RUNTIME-005"), "{err}");
+    }
+
+    #[test]
+    fn closed_end_rejects_send_transfer_and_duplicate_close() {
+        let mut registry = VirtualPortRegistry::new();
+        let p1 = primary(1);
+        let a1 = app_bound(1);
+        let (cap_p, cap_a) = registry.create_pair(p1, a1).expect("create pair");
+        registry.close(cap_a, a1).expect("close app end");
+        let err = registry
+            .send(cap_p, p1, b"x")
+            .expect_err("send after peer close");
+        assert!(err.to_string().contains("KELD-RUNTIME-006"), "{err}");
+        let err = registry
+            .transfer(cap_p, p1, app_bound(2))
+            .expect_err("transfer after peer close");
+        assert!(err.to_string().contains("KELD-RUNTIME-006"), "{err}");
+        let err = registry.close(cap_a, a1).expect_err("duplicate close");
+        assert!(err.to_string().contains("KELD-RUNTIME-006"), "{err}");
+    }
+
+    #[test]
+    fn queue_full_rejects_without_delivery() {
+        let mut registry = VirtualPortRegistry::with_queue_capacity(2);
+        let p1 = primary(1);
+        let a1 = app_bound(1);
+        let (cap_p, cap_a) = registry.create_pair(p1, a1).expect("create pair");
+        registry.send(cap_p, p1, b"1").expect("first");
+        registry.send(cap_p, p1, b"2").expect("second");
+        let err = registry.send(cap_p, p1, b"3").expect_err("queue full");
+        assert!(err.to_string().contains("KELD-RUNTIME-010"), "{err}");
+        assert_eq!(
+            registry
+                .recv(cap_a, a1)
+                .expect("one")
+                .expect("one")
+                .as_bytes(),
+            b"1"
+        );
+        assert!(
+            registry
+                .recv(cap_a, a1)
+                .expect("two")
+                .expect("two")
+                .as_bytes()
+                == b"2",
+            "third message must not have been delivered"
+        );
+    }
+}

--- a/docs/api/virtual-port.md
+++ b/docs/api/virtual-port.md
@@ -1,0 +1,87 @@
+# Virtual port API (`keld_runtime::registry`)
+
+Status: KEL-75 T3 · Unix authenticated roles only
+
+## Overview
+
+The host owns every virtual port pair. Roles never connect directly; the host
+mediates send, one-shot transfer, close, and generation revocation.
+
+## Types
+
+| Type | Role |
+|---|---|
+| `RolePrincipal` | Host-minted `(RoleOwner, RoleGeneration)` identity |
+| `PortCapability` | Reference to one live end of a pair |
+| `PortMessage` | Inline bounded payload (`MAX_PORT_MESSAGE_LEN` = 4096) |
+| `VirtualPortRegistry` | Host-owned pair table and route state |
+
+## Operations
+
+### Create pair
+
+```rust
+let primary = RolePrincipal::new(RoleOwner::Primary, generation);
+let app = RolePrincipal::new(RoleOwner::AppBound, generation);
+let (cap_a, cap_b) = registry.create_role_port_pair(primary, app)?;
+```
+
+Both principals must be live generations not previously revoked in the
+registry.
+
+### Send (FIFO)
+
+```rust
+registry.virtual_ports_mut().send(cap_a, primary, b"hello")?;
+let msg = registry.virtual_ports_mut().recv(cap_b, app)?.expect("one message");
+```
+
+Queue capacity defaults to 64 messages per end (`DEFAULT_PORT_QUEUE_CAPACITY`).
+Overflow returns `KELD-RUNTIME-010`.
+
+### Transfer (one-shot)
+
+```rust
+registry.virtual_ports_mut().transfer(cap_b, app, target_principal)?;
+```
+
+Failures: self (`007`), duplicate (`008`), source after relinquish (`009`),
+closed (`006`), stale generation (`005`).
+
+### Close and disconnect
+
+```rust
+registry.virtual_ports_mut().close(cap_a, primary)?;
+let reason = registry
+    .virtual_ports_mut()
+    .poll_disconnect(cap_b, app)?
+    .expect("exactly one peer disconnect");
+```
+
+`poll_disconnect` returns `Some` exactly once per end generation.
+
+### Revoke generation
+
+```rust
+registry.revoke_role_ports(principal);
+```
+
+Invalidates every pair touching that generation.
+
+## Errors (`KELD-RUNTIME-004`–`011`)
+
+| Code | When |
+|---|---|
+| 004 | Wrong owner / foreign delivery |
+| 005 | Stale role generation |
+| 006 | Closed or revoked pair |
+| 007 | Self transfer |
+| 008 | Duplicate transfer |
+| 009 | Source transfer after relinquish |
+| 010 | Queue full |
+| 011 | Message too large |
+
+## Auth
+
+No default-deny bypass. Port capabilities are host-minted; children receive
+capabilities only through future facade layers, not raw OS handles.

--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -177,7 +177,8 @@ module exists, where each `unsafe` block carries a `// SAFETY:` proof.
   supervision, the host-owned concurrent echo app-link (KEL-30), KEL-75 T1b's
   Unix authenticated role coordinator (`keld_runtime::primary`), and KEL-75 T2's
   Unix `keld_runtime::registry::RoleRegistry` for one `primary` plus one
-  independent `app-bound` role. Window-bound roles, virtual ports, role grants,
+  independent `app-bound` role, and KEL-75 T3 bounded host-owned virtual ports
+  between authenticated role generations. Window-bound roles, role grants,
   strict sandbox admission, and Windows named-pipe/DACL bootstrap remain later
   KEL-75/KEL-78 slices.
 - Webview content processes: whatever the selected engine does (WKWebView WebContent,

--- a/docs/architecture/06-runtime-and-tooling.md
+++ b/docs/architecture/06-runtime-and-tooling.md
@@ -54,8 +54,10 @@ role family: KEL-70's generic one-child supervisor, KEL-75 T1a's Unix authentica
 bootstrap listener, T1b's per-role generation coordinator, and T2's
 `keld_runtime::registry::RoleRegistry` which owns one `primary` and one `app-bound`
 supervisor independently. A primary restart does not revoke or stop the app-bound
-role. It does not implement window-bound lifecycle, role-specific grants, virtual
-ports, strict OS sandboxing, or Windows named-pipe/DACL bootstrap.
+role. It does not implement window-bound lifecycle, role-specific grants, or
+strict OS sandboxing. KEL-75 T3 adds bounded host-owned virtual ports between
+authenticated role generations in `VirtualPortRegistry`. Windows named-pipe/DACL
+bootstrap remains later work.
 
 The ordered destination flow below is KEL-75's source of truth for spawn, port routing,
 window close and restart. KEL-78 separately owns real-OS sandbox admission proof.
@@ -109,9 +111,9 @@ Ports are FIFO per generation, transfers are one-shot and receiver-bound, and cl
 generation revocation disconnects the peer without exposing another principal. Exact
 Electron-observable queue/start, transfer validation and close-event behavior is owned
 by pinned conformance entries—not assumed from this generic runtime contract. Live Unix
-slices are T1b (one authenticated role generation) and T2 (one primary plus one
-independent app-bound role in `RoleRegistry`). Window-bound roles and virtual ports
-follow only after those slices.
+slices are T1b (one authenticated role generation), T2 (one primary plus one
+independent app-bound role in `RoleRegistry`), and T3 (bounded virtual ports between
+authenticated roles). Window-bound roles follow only after those slices.
 
 ## 2. keld CLI: verbs and guarantees
 

--- a/docs/engineering/keld-error-codes.md
+++ b/docs/engineering/keld-error-codes.md
@@ -409,6 +409,54 @@ match the crate that already emits the code. Do not invent a third spelling.
 - message: Prepared child lifecycle provisioning or revocation failed
 - fix: Check the role bootstrap endpoint and its owner-only directory, then retry `keld dev`.
 
+## KELD-RUNTIME-004
+
+- crate: keld-runtime
+- message: Virtual port end is not owned by the presented principal
+- fix: Use the capability minted for the live role generation.
+
+## KELD-RUNTIME-005
+
+- crate: keld-runtime
+- message: Virtual port principal generation is stale
+- fix: Provision a fresh role generation before routing or transferring ports.
+
+## KELD-RUNTIME-006
+
+- crate: keld-runtime
+- message: Virtual port end is closed or its pair was revoked
+- fix: Create a new host-owned pair for the live role generations.
+
+## KELD-RUNTIME-007
+
+- crate: keld-runtime
+- message: Virtual port transfer target is the current owner
+- fix: Choose a different authenticated role generation.
+
+## KELD-RUNTIME-008
+
+- crate: keld-runtime
+- message: Virtual port end was already transferred once
+- fix: Port transfer is one-shot per end generation.
+
+## KELD-RUNTIME-009
+
+- crate: keld-runtime
+- message: Original virtual port owner cannot transfer after relinquishing the end
+- fix: Use the current owner's capability.
+
+## KELD-RUNTIME-010
+
+- crate: keld-runtime
+- message: Virtual port queue is full
+- fix: Drain the peer or close the end before sending more.
+
+## KELD-RUNTIME-011
+
+- crate: keld-runtime
+- message: Virtual port message exceeds inline length limit
+- fix: Split the payload or use a later bulk lane when available.
+
 ## KELD-NATIVE-001
 
 - crate: keld-native

--- a/docs/specs/kel75-principalized-bun-child-roles.md
+++ b/docs/specs/kel75-principalized-bun-child-roles.md
@@ -239,7 +239,7 @@ never silently weaken a strict profile.
   flow. No Windows named pipe/DACL, ports, extra roles, sandbox or shared memory.
 - [x] T2: Add one `app-bound` role and host-owned lifecycle registry; prove independent
   crash/restart isolation and stale-generation rejection.
-- [ ] T3: Add a bounded host-owned virtual-port pair between two authenticated roles;
+- [x] T3: Add a bounded host-owned virtual-port pair between two authenticated roles;
   prove transfer, close and cross-principal negative cases before Electron facade code.
 - [ ] T4: Add `window-bound` role lifecycle and real host-window-close integration.
 - [ ] T5: Add the `utilityProcess`/`MessageChannelMain` compatibility facade through

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -984,7 +984,8 @@ module exists, where each `unsafe` block carries a `// SAFETY:` proof.
   supervision, the host-owned concurrent echo app-link (KEL-30), KEL-75 T1b's
   Unix authenticated role coordinator (`keld_runtime::primary`), and KEL-75 T2's
   Unix `keld_runtime::registry::RoleRegistry` for one `primary` plus one
-  independent `app-bound` role. Window-bound roles, virtual ports, role grants,
+  independent `app-bound` role, and KEL-75 T3 bounded host-owned virtual ports
+  between authenticated role generations. Window-bound roles, role grants,
   strict sandbox admission, and Windows named-pipe/DACL bootstrap remain later
   KEL-75/KEL-78 slices.
 - Webview content processes: whatever the selected engine does (WKWebView WebContent,
@@ -1869,8 +1870,10 @@ role family: KEL-70's generic one-child supervisor, KEL-75 T1a's Unix authentica
 bootstrap listener, T1b's per-role generation coordinator, and T2's
 `keld_runtime::registry::RoleRegistry` which owns one `primary` and one `app-bound`
 supervisor independently. A primary restart does not revoke or stop the app-bound
-role. It does not implement window-bound lifecycle, role-specific grants, virtual
-ports, strict OS sandboxing, or Windows named-pipe/DACL bootstrap.
+role. It does not implement window-bound lifecycle, role-specific grants, or
+strict OS sandboxing. KEL-75 T3 adds bounded host-owned virtual ports between
+authenticated role generations in `VirtualPortRegistry`. Windows named-pipe/DACL
+bootstrap remains later work.
 
 The ordered destination flow below is KEL-75's source of truth for spawn, port routing,
 window close and restart. KEL-78 separately owns real-OS sandbox admission proof.
@@ -1924,9 +1927,9 @@ Ports are FIFO per generation, transfers are one-shot and receiver-bound, and cl
 generation revocation disconnects the peer without exposing another principal. Exact
 Electron-observable queue/start, transfer validation and close-event behavior is owned
 by pinned conformance entries—not assumed from this generic runtime contract. Live Unix
-slices are T1b (one authenticated role generation) and T2 (one primary plus one
-independent app-bound role in `RoleRegistry`). Window-bound roles and virtual ports
-follow only after those slices.
+slices are T1b (one authenticated role generation), T2 (one primary plus one
+independent app-bound role in `RoleRegistry`), and T3 (bounded virtual ports between
+authenticated roles). Window-bound roles follow only after those slices.
 
 ## 2. keld CLI: verbs and guarantees
 
@@ -3314,6 +3317,54 @@ match the crate that already emits the code. Do not invent a third spelling.
 - crate: keld-runtime
 - message: Prepared child lifecycle provisioning or revocation failed
 - fix: Check the role bootstrap endpoint and its owner-only directory, then retry `keld dev`.
+
+## KELD-RUNTIME-004
+
+- crate: keld-runtime
+- message: Virtual port end is not owned by the presented principal
+- fix: Use the capability minted for the live role generation.
+
+## KELD-RUNTIME-005
+
+- crate: keld-runtime
+- message: Virtual port principal generation is stale
+- fix: Provision a fresh role generation before routing or transferring ports.
+
+## KELD-RUNTIME-006
+
+- crate: keld-runtime
+- message: Virtual port end is closed or its pair was revoked
+- fix: Create a new host-owned pair for the live role generations.
+
+## KELD-RUNTIME-007
+
+- crate: keld-runtime
+- message: Virtual port transfer target is the current owner
+- fix: Choose a different authenticated role generation.
+
+## KELD-RUNTIME-008
+
+- crate: keld-runtime
+- message: Virtual port end was already transferred once
+- fix: Port transfer is one-shot per end generation.
+
+## KELD-RUNTIME-009
+
+- crate: keld-runtime
+- message: Original virtual port owner cannot transfer after relinquishing the end
+- fix: Use the current owner's capability.
+
+## KELD-RUNTIME-010
+
+- crate: keld-runtime
+- message: Virtual port queue is full
+- fix: Drain the peer or close the end before sending more.
+
+## KELD-RUNTIME-011
+
+- crate: keld-runtime
+- message: Virtual port message exceeds inline length limit
+- fix: Split the payload or use a later bulk lane when available.
 
 ## KELD-NATIVE-001
 


### PR DESCRIPTION
## Summary
- Add `VirtualPortRegistry` with host-mediated FIFO send, one-shot transfer, close/disconnect, and generation revocation between `RolePrincipal` identities.
- Integrate virtual ports into `RoleRegistry` (`create_role_port_pair`, `revoke_role_ports`, `virtual_ports_mut`).
- Contract fixture tests cover AC5 ordering, exactly-once disconnect, foreign-delivery rejection, and transfer failure modes; one Bun integration test routes between bound primary and app-bound roles.

## Spec refs
- `docs/specs/kel75-principalized-bun-child-roles.md` (T3)
- `docs/architecture/02-ipc.md` §5 (virtual-port mapping)
- `docs/architecture/06-runtime-and-tooling.md` §1.1
- `docs/api/virtual-port.md` (new API contract)

## Review gates
- unsafe: none
- public API: yes — `RolePrincipal`, `VirtualPortRegistry`, `PortCapability`, registry port helpers
- permission model: none (no grant changes; default-deny unchanged)
- dependency: none
- wire protocol: none (host-internal T3 slice; no new kipc frame)

## Tests
- 8 new `keld-runtime` tests (7 contract fixture + 1 registry Bun integration)
- Full gate: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo nextest run --workspace --profile ci` — 396 passed locally

## Platforms
- Unix only (`#[cfg(unix)]`); macOS exercised locally for Bun fixtures

## Perf impact
- No hot-path change; host-internal bounded queues only. No benchmark claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bounded virtual communication ports between authenticated runtime roles.
  - Supports FIFO messaging, one-time ownership transfer, closure notifications, and revocation of stale role connections.
  - Enforces message-size and queue-capacity limits with clear error reporting.

- **Documentation**
  - Added API guidance covering messaging, ownership, transfers, closures, revocation, and security constraints.
  - Updated architecture and error-code documentation to reflect virtual-port support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->