### PR TITLE
chore(competitors): pin lockfile SHAs and add tauri-plugins-workspace (KEL-68)

### DIFF
--- a/competitors.lock.toml
+++ b/competitors.lock.toml
@@ -2,7 +2,9 @@
 # Trees land under gitignored `competitors/` (never commit those trees).
 # kind = "competitor"       → competitors/<name>
 # kind = "migration-oracle" → competitors/migration/<name>
-# Optional `sha` pins a commit after shallow fetch; omit to track `branch`.
+# `sha` pins a commit after shallow fetch (REQUIRED as of KEL-68 audit-191 follow-up: research
+# notes cite competitor path:line at these SHAs; an unpinned "locked clone" is whatever a
+# machine happened to fetch that day). Bump pins in one commit per surveillance sweep.
 # Unknown kinds are rejected. There is no `upstream-reference` kind; Bun / wry / tao
 # use `competitor` so `just competitors-sync` lands them at competitors/<name>.
 
@@ -11,36 +13,42 @@ name = "electron"
 kind = "competitor"
 url = "https://github.com/electron/electron.git"
 branch = "main"
+sha = "465fc7636865eaf9093fef959fcc3c3aff2942d4"
 
 [[repo]]
 name = "tauri"
 kind = "competitor"
 url = "https://github.com/tauri-apps/tauri.git"
 branch = "dev"
+sha = "56d19c39e457b528433dc546106cd0bff4066bc2"
 
 [[repo]]
 name = "wails"
 kind = "competitor"
 url = "https://github.com/wailsapp/wails.git"
 branch = "master"
+sha = "f38ae268344700a3f48dd1e95b716f2059f7269e"
 
 [[repo]]
 name = "neutralino"
 kind = "competitor"
 url = "https://github.com/neutralinojs/neutralinojs.git"
 branch = "main"
+sha = "8b99cb6122ed04ad2408e1bc67809c0da12ad14a"
 
 [[repo]]
 name = "nwjs"
 kind = "competitor"
 url = "https://github.com/nwjs/nw.js.git"
 branch = "main"
+sha = "71e4e25322a91f080513eb0ba121b6708075eef2"
 
 [[repo]]
 name = "electrobun"
 kind = "competitor"
 url = "https://github.com/blackboardsh/electrobun.git"
 branch = "main"
+sha = "cba306e9665dc88409442a586c95b3c43e98109c"
 
 # Keld upstream checkouts (not framework competitors): Bun runtime, current wry
 # webview scaffolding, current tao event-loop scaffolding.
@@ -49,18 +57,28 @@ name = "bun"
 kind = "competitor"
 url = "https://github.com/oven-sh/bun.git"
 branch = "main"
+sha = "abe2ad4f0064334ebe83427ee689eb3e8d713a2e"
 
 [[repo]]
 name = "wry"
 kind = "competitor"
 url = "https://github.com/tauri-apps/wry.git"
 branch = "dev"
+sha = "d2937514ee5b01f4b52b6132f895180e90dd0fc7"
 
 [[repo]]
 name = "tao"
 kind = "competitor"
 url = "https://github.com/tauri-apps/tao.git"
 branch = "dev"
+sha = "2f9eecf236f4f6a8acfa03329c57039224a3ce99"
+
+[[repo]]
+name = "tauri-plugins-workspace"
+kind = "competitor"
+url = "https://github.com/tauri-apps/plugins-workspace.git"
+branch = "v2"
+sha = "db9c5998feff9384f9cbbefcbe0d45937c00a1fc"
 
 # Flagship Electron app — migration/compat oracle, not a framework competitor.
 [[repo]]
@@ -68,3 +86,4 @@ name = "vscode"
 kind = "migration-oracle"
 url = "https://github.com/microsoft/vscode.git"
 branch = "main"
+sha = "0984c920744f2013d0ad2bc5e826fa45a64069ab"


### PR DESCRIPTION
## Summary

`competitors.lock.toml` had zero `sha` pins (all ten entries branch-tracking) although its own header offered pinning — so every "locked-tree" research note actually cited whatever SHA that machine had fetched that day, which is exactly why the OS-depth and micro notes disagree on competitor SHAs (research 191 §6). This PR pins every entry to the SHA currently on disk in the maintainer clones (verified: all note-cited SHAs still resolve at these tips) and adds `tauri-plugins-workspace` (`db9c5998`, branch `v2`), which notes 169 and 190 cite as primary evidence but the lockfile never listed — per the 2026-08-21 learning, unlisted clones are invisible to agents. Header comment now states pins are required and bumped one commit per surveillance sweep (roadmap 195 §R4/§G5).

Not done here (human decision, listed for the record): 15 further on-disk clones are unlisted (biome, chromium-embedded, deno, gtk, oxc, pnpm, rolldown, ruff, sparkle, swc, uv, webkit, webview2-samples, zig-bsdiff) plus a stray top-level `competitors/vscode` duplicating `competitors/migration/vscode`.

## Spec refs

No boundary change. `AGENTS.md` § Private research / competitors tooling; `tools/competitors_sync.rs` (`sha` field semantics: shallow fetch + reset); research `191-post-research-full-surface-audit.md` §6, `195-master-roadmap-checklist.md` §R4.

## Review gates

none — reference-clone metadata only; no crate dependency, unsafe, API, permission, or wire change.

## Tests

- `tools/competitors_sync.rs` compiled with `rustc --edition=2024 -D warnings` and run as `competitors-sync --dry-run .` against the primary maintainer checkout (where the clones live) with this PR's lockfile: **`dry-run ok (11 repos)`**, every entry resolved to its destination with `sha=<pin>` (electron 465fc763…, tauri 56d19c39…, wails f38ae268…, neutralino 8b99cb61…, nwjs 71e4e253…, electrobun cba306e9…, bun abe2ad4f…, wry d2937514…, tao 2f9eecf2…, tauri-plugins-workspace db9c5998…, vscode 0984c920…). Primary lockfile restored afterwards (clean).
- Pins are the clones' current `git rev-parse HEAD` values, so the next real `just competitors-sync` is a no-op reset (shallow fetch of an already-present commit).
- TOML parsed with Python `tomllib`: 11 `[[repo]]` entries, every entry carries `name/kind/url/branch/sha`.

## Platforms

Tooling file only; no OS path. Verified on macOS arm64.

## Perf impact

None.

## Linear

KEL-68 — Branch handoff posted there. Merge intent: human-decide.