### PR TITLE
docs(agents): declare the learnings area vocabulary that entries actually use

### DIFF
--- a/docs/agents/learnings.md
+++ b/docs/agents/learnings.md
@@ -11,7 +11,11 @@ Format — one line each, newest last:
 ```
 
 `[area]` is a crate short name (`ipc`, `wv`, `guard`, `native`, `runtime`, `update`,
-`pack`, `compat`, `core`, `cli`), `bench`, `docs`, `ts`, `build`, `ci`, or `process`.
+`pack`, `compat`, `core`, `cli`, `host`), optionally suffixed with an OS when the fact is
+OS-specific (`wv/macos`, `wv/windows`, `wv/linux`, `bench/macos`); or one of the
+cross-cutting areas `bench`, `bridge`, `build`, `ci`, `deps`, `docs`, `git`, `process`,
+`shell`, `tooling`, `ts`. A new value is added to this list in the same PR that first
+uses it — an entry whose area is not listed here is the defect, not the list.
 
 Compaction (maintainers, roughly when this list passes ~40 entries): move learnings
 that proved stable into the root `AGENTS.md`, the relevant spec, or a crate

--- a/docs/agents/learnings.md
+++ b/docs/agents/learnings.md
@@ -10,12 +10,13 @@ Format — one line each, newest last:
 - YYYY-MM-DD [area] fact. (evidence: path, issue, or command)
 ```
 
-`[area]` is a crate short name (`ipc`, `wv`, `guard`, `native`, `runtime`, `update`,
-`pack`, `compat`, `core`, `cli`, `host`), optionally suffixed with an OS when the fact is
-OS-specific (`wv/macos`, `wv/windows`, `wv/linux`, `bench/macos`); or one of the
-cross-cutting areas `bench`, `bridge`, `build`, `ci`, `deps`, `docs`, `git`, `process`,
-`shell`, `tooling`, `ts`. A new value is added to this list in the same PR that first
-uses it — an entry whose area is not listed here is the defect, not the list.
+`[area]` is a base area, optionally suffixed with an OS when the fact is OS-specific
+(`wv/macos`, `wv/windows`, `wv/linux`, `bench/macos`). Base areas are the crate short
+names (`ipc`, `wv`, `guard`, `native`, `runtime`, `update`, `pack`, `compat`, `core`,
+`cli`, `host`) and the cross-cutting areas (`bench`, `bridge`, `build`, `ci`, `deps`,
+`docs`, `git`, `process`, `shell`, `tooling`, `ts`). A new value is added to this list in
+the same PR that first uses it — an entry whose area is not listed here is the defect,
+not the list.
 
 Compaction (maintainers, roughly when this list passes ~40 entries): move learnings
 that proved stable into the root `AGENTS.md`, the relevant spec, or a crate


### PR DESCRIPTION
## Summary

`docs/agents/learnings.md` declares its allowed `[area]` values, but 9 of the 23 values in actual use were never declared — `host` (a crate!), the OS-suffixed forms (`wv/macos`, `wv/windows`, `wv/linux`, `bench/macos`), and the cross-cutting `bridge`, `deps`, `git`, `shell`, `tooling`. CodeRabbit has now flagged this class on two consecutive PRs (#69 → follow-up #78 → a further round on #78 itself), each time costing a round-trip on a log that is appended to by nearly every PR.

The honest fix is to declare reality rather than rewrite append-only history: every one of the nine is meaningful (`host` is a crate short name; `wv/macos` is strictly more precise than `wv`; `deps` covers dependency licensing facts; `git` covers the worktree rules; `shell` covers the zsh `path`-variable trap that cost a debugging session). Rewriting them into coarser buckets would destroy information in a log whose whole value is precision.

The rule is now also self-maintaining: **"A new value is added to this list in the same PR that first uses it — an entry whose area is not listed here is the defect, not the list."** That closes the drift loop instead of re-litigating it per PR.

Verified: a script parsing the declared block against every `- YYYY-MM-DD [area]` entry reports **23 areas used, 0 undeclared** after this change (base name matched for OS-suffixed forms).

## Spec refs

No boundary change. `docs/agents/learnings.md` format header (the self-improvement rule in root `AGENTS.md` § Self-improvement points here). Related: research `191-post-research-full-surface-audit.md` (hygiene leftovers) and `195-master-roadmap-checklist.md` Δ ledger, which recorded this as an R-phase leftover.

## Review gates

none

## Tests

- Area-coverage script (inline, above): 23 used, 0 undeclared.
- `git diff --check` clean.
- `just llms-check` — pass.
- `cargo fmt --all --check` — pass; `cargo clippy --workspace --all-targets -- -D warnings` — pass; `cargo nextest run --workspace --profile ci` — **405 passed, 0 skipped** (markdown-only change; gates run to prove nothing else moved).

## Platforms

Docs only; no OS path. Gates run on macOS arm64.

## Perf impact

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the documented area labels to cover runtime, shell, tooling, bridge, dependencies, Git, and native components.
  * Added support for optional operating-system-specific suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->