### PR TITLE
fix(ci): switch KeldBot to pull_request_target for fork PR support

### DIFF
--- a/.github/workflows/keldbot.yml
+++ b/.github/workflows/keldbot.yml
@@ -3,7 +3,12 @@
 name: KeldBot                    # Actions tab mein jo naam dikhega
 
 on:                              # DOORBELL — kab jagana hai robot ko 🛎️
-  pull_request:
+  # pull_request_target (not pull_request): fork PRs se bhi secrets milte hain, isliye external
+  # contributors ke liye bhi checks kaam karte hain. Safe hai kyunki koi actions/checkout nahi
+  # hai (PR ka code kabhi runner pe nahi aata) aur title/body sirf context.payload se JS data ke
+  # taur pe padhte hain, kabhi shell/script text mein interpolate nahi hote — same pattern
+  # jo oven-sh/bun apne comment-cop.yml/on-slop.yml mein use karta hai.
+  pull_request_target:
     types: [opened, edited, synchronize]   # opened/edited: template; opened/synchronize: size — har job apna type khud chunta hai neeche
 
 concurrency:                     # ek PR pe do edits jaldi-jaldi ho toh purana run cancel, race/duplicate comment na ho

--- a/.github/workflows/keldbot.yml
+++ b/.github/workflows/keldbot.yml
@@ -66,8 +66,8 @@ jobs:
               await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [LABEL] });
 
               const commentBody =
-                `${MARKER}\n👋 Ye sections PR description mein missing ya khaali hain: **${missing.join(", ")}**\n\n` +
-                `Template yahan hai: .github/PULL_REQUEST_TEMPLATE.md — edit karke add kar do, phir description save karte hi main dobara check karunga.`;
+                `${MARKER}\n👋 These sections are missing or empty in the PR description: **${missing.join(", ")}**\n\n` +
+                `The template is here: .github/PULL_REQUEST_TEMPLATE.md — fill them in and save the description, and I'll re-check automatically.`;
 
               if (existing) {
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: commentBody });
@@ -91,11 +91,11 @@ jobs:
                 owner,
                 repo,
                 comment_id: existing.id,
-                body: `${MARKER}\n✅ Template ab complete hai, thanks for fixing it!`,
+                body: `${MARKER}\n✅ Template is complete now, thanks for fixing it!`,
               });
             }
 
-            core.info("Template complete hai ✅");
+            core.info("Template complete ✅");
 
   size-label:                    # doosra job — PR size (added+deleted lines) ke hisaab se label
     if: github.event.action != 'edited'   # description edit se diff size nahi badalta, sirf opened/synchronize pe chalao
@@ -169,9 +169,9 @@ jobs:
               await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [LABEL] });
 
               const commentBody =
-                `${MARKER}\n👋 PR title conventional-commit format follow nahi karta: \`type(scope): subject\`\n\n` +
+                `${MARKER}\n👋 The PR title doesn't match the conventional-commit format: \`type(scope): subject\`\n\n` +
                 `Allowed types: \`${TYPES.join("`, `")}\`. Example: \`feat(ipc): add shm channel\`. ` +
-                `Title edit karte hi main dobara check karunga (AGENTS.md § Commits & PRs).`;
+                `Edit the title and I'll re-check automatically (AGENTS.md § Commits & PRs).`;
 
               if (existing) {
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: commentBody });
@@ -215,7 +215,7 @@ jobs:
                 owner,
                 repo,
                 comment_id: existing.id,
-                body: `${MARKER}\n✅ Title ab conventional-commit format follow karta hai, thanks!`,
+                body: `${MARKER}\n✅ Title matches the conventional-commit format now, thanks!`,
               });
             }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,12 +387,14 @@ is red, read KeldBot's own comment first (it names exactly what's missing) befor
 the rule from this file. Comments/labels post from the `keldrobo` account, not
 `github-actions[bot]`.
 
-**Known limitation:** GitHub does not pass repository secrets to `pull_request`-triggered
-runs from a forked repository, so `ROBOKELD_TOKEN` is unavailable and all three jobs fail
-with an auth error on fork PRs rather than doing their job. Since `gyldlab/keld` is public
-and accepts fork contributions, an external contributor's PR gets a red, unhelpful KeldBot
-check today. Fixing this (e.g. degrade to no-op on forks instead of failing loud) is a known
-follow-up, not yet done.
+The workflow trigger is `pull_request_target`, not `pull_request` — deliberately, so PRs from
+forks also get real secrets and working checks (GitHub does not pass repo secrets to
+`pull_request`-triggered runs from a forked repo). Safe here specifically because
+`keldbot.yml` never runs `actions/checkout` and never interpolates PR title/body into
+shell/script text — only reads them as JS data via `context.payload` inside
+`actions/github-script`. Do not add a checkout step to this workflow without re-deriving this
+safety argument from scratch; that combination (`pull_request_target` + checking out
+untrusted PR code) is the classic vulnerable pattern this file avoids.
 
 Label taxonomy on `gyldlab/keld` — bot-applied vs. human-applied differ, don't assume either:
 - `needs-template-fix`, `needs-conventional-title`, `size/*`, `type:*` (8, one per allowed


### PR DESCRIPTION
## Summary

- Switch KeldBot's trigger from `pull_request` to `pull_request_target` so external contributors' fork PRs get working `gatekeeper`/`size-label`/`title-lint` checks instead of failing on a missing secret.
- Safe here because the workflow never checks out PR code and never interpolates title/body into shell/script text -- same pattern oven-sh/bun uses in `comment-cop.yml`/`on-slop.yml` for the identical reason.
- Update AGENTS.md's fork-PR note accordingly, plus a guardrail against ever adding `actions/checkout` to this workflow without re-deriving the safety argument.
- Switch KeldBot's PR-facing comment text (missing-sections, bad-title, and their resolved-✅ follow-ups) from Hinglish to plain English. Internal `#`/`//` code comments are unaffected.

## Spec refs

No boundary change

## Review gates

none

## Tests

- Validated `.github/workflows/keldbot.yml` parses as YAML at every stage.
- **Known bootstrapping gap, needs admin merge:** because the trigger-type change itself means neither `pull_request` (evaluated from this PR's merged content, which now says `pull_request_target`) nor `pull_request_target` (evaluated from `main`'s still-`pull_request` content) fires for this specific PR, `gatekeeper`/`title-lint` never run on it -- not a failure, just structurally unable to report. All other checks (rustfmt, clippy x3 platforms, MSRV, cargo-deny, gitleaks, CodeRabbit, change router) passed. This is a one-time transition; every PR after this merges will get working required checks again. Needs an admin ("Merge without waiting for requirements") to merge past the stuck required checks.
- Planned follow-up after merge: open a same-repo PR to confirm KeldBot still runs correctly under the new trigger, and confirm the English comment text renders as expected. Actually verifying the fork-PR case would require creating a PR from an external fork account, which isn't achievable from this session -- rests on GitHub's documented pull_request_target behavior and Bun's identical real-world usage.

## Platforms

GitHub Actions (ubuntu-latest runner) only.

## Perf impact

none

## Linear

KEL-106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automated pull request checks so eligible contributions from forked repositories can run with the required secrets.
  * Improved the clarity of validation and title-check status messages and logs.

* **Documentation**
  * Added guidance explaining the workflow’s security considerations and precautions for future changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->