### PR TITLE
fix(ci): scope the router's mark-all trigger to ci.yml, not every workflow

### DIFF
--- a/tools/ci_changes.sh
+++ b/tools/ci_changes.sh
@@ -267,11 +267,19 @@ classify_path() {
             docs="$TRUE"
             ;;
 
-        # The router and workflow decide which jobs execute. Any edit here must
+        # The router and ci.yml decide which jobs execute. Any edit here must
         # exercise every conditional lane, otherwise a classification defect can
         # hide the very job that would expose it.
-        .github/workflows/* | tools/ci_changes.sh | tools/ci_changes_test.sh)
+        .github/workflows/ci.yml | tools/ci_changes.sh | tools/ci_changes_test.sh)
             mark_all
+            ;;
+
+        # Any other workflow file (e.g. an unrelated bot automation) has no path
+        # into the Rust workspace, GUI, or the ci.yml router itself -- ci_hygiene.rs
+        # only reads .github/workflows/ci.yml by name, so it cannot validate these
+        # either. Nothing to mark; a diff touching only such a file legitimately
+        # needs no conditional lane.
+        .github/workflows/*)
             ;;
 
         # Workspace and toolchain inputs can alter every Rust build, keld-host's

--- a/tools/ci_changes_test.sh
+++ b/tools/ci_changes_test.sh
@@ -124,6 +124,16 @@ expect_package_token "unknown input selects all workspace packages" keld-host "$
 workflow_classification="$(result_for_paths .github/workflows/ci.yml)"
 expect_flags "workflow input exercises all jobs; GTK apt stays on GUI smoke only" "$workflow_all" "$workflow_classification"
 
+other_workflow_classification="$(result_for_paths .github/workflows/keldbot.yml)"
+expect_flags "unrelated bot workflow has no path into any conditional lane" "$all_false" "$other_workflow_classification"
+expect_empty_packages "unrelated bot workflow selects no package" "$other_workflow_classification"
+
+router_script_classification="$(result_for_paths tools/ci_changes.sh)"
+expect_flags "router script edit still exercises all jobs" "$workflow_all" "$router_script_classification"
+
+router_test_classification="$(result_for_paths tools/ci_changes_test.sh)"
+expect_flags "router test edit still exercises all jobs" "$workflow_all" "$router_test_classification"
+
 actual_host_dirs="$(cd "$repo_root" && "$router" host-dirs | sort)"
 for required_dir in crates/keld-host crates/keld-core crates/keld-guard crates/keld-ipc crates/keld-runtime crates/keld-wv; do
     if ! grep -Fxq "$required_dir" <<<"$actual_host_dirs"; then


### PR DESCRIPTION
## Summary

- The CI router (`tools/ci_changes.sh`) previously ran every conditional lane (Rust clippy on 3 platforms, MSRV, cargo-deny, GUI smoke) for a change under *any* `.github/workflows/*` file -- including unrelated bot automation like `keldbot.yml`, which has no path into the Rust workspace or the router itself. `ci_hygiene.rs` only reads `.github/workflows/ci.yml` by name (confirmed by grep), so it can't validate other workflow files either -- that coverage was never real.
- Narrow the `mark_all` trigger to `.github/workflows/ci.yml` and the router scripts themselves (`tools/ci_changes.sh`, `tools/ci_changes_test.sh`) -- the only files that could actually hide a routing defect from itself. Other workflow files now correctly select no conditional lane, same as a docs-only change.

## Spec refs

`AGENTS.md` § CI dependency routing -- narrows the existing "fail-safe on workflow edits" rule to the files where the failure mode it protects against can actually occur; the rule itself (router edits must exercise every lane) is unchanged and still applies to `ci.yml`/the router scripts.

## Review gates

none

## Tests

- Verified in isolation (`tools/ci_changes.sh classify`): `.github/workflows/keldbot.yml` -> all lanes false; `.github/workflows/ci.yml`, `tools/ci_changes.sh`, `tools/ci_changes_test.sh` -> still `mark_all` (regression-safe, matches the existing `workflow_all` test case).
- Added contract test cases to `tools/ci_changes_test.sh` per AGENTS.md's router-testing rule: unrelated bot workflow -> all-false, plus explicit regression coverage for the router script and its own test file still triggering `mark_all`.
- `bash -n` syntax-checked both edited files.
- Full `tools/ci_changes_test.sh` run locally hits a pre-existing, unrelated failure in the runtime-package classification test (a Windows path-casing issue between `git rev-parse --show-toplevel` and `cargo metadata`'s `manifest_path`) -- confirmed via `git stash` that it reproduces identically on the unmodified baseline, so it's not something this change touches or introduces. This PR's own `change router` CI job (running on the actual GitHub Actions Ubuntu runner) is the authoritative check.

## Platforms

Bash router script; validated on Windows locally (with the above caveat) and will run for real on the Ubuntu `change router` job in this PR's own CI.

## Perf impact

Reduces CI time for `.github/workflows/*`-only PRs that don't touch `ci.yml` (e.g. `keldbot.yml` changes): skips ~2-3 minutes of clippy x3 platforms + MSRV + cargo-deny + GUI smoke that were never validating anything for those files.

## Linear

KEL-106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated CI change detection so unrelated workflow edits no longer trigger conditional CI lanes or package selections.
  - Changes to the CI configuration and routing scripts continue to activate all required CI jobs.

- **Tests**
  - Added coverage for unrelated bot workflow changes.
  - Added validation for CI router and router test script changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->