### PR TITLE
ci: the mandated verification profile must not retry (KEL-112)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,24 @@
-# cargo-nextest configuration — CI profile with flaky-test retry.
+# cargo-nextest configuration.
 # Install locally: cargo install cargo-nextest --locked
 # Run: cargo nextest run --workspace --profile ci
+#
+# The `ci` profile is the verification gate AGENTS.md mandates, so it MUST NOT
+# retry. A retry turns exactly the non-determinism the anti-flake rules exist to
+# prevent into a green summary, and hides the first failure from the human or
+# agent reading it — the same "papering over a failure" that AGENTS.md forbids
+# everywhere else, applied to the gate that enforces it. A test that is not
+# deterministic is fixed at the test (await the condition, bind port 0, use a
+# temp dir), never absorbed here.
+#
+# The profile is kept (empty, inheriting `default`) because `--profile ci` is
+# named by AGENTS.md, the `justfile`, and `.github/workflows/ci.yml`.
+#
+# `tools/ci_hygiene.rs` fails if a literal `retries` key reappears under
+# `[profile.ci]`. That is a speed bump, NOT enforcement of the rule above:
+# nextest resolves retries from this file UNION `--retries` UNION
+# `NEXTEST_RETRIES`, and flag and env win over the file, so a retrying gate can
+# be produced without editing this file at all. Reading the config cannot decide
+# the question. KEL-115 tracks proving it by behaviour instead — running the real
+# gate command against a deliberately failing test and asserting one attempt.
 
 [profile.ci]
-retries = 1

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,8 +13,10 @@
 # The profile is kept (empty, inheriting `default`) because `--profile ci` is
 # named by AGENTS.md, the `justfile`, and `.github/workflows/ci.yml`.
 #
-# `tools/ci_hygiene.rs` fails if a literal `retries` key reappears under
-# `[profile.ci]`. That is a speed bump, NOT enforcement of the rule above:
+# `tools/ci_hygiene.rs` fails if a plainly-spelled `retries` key reappears in any
+# section that binds this gate: `[profile.ci]`, `[profile.default]` (which `ci`
+# inherits, and where nextest's own docs put retries), or either profile's
+# `[[...overrides]]`. That is a speed bump, NOT enforcement of the rule above:
 # nextest resolves retries from this file UNION `--retries` UNION
 # `NEXTEST_RETRIES`, and flag and env win over the file, so a retrying gate can
 # be produced without editing this file at all. Reading the config cannot decide

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,10 +13,12 @@
 # The profile is kept (empty, inheriting `default`) because `--profile ci` is
 # named by AGENTS.md, the `justfile`, and `.github/workflows/ci.yml`.
 #
-# `tools/ci_hygiene.rs` fails if a plainly-spelled `retries` key reappears in any
-# section that binds this gate: `[profile.ci]`, `[profile.default]` (which `ci`
-# inherits, and where nextest's own docs put retries), or either profile's
-# `[[...overrides]]`. That is a speed bump, NOT enforcement of the rule above:
+# `tools/ci_hygiene.rs` fails on a plainly-spelled `retries` in the sections
+# measured to bind this gate: `[profile.ci]`, `[profile.default]` (which `ci`
+# inherits, and where nextest's own docs put retries), either profile's
+# `[[...overrides]]`, and either profile's `.retries` sub-table. That list is
+# what has been measured, not a proof that nothing else binds. It is a speed
+# bump, NOT enforcement of the rule above:
 # nextest resolves retries from this file UNION `--retries` UNION
 # `NEXTEST_RETRIES`, and flag and env win over the file, so a retrying gate can
 # be produced without editing this file at all. Reading the config cannot decide

--- a/docs/engineering/decisions.md
+++ b/docs/engineering/decisions.md
@@ -322,8 +322,10 @@ cargo nextest run --workspace --profile ci
 ```
 
 Toolchain pin: `rust-toolchain.toml` (`1.97.1`, rustfmt + clippy). Nextest CI
-profile: `.config/nextest.toml` (`retries = 1`). Workspace clippy is already
-pedantic; do not re-enable it per crate (learnings 2026-07-08).
+profile: `.config/nextest.toml`, deliberately empty — the mandated gate MUST NOT
+retry, because a retry reports a flaky test green and hides its first failure
+(KEL-112). Workspace clippy is already pedantic; do not re-enable it per crate
+(learnings 2026-07-08).
 
 **Chose — local mirror of CI (`justfile`).** `just ci` runs, in order:
 `agents-md` → `mermaid-test` → `mermaid-check` → `mermaid-render-check` → `llms-test` →

--- a/docs/onboarding/05-development-guide.md
+++ b/docs/onboarding/05-development-guide.md
@@ -180,6 +180,10 @@ cargo nextest run -p keld-ipc -- frame         # one crate, substring filter
 cargo test --workspace                         # fallback if nextest is unavailable
 ```
 
+The `ci` profile declares no retries, so a test that fails once fails the gate. That is
+a property of the profile, not of the command: `--retries N` and `NEXTEST_RETRIES=N`
+still override it, and neither belongs in a verification run (KEL-112).
+
 `cargo nextest run -p keld-ipc -- frame` applies a substring filter. Quote its fresh
 summary when using it; the selected test/binary/skipped totals are not a documentation
 contract.

--- a/docs/onboarding/05-development-guide.md
+++ b/docs/onboarding/05-development-guide.md
@@ -174,7 +174,7 @@ cross-platform code, CI usually agrees.
 ## 4. Running tests
 
 ```bash
-cargo nextest run --workspace --profile ci     # the gate; ci profile sets retries = 1
+cargo nextest run --workspace --profile ci     # the gate; no retries, a flake fails here
 cargo nextest run -p keld-ipc                  # one crate
 cargo nextest run -p keld-ipc -- frame         # one crate, substring filter
 cargo test --workspace                         # fallback if nextest is unavailable

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2953,8 +2953,10 @@ cargo nextest run --workspace --profile ci
 ```
 
 Toolchain pin: `rust-toolchain.toml` (`1.97.1`, rustfmt + clippy). Nextest CI
-profile: `.config/nextest.toml` (`retries = 1`). Workspace clippy is already
-pedantic; do not re-enable it per crate (learnings 2026-07-08).
+profile: `.config/nextest.toml`, deliberately empty — the mandated gate MUST NOT
+retry, because a retry reports a flaky test green and hides its first failure
+(KEL-112). Workspace clippy is already pedantic; do not re-enable it per crate
+(learnings 2026-07-08).
 
 **Chose — local mirror of CI (`justfile`).** `just ci` runs, in order:
 `agents-md` → `mermaid-test` → `mermaid-check` → `mermaid-render-check` → `llms-test` →

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -510,24 +510,32 @@ fn is_pinned_sha(spec: &str) -> bool {
 /// must not retry: a retry reports a flaky test as green and hides the first
 /// failure from the summary a human or agent reads (KEL-112).
 ///
-/// Deliberately narrow, and its limits are the point. It catches the literal
-/// reappearance of a `retries` key under `[profile.ci]` — the regression that
-/// actually happened. It does NOT catch, and cannot:
+/// Deliberately narrow, and its limits are the point.
+///
+/// It catches a plainly-spelled `retries` key in any section that binds the
+/// gate — see [`section_binds_ci_gate`]. It does NOT catch:
 ///
 /// - `cargo nextest run --profile ci --retries 2`
 /// - `NEXTEST_RETRIES=2` in the job's environment
 /// - `--profile local` pointed at a profile that does retry
+/// - a key spelled so as to evade a line reader: `"retries"`, an escape-encoded
+///   `"\U00000072etries"`, or a header hidden inside a multi-line string
 ///
-/// All three were reproduced against this exact config with the guard green.
-/// nextest resolves retries from config UNION flag UNION env, with flag and env
-/// taking precedence, so no amount of parsing this file can decide the
-/// question — the inputs are not in it. Three rounds of hardening this parser
-/// each produced a new bypass from outside its frame. KEL-115 replaces it with
-/// a behavioural check: run the real gate command against a deliberately
-/// failing test and assert exactly one attempt.
+/// The first three were reproduced against this exact config with the guard
+/// green, and no reading of this file can catch them: nextest resolves retries
+/// from config UNION flag UNION env, flag and env winning, so the deciding
+/// inputs are not in the file at all.
 ///
-/// Do not extend this to chase a new spelling. Extending it makes it look more
-/// authoritative without making it more correct, which is the worse failure.
+/// The fourth is decidable but deliberately not chased. Three rounds of
+/// hardening a parser for it each produced a new spelling from outside the
+/// previous frame, and an evasive spelling is not the regression this guard
+/// exists to prevent — an ordinary edit re-adding `retries` is. KEL-115
+/// replaces the whole approach with a behavioural check: run the real gate
+/// command against a deliberately failing test and assert exactly one attempt.
+///
+/// Extend this only to a section that genuinely binds the gate and is verified
+/// to retry. Do not extend it to chase an evasive spelling: that makes it look
+/// more authoritative without making it more correct.
 fn check_ci_profile_does_not_retry(root: &Path) -> Result<(), String> {
     let text = read(root, NEXTEST_CONFIG)?;
     if profile_section_sets_retries(&text, "ci") {
@@ -541,15 +549,37 @@ fn check_ci_profile_does_not_retry(root: &Path) -> Result<(), String> {
     Ok(())
 }
 
-/// True when `[profile.<name>]` declares a `retries` key. Reads only that
-/// section: a `retries` line under any other profile is not this contract.
-fn profile_section_sets_retries(text: &str, name: &str) -> bool {
-    let header = format!("[profile.{name}]");
+/// True when a section that binds `--profile ci` declares a `retries` key.
+///
+/// Three sections bind it, all verified against cargo-nextest 0.9.140 by
+/// counting `TRY` lines from a deliberately failing test:
+///
+/// - `[profile.ci]` itself.
+/// - `[profile.default]` — `ci` inherits it, and nextest's own documentation
+///   puts `retries` here, so this is the *likeliest* accidental regression, not
+///   an exotic one.
+/// - `[[profile.ci.overrides]]` and `[[profile.default.overrides]]`, whose
+///   `retries` applies to every test the override's filter matches.
+///
+/// A `retries` under a profile that does not bind the gate — `[profile.local]`,
+/// `[profile.ci-extra]` — is correctly not this contract: measured, those run a
+/// single attempt under `--profile ci`.
+fn section_binds_ci_gate(header: &str) -> bool {
+    matches!(
+        header,
+        "[profile.ci]"
+            | "[profile.default]"
+            | "[[profile.ci.overrides]]"
+            | "[[profile.default.overrides]]"
+    )
+}
+
+fn profile_section_sets_retries(text: &str, _name: &str) -> bool {
     let mut inside = false;
     for line in text.lines() {
         let line = line.trim();
         if line.starts_with('[') {
-            inside = line == header;
+            inside = section_binds_ci_gate(line);
             continue;
         }
         if inside && line.split('=').next().is_some_and(|key| key.trim() == "retries") {
@@ -900,6 +930,49 @@ mod tests {
             .expect_err("the mandated verification profile must not retry (KEL-112)");
         assert!(error.contains("retries"), "{error}");
         assert!(error.contains(NEXTEST_CONFIG), "{error}");
+    }
+
+    #[test]
+    fn the_inherited_default_profile_is_the_gate_too() {
+        // `--profile ci` inherits `default`, and nextest's own documentation
+        // puts `retries` there — so this is the likeliest accidental
+        // regression, not an exotic one. Measured on cargo-nextest 0.9.140:
+        // `[profile.default] retries = 2` with an empty `[profile.ci]` runs a
+        // failing test 3 times under `--profile ci`.
+        let temp = complete_fixture();
+        temp.write(
+            NEXTEST_CONFIG,
+            "[profile.default]\nretries = 2\n\n[profile.ci]\n",
+        );
+        let error = check(temp.path())
+            .expect_err("`ci` inherits `default`, so retries there bind the mandated gate");
+        assert!(error.contains("retries"), "{error}");
+    }
+
+    #[test]
+    fn an_override_that_retries_binds_the_gate() {
+        // An override's `retries` applies to every test its filter matches.
+        let temp = complete_fixture();
+        temp.write(
+            NEXTEST_CONFIG,
+            "[profile.ci]\n\n[[profile.ci.overrides]]\nfilter = \"all()\"\nretries = 2\n",
+        );
+        let error = check(temp.path())
+            .expect_err("an override under the mandated profile still retries it");
+        assert!(error.contains("retries"), "{error}");
+    }
+
+    #[test]
+    fn a_profile_that_does_not_bind_the_gate_may_retry() {
+        // The no-false-positive side: measured, `[profile.local]` runs a single
+        // attempt under `--profile ci`, so rejecting it would block a
+        // legitimate local convenience for no gain.
+        let temp = complete_fixture();
+        temp.write(
+            NEXTEST_CONFIG,
+            "[profile.ci]\n\n[profile.local]\nretries = 3\n",
+        );
+        check(temp.path()).expect("a profile the gate does not inherit is not this contract");
     }
 
     #[test]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -512,8 +512,10 @@ fn is_pinned_sha(spec: &str) -> bool {
 ///
 /// Deliberately narrow, and its limits are the point.
 ///
-/// It catches a plainly-spelled `retries` key in any section that binds the
-/// gate — see [`section_binds_ci_gate`]. It does NOT catch:
+/// It catches a plainly-spelled `retries` in the section family that binds the
+/// gate — see [`classify_gate_section`]: either profile's own table, its
+/// `[[...overrides]]`, or its `.retries` sub-table, with a trailing comment on
+/// the header tolerated. It does NOT catch:
 ///
 /// - `cargo nextest run --profile ci --retries 2`
 /// - `NEXTEST_RETRIES=2` in the job's environment
@@ -525,6 +527,11 @@ fn is_pinned_sha(spec: &str) -> bool {
 /// green, and no reading of this file can catch them: nextest resolves retries
 /// from config UNION flag UNION env, flag and env winning, so the deciding
 /// inputs are not in the file at all.
+///
+/// The enumeration above is what has been *measured*, not a proof of
+/// completeness. nextest owns profile resolution, and a future version may add
+/// another binding form; this guard would not know. That asymmetry is the
+/// reason KEL-115 replaces it rather than growing it.
 ///
 /// The fourth is decidable but deliberately not chased. Three rounds of
 /// hardening a parser for it each produced a new spelling from outside the
@@ -538,55 +545,98 @@ fn is_pinned_sha(spec: &str) -> bool {
 /// more authoritative without making it more correct.
 fn check_ci_profile_does_not_retry(root: &Path) -> Result<(), String> {
     let text = read(root, NEXTEST_CONFIG)?;
-    if profile_section_sets_retries(&text, "ci") {
+    if let Some(section) = gate_section_setting_retries(&text) {
         return Err(format!(
-            "CI-HYGIENE: `{NEXTEST_CONFIG}` sets `retries` under `[profile.ci]`, the profile \
-             AGENTS.md mandates as the verification gate — a flaky test would report green and \
-             its first failure would never be shown. Remove the `retries` key and fix the \
-             non-deterministic test instead (await the condition, bind port 0, use a temp dir)."
+            "CI-HYGIENE: `{NEXTEST_CONFIG}` sets `retries` under `{section}`, which binds \
+             `--profile ci` — the profile AGENTS.md mandates as the verification gate. A flaky \
+             test would report green and its first failure would never be shown. Remove the \
+             `retries` key and fix the non-deterministic test instead (await the condition, \
+             bind port 0, use a temp dir)."
         ));
     }
     Ok(())
 }
 
-/// True when a section that binds `--profile ci` declares a `retries` key.
-///
-/// Three sections bind it, all verified against cargo-nextest 0.9.140 by
-/// counting `TRY` lines from a deliberately failing test:
-///
-/// - `[profile.ci]` itself.
-/// - `[profile.default]` — `ci` inherits it, and nextest's own documentation
-///   puts `retries` here, so this is the *likeliest* accidental regression, not
-///   an exotic one.
-/// - `[[profile.ci.overrides]]` and `[[profile.default.overrides]]`, whose
-///   `retries` applies to every test the override's filter matches.
-///
-/// A `retries` under a profile that does not bind the gate — `[profile.local]`,
-/// `[profile.ci-extra]` — is correctly not this contract: measured, those run a
-/// single attempt under `--profile ci`.
-fn section_binds_ci_gate(header: &str) -> bool {
-    matches!(
-        header,
-        "[profile.ci]"
-            | "[profile.default]"
-            | "[[profile.ci.overrides]]"
-            | "[[profile.default.overrides]]"
-    )
+/// How a section header relates to the profile `--profile ci` resolves.
+#[derive(PartialEq)]
+enum GateSection {
+    /// The section itself *is* the retries table: `[profile.ci.retries]`.
+    IsRetries,
+    /// A section whose `retries` key binds the gate.
+    MayDeclareRetries,
+    /// Not this contract.
+    Unrelated,
 }
 
-fn profile_section_sets_retries(text: &str, _name: &str) -> bool {
-    let mut inside = false;
+/// Classifies a TOML section header against the profile the mandated gate uses.
+///
+/// Structural rather than a list of literal spellings, because the shapes that
+/// bind the gate are a *family*, not a fixed set: `retries` is a key under the
+/// profile, and also a legitimate sub-table (`[profile.ci.retries]`, nextest's
+/// documented retries-with-backoff form), and both `ci` and `default` carry it
+/// because `--profile ci` inherits `default`.
+///
+/// Verified against cargo-nextest 0.9.140 by counting `TRY` lines from a
+/// deliberately failing test. Binding: `[profile.ci]`, `[profile.default]`,
+/// either profile's `[[...overrides]]`, and either profile's `.retries`
+/// sub-table. Not binding, and correctly ignored: `[profile.local]`,
+/// `[profile.ci-extra]`, `[profile.default-miri]` — measured, all run a single
+/// attempt under `--profile ci`.
+fn classify_gate_section(header: &str) -> GateSection {
+    // A trailing comment is ordinary TOML: `[profile.ci] # keep empty` is still
+    // the `ci` section, and comparing the whole line would miss it.
+    let header = header.split('#').next().unwrap_or(header).trim();
+    let inner = match header
+        .strip_prefix("[[")
+        .and_then(|rest| rest.strip_suffix("]]"))
+    {
+        Some(inner) => inner,
+        None => match header.strip_prefix('[').and_then(|r| r.strip_suffix(']')) {
+            Some(inner) => inner,
+            None => return GateSection::Unrelated,
+        },
+    };
+    let mut parts = inner.split('.').map(str::trim);
+    if parts.next() != Some("profile") {
+        return GateSection::Unrelated;
+    }
+    // `--profile ci` resolves against `ci` and the `default` it inherits.
+    if !matches!(parts.next(), Some("ci" | "default")) {
+        return GateSection::Unrelated;
+    }
+    match (parts.next(), parts.next()) {
+        (None, _) | (Some("overrides"), None) => GateSection::MayDeclareRetries,
+        (Some("retries"), None) => GateSection::IsRetries,
+        _ => GateSection::Unrelated,
+    }
+}
+
+/// The gate-binding section that declares `retries`, if any.
+///
+/// Returns the header so the error can name the section it actually found: a
+/// message hard-coding `[profile.ci]` sends a reader to the wrong line when the
+/// key is under `[profile.default]`.
+fn gate_section_setting_retries(text: &str) -> Option<String> {
+    let mut current: Option<String> = None;
     for line in text.lines() {
         let line = line.trim();
         if line.starts_with('[') {
-            inside = section_binds_ci_gate(line);
+            let header = line.split('#').next().unwrap_or(line).trim().to_owned();
+            match classify_gate_section(line) {
+                // The section header *is* the declaration; there is no key to find.
+                GateSection::IsRetries => return Some(header),
+                GateSection::MayDeclareRetries => current = Some(header),
+                GateSection::Unrelated => current = None,
+            }
             continue;
         }
-        if inside && line.split('=').next().is_some_and(|key| key.trim() == "retries") {
-            return true;
+        if line.split('=').next().is_some_and(|key| key.trim() == "retries") {
+            if let Some(header) = current.clone() {
+                return Some(header);
+            }
         }
     }
-    false
+    None
 }
 
 fn check_gitignore(root: &Path) -> Result<(), String> {
@@ -960,6 +1010,67 @@ mod tests {
         let error = check(temp.path())
             .expect_err("an override under the mandated profile still retries it");
         assert!(error.contains("retries"), "{error}");
+    }
+
+    #[test]
+    fn the_retries_sub_table_binds_the_gate() {
+        // nextest's documented retries-with-backoff form is a sub-table, not a
+        // key. Measured: `[profile.ci.retries]` with `count = 2` runs a failing
+        // test 3 times under `--profile ci`. A guard matching literal section
+        // names missed it entirely, because the section *is* the declaration.
+        for header in ["[profile.ci.retries]", "[profile.default.retries]"] {
+            let temp = complete_fixture();
+            temp.write(
+                NEXTEST_CONFIG,
+                &format!("[profile.ci]\n\n{header}\ncount = 2\nbackoff = \"fixed\"\n"),
+            );
+            let error = check(temp.path())
+                .expect_err("a retries sub-table retries the mandated gate");
+            assert!(error.contains(header), "{error}");
+        }
+    }
+
+    #[test]
+    fn a_trailing_comment_does_not_hide_the_section() {
+        // `[profile.ci] # keep this empty` is ordinary TOML and still the `ci`
+        // section. Comparing the whole trimmed line against a literal header
+        // silently skipped it while nextest retried.
+        let temp = complete_fixture();
+        temp.write(
+            NEXTEST_CONFIG,
+            "[profile.ci] # keep this empty\nretries = 2\n",
+        );
+        let error =
+            check(temp.path()).expect_err("a commented header is still the mandated profile");
+        assert!(error.contains("[profile.ci]"), "{error}");
+    }
+
+    #[test]
+    fn an_inherited_override_that_retries_binds_the_gate() {
+        // The fourth binding section. Its absence from the tests was why the
+        // doc comment could claim all four were verified while one was not.
+        let temp = complete_fixture();
+        temp.write(
+            NEXTEST_CONFIG,
+            "[profile.ci]\n\n[[profile.default.overrides]]\nfilter = \"all()\"\nretries = 2\n",
+        );
+        let error = check(temp.path())
+            .expect_err("an override on the inherited profile still retries the gate");
+        assert!(error.contains("[[profile.default.overrides]]"), "{error}");
+    }
+
+    #[test]
+    fn the_error_names_the_section_it_found() {
+        // A message hard-coding `[profile.ci]` sends the reader to the wrong
+        // line when the key is under the profile `ci` inherits.
+        let temp = complete_fixture();
+        temp.write(NEXTEST_CONFIG, "[profile.default]\nretries = 2\n\n[profile.ci]\n");
+        let error = check(temp.path()).expect_err("inherited retries bind the gate");
+        assert!(error.contains("[profile.default]"), "{error}");
+        assert!(
+            !error.contains("under `[profile.ci]`"),
+            "must not name a section it did not find: {error}"
+        );
     }
 
     #[test]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -545,6 +545,15 @@ fn is_pinned_sha(spec: &str) -> bool {
 /// more authoritative without making it more correct.
 fn check_ci_profile_does_not_retry(root: &Path) -> Result<(), String> {
     let text = read(root, NEXTEST_CONFIG)?;
+    if let Some((section, parent)) = gate_section_with_unfollowable_parent(&text) {
+        return Err(format!(
+            "CI-HYGIENE: `{NEXTEST_CONFIG}` has `{section}` inheriting from `{parent}`, and \
+             this check cannot follow that chain to prove the mandated gate does not retry — \
+             nextest inheritance is transitive, so `retries` anywhere up the chain binds \
+             `--profile ci`. Inherit from `default` (the implicit parent) instead, or move \
+             the settings into `{section}` directly."
+        ));
+    }
     if let Some(section) = gate_section_setting_retries(&text) {
         return Err(format!(
             "CI-HYGIENE: `{NEXTEST_CONFIG}` sets `retries` under `{section}`, which binds \
@@ -609,6 +618,52 @@ fn classify_gate_section(header: &str) -> GateSection {
         (Some("retries"), None) => GateSection::IsRetries,
         _ => GateSection::Unrelated,
     }
+}
+
+/// A gate-binding section whose `inherits` points somewhere this check cannot
+/// follow, as `(section, parent)`.
+///
+/// nextest lets any profile name a parent (`inherits = "shared"`), and the
+/// chain is transitive: measured, `[profile.ci] inherits = "a"`, `[profile.a]
+/// inherits = "b"`, `[profile.b] retries = 2` runs a failing test 3 times under
+/// `--profile ci`. Following an arbitrary chain is more parsing than this guard
+/// is willing to own, so an unfollowable parent FAILS CLOSED: silence about a
+/// chain it cannot read must not be reported as "no retries".
+///
+/// `inherits = "default"` is allowed because it is the implicit parent anyway,
+/// and `[profile.default]` is already classified.
+fn gate_section_with_unfollowable_parent(text: &str) -> Option<(String, String)> {
+    let mut current: Option<String> = None;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            let header = line.split('#').next().unwrap_or(line).trim().to_owned();
+            current = match classify_gate_section(line) {
+                GateSection::Unrelated => None,
+                _ => Some(header),
+            };
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "inherits" {
+            continue;
+        }
+        let parent = value
+            .split('#')
+            .next()
+            .unwrap_or(value)
+            .trim()
+            .trim_matches(['"', '\''])
+            .to_owned();
+        if parent != "default" {
+            if let Some(section) = current.clone() {
+                return Some((section, parent));
+            }
+        }
+    }
+    None
 }
 
 /// The gate-binding section that declares `retries`, if any.
@@ -1071,6 +1126,32 @@ mod tests {
             !error.contains("under `[profile.ci]`"),
             "must not name a section it did not find: {error}"
         );
+    }
+
+    #[test]
+    fn an_unfollowable_parent_fails_closed() {
+        // nextest inheritance is transitive. Measured: `[profile.ci] inherits =
+        // "a"`, `[profile.a] inherits = "b"`, `[profile.b] retries = 2` runs a
+        // failing test 3 times under `--profile ci`. This guard does not follow
+        // chains, so it must refuse rather than report silence as no-retries.
+        let temp = complete_fixture();
+        temp.write(
+            NEXTEST_CONFIG,
+            "[profile.shared]\nretries = 2\n\n[profile.ci]\ninherits = \"shared\"\n",
+        );
+        let error = check(temp.path())
+            .expect_err("a parent this check cannot follow must fail closed");
+        assert!(error.contains("shared"), "{error}");
+        assert!(error.contains("cannot follow"), "{error}");
+    }
+
+    #[test]
+    fn inheriting_the_implicit_default_parent_is_allowed() {
+        // `default` is the implicit parent and is already classified, so naming
+        // it explicitly must not be a false positive.
+        let temp = complete_fixture();
+        temp.write(NEXTEST_CONFIG, "[profile.ci]\ninherits = \"default\"\n");
+        check(temp.path()).expect("inheriting the implicit parent is a no-op");
     }
 
     #[test]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -14,6 +14,7 @@ const PR_TEMPLATE: &str = ".github/PULL_REQUEST_TEMPLATE.md";
 const ISSUE_DIR: &str = ".github/ISSUE_TEMPLATE";
 const WORKFLOW: &str = ".github/workflows/ci.yml";
 const GITIGNORE: &str = ".gitignore";
+const NEXTEST_CONFIG: &str = ".config/nextest.toml";
 const MERMAID_CHECKER: &str = "tools/mermaid_docs.rs";
 const MERMAID_RENDERER: &str = "tools/mermaid_render_check.sh";
 const MERMAID_CONFIG: &str = "tools/mermaid-render-config.json";
@@ -505,6 +506,59 @@ fn is_pinned_sha(spec: &str) -> bool {
     sha.len() == 40 && sha.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
+/// The verification gate AGENTS.md mandates is `--profile ci`, so that profile
+/// must not retry: a retry reports a flaky test as green and hides the first
+/// failure from the summary a human or agent reads (KEL-112).
+///
+/// Deliberately narrow, and its limits are the point. It catches the literal
+/// reappearance of a `retries` key under `[profile.ci]` — the regression that
+/// actually happened. It does NOT catch, and cannot:
+///
+/// - `cargo nextest run --profile ci --retries 2`
+/// - `NEXTEST_RETRIES=2` in the job's environment
+/// - `--profile local` pointed at a profile that does retry
+///
+/// All three were reproduced against this exact config with the guard green.
+/// nextest resolves retries from config UNION flag UNION env, with flag and env
+/// taking precedence, so no amount of parsing this file can decide the
+/// question — the inputs are not in it. Three rounds of hardening this parser
+/// each produced a new bypass from outside its frame. KEL-115 replaces it with
+/// a behavioural check: run the real gate command against a deliberately
+/// failing test and assert exactly one attempt.
+///
+/// Do not extend this to chase a new spelling. Extending it makes it look more
+/// authoritative without making it more correct, which is the worse failure.
+fn check_ci_profile_does_not_retry(root: &Path) -> Result<(), String> {
+    let text = read(root, NEXTEST_CONFIG)?;
+    if profile_section_sets_retries(&text, "ci") {
+        return Err(format!(
+            "CI-HYGIENE: `{NEXTEST_CONFIG}` sets `retries` under `[profile.ci]`, the profile \
+             AGENTS.md mandates as the verification gate — a flaky test would report green and \
+             its first failure would never be shown. Remove the `retries` key and fix the \
+             non-deterministic test instead (await the condition, bind port 0, use a temp dir)."
+        ));
+    }
+    Ok(())
+}
+
+/// True when `[profile.<name>]` declares a `retries` key. Reads only that
+/// section: a `retries` line under any other profile is not this contract.
+fn profile_section_sets_retries(text: &str, name: &str) -> bool {
+    let header = format!("[profile.{name}]");
+    let mut inside = false;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            inside = line == header;
+            continue;
+        }
+        if inside && line.split('=').next().is_some_and(|key| key.trim() == "retries") {
+            return true;
+        }
+    }
+    false
+}
+
 fn check_gitignore(root: &Path) -> Result<(), String> {
     let text = read(root, GITIGNORE)?;
     if github_dir_is_ignored(&text) {
@@ -663,6 +717,7 @@ fn check_mermaid_gate_files(root: &Path) -> Result<(), String> {
 
 fn check(root: &Path) -> Result<(), String> {
     check_gitignore(root)?;
+    check_ci_profile_does_not_retry(root)?;
     check_codeowners(root)?;
     check_pr_template(root)?;
     check_issue_templates(root)?;
@@ -819,6 +874,7 @@ mod tests {
         );
         temp.write(WORKFLOW, &valid_workflow());
         temp.write(MERMAID_CHECKER, "fn main() {}\n");
+        temp.write(NEXTEST_CONFIG, "[profile.ci]\n");
         temp.write(
             MERMAID_RENDERER,
             "sha256:29077c6bd02f14bdfdd5fee552d9c00fe68d4fab3cd84952d21e2d1faf2fadaf\n--network none\n--read-only\n--cap-drop ALL\n--security-opt no-new-privileges\n--memory 2g\n--pids-limit 256\nrun_with_timeout 120 docker run\nrun_with_timeout 300 docker pull\n--pull never\n--jobs 2\n:/input/source.md:ro\ntrap cleanup EXIT\n/tmp/keld-mermaid-render.\n",
@@ -834,6 +890,41 @@ mod tests {
     fn complete_fixture_passes() {
         let temp = complete_fixture();
         check(temp.path()).expect("complete KEL-39 fixture must pass");
+    }
+
+    #[test]
+    fn ci_profile_that_retries_is_rejected() {
+        let temp = complete_fixture();
+        temp.write(NEXTEST_CONFIG, "[profile.ci]\nretries = 1\n");
+        let error = check(temp.path())
+            .expect_err("the mandated verification profile must not retry (KEL-112)");
+        assert!(error.contains("retries"), "{error}");
+        assert!(error.contains(NEXTEST_CONFIG), "{error}");
+    }
+
+    #[test]
+    fn ci_profile_without_retries_passes() {
+        let temp = complete_fixture();
+        temp.write(NEXTEST_CONFIG, "[profile.ci]\nfail-fast = false\n");
+        check(temp.path()).expect("a ci profile with no retries is the contract");
+    }
+
+    #[test]
+    fn retries_under_a_different_profile_is_not_this_contract() {
+        // Guards over-matching: only the profile AGENTS.md mandates is bound.
+        let temp = complete_fixture();
+        temp.write(
+            NEXTEST_CONFIG,
+            "[profile.local]\nretries = 3\n\n[profile.ci]\n",
+        );
+        check(temp.path()).expect("only `[profile.ci]` is the verification gate");
+    }
+
+    #[test]
+    fn commented_out_retries_is_not_a_retry() {
+        let temp = complete_fixture();
+        temp.write(NEXTEST_CONFIG, "[profile.ci]\n# retries = 1 (removed, KEL-112)\n");
+        check(temp.path()).expect("a comment is documentation, not configuration");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`.config/nextest.toml` set `retries = 1` on `[profile.ci]` — the profile AGENTS.md names as the verification gate. **Every test in the repo's own required gate got one silent retry:** a test that failed once and passed on the retry reported green, and the summary a human or agent reads never showed the first failure.

That contradicts the rules the gate exists to enforce. AGENTS.md forbids "retrying a deterministic failure" and requires awaiting conditions rather than tolerating timing. A non-deterministic test is fixed at the test — await the condition, bind port 0, use a temp dir — not absorbed by the runner.

The profile is kept but empty (inheriting `default`) because `--profile ci` is named by AGENTS.md, the `justfile` and `.github/workflows/ci.yml`; removing the section would break all three call sites for no gain.

**The retry was not load-bearing.** Five consecutive `--profile ci` runs of the full workspace passed with zero retries consumed, and this branch's own run is 444 passed with no `TRY` lines emitted at all.

## Scope withdrawn — please review this specifically

The guard in `tools/ci_hygiene.rs` catches the literal reappearance of a `retries` key under `[profile.ci]` — the regression that actually happened. **It is a speed bump, and both it and `.config/nextest.toml` now say so in their own comments.**

An earlier version of this PR carried an 800-line TOML scope parser that tried to catch every spelling. It was withdrawn. Three rounds of adversarial review, and the last reviewer said outright it could not break the parser — so it broke the *contract* instead, from outside the parser's frame:

```
cargo nextest run --profile ci --retries 2        -> TRY 1/2/3   guard exit 0
NEXTEST_RETRIES=2 cargo nextest run --profile ci  -> TRY 1/2/3   guard exit 0
--profile local  + [profile.local] retries = 2    -> TRY 1/2/3   guard exit 0
```

All three reproduced against this exact committed config with the guard green. The third is the sharpest: the guard's own accept side *deliberately blesses* `[profile.local] retries = 3` as out of scope, and the workflow simply points `--profile` at it. **Two individually guard-green files compose into a retrying gate.**

nextest resolves retries from config ∪ `--retries` ∪ `NEXTEST_RETRIES`, with flag and env taking precedence. No amount of parsing this file can decide the question, because the deciding inputs are not in it. The earlier rounds also found genuine parser bugs (escape-encoded keys such as `"\U00000072etries"` slipping past a substring pre-filter that gated the whole fail-closed pipeline) — good work, but hardening a frame that cannot answer the question.

**KEL-115** replaces it with a canary: run the real gate command against a deliberately failing test and assert exactly one attempt. Immune to every spelling, because it measures what the gate did.

The narrow guard is kept rather than deleted because it catches the actual historical regression.

## Correction — the "honest scope" comment was itself wrong

An isolated review found that the comment I wrote *to state the guard's limits honestly* overstated them in the other direction. It said the un-caught cases were external-only, and that "no amount of parsing this file can decide the question — the inputs are not in it." Two **in-file** shapes make the mandated gate retry and passed the guard green:

```
[profile.default] retries = 2   + empty [profile.ci]   -> TRY 1/2/3
[[profile.ci.overrides]] retries = 2                   -> TRY 1/2/3
```

Both measured on cargo-nextest 0.9.140 by TRY-line counting. `--profile ci` **inherits `default`**, and nextest's own documentation puts `retries` under `default` — so that is the *likeliest* accidental regression, not an exotic one. The old comment told the next reader that shape could not exist. A false reassurance is worse than the silence it replaced.

Fixed in `4873d58`. `section_binds_ci_gate` now names the four sections that bind the gate, each verified to retry:

| section | binds the gate | measured |
|---|---|---|
| `[profile.ci]` | yes | TRY 1/2/3 |
| `[profile.default]` | yes — `ci` inherits it | TRY 1/2/3 |
| `[[profile.ci.overrides]]` | yes | TRY 1/2/3 |
| `[[profile.default.overrides]]` | yes | TRY 1/2/3 |
| `[profile.local]`, `[profile.ci-extra]` | **no** | single attempt |

The last row is the no-false-positive side: rejecting those would block a legitimate local convenience for no gain.

**This is not a reopening of the withdrawn arms race.** An evasive spelling (`"retries"`, an escape-encoded `"\U00000072etries"`, a header hidden in a multi-line string) is still deliberately not chased — it is decidable but it is not the regression this guard exists to prevent. The comment now separates limits that are **undecidable** (flag, env, profile substitution) from ones **decidable but declined**, instead of collapsing both into "cannot".

Also corrects two authoritative docs that still asserted the removed setting: `docs/engineering/decisions.md` — the decision log for this very gate, and in the generated llms corpus — and `docs/onboarding/05-development-guide.md`, whose command annotation read `# the gate; ci profile sets retries = 1`.

## Third round — two live bypasses in the guard I had just extended

A follow-up isolated review broke it again, both measured against cargo-nextest 0.9.140 by TRY-line counting (baseline: empty `[profile.ci]` = 0 TRY lines):

```
[profile.ci.retries]  count = 2      -> 4 TRY lines, guard exit 0
[profile.ci] # keep this empty
retries = 2                          -> 4 TRY lines, guard exit 0
```

The first is **nextest's own documented retries-with-backoff form**: `retries` is a sub-table, so the *section header itself* is the declaration and there is no key line to find. The second is an ordinary TOML trailing comment, missed because the code compared the whole trimmed line against a literal header string.

Matching literal spellings was the wrong frame for a shape that is a **family**. Fixed in `a24ec21`: `classify_gate_section` parses the header structurally — strip a trailing comment, unwrap `[..]` or `[[..]]`, split the dotted path, require `profile` then `ci`-or-`default`, then decide from the remainder (nothing or `overrides` may *declare* `retries`; `retries` itself **is** the declaration).

Verified end-to-end through the real CLI against a `git archive HEAD` copy:

| config | guard | section named |
|---|---|---|
| `[profile.ci] retries = 2` | exit 1 | `[profile.ci]` |
| `[profile.ci.retries]` table | exit 1 | `[profile.ci.retries]` |
| `[profile.ci] # comment` | exit 1 | `[profile.ci]` |
| `[profile.default.retries]` table | exit 1 | `[profile.default.retries]` |
| `[[profile.default.overrides]]` | exit 1 | `[[profile.default.overrides]]` |
| `[profile.local] retries = 3` | **exit 0** | — |
| `[profile.ci]` empty | **exit 0** | — |

Two more from the same round: the error hard-coded `[profile.ci]` while firing for four different sections, sending a reader to the wrong line whenever the key was under the inherited profile — it now names the section it found. And `[[profile.default.overrides]]` had **no test**, so the doc comment's claim that all four sections were verified was false for one of them.

Both doc blocks now say the enumeration is what has been **measured**, not a proof of completeness: nextest owns profile resolution and a future version may add another binding form this guard would not know about. That asymmetry is precisely why KEL-115 replaces it rather than growing it.

## Spec refs

`.config/nextest.toml` and `tools/ci_hygiene.rs`. The rule itself is root `AGENTS.md` § Commands & verification and § No workarounds. No boundary change.

## Review gates

none — no unsafe, public API, permission model, dependency, or wire-protocol change.

## Tests

`just hygiene` **48 passed / 0 failed** (`ci-hygiene check .` exit 0) · `cargo fmt --check` clean · `cargo nextest run --workspace --profile ci` **444 passed, 0 failed, zero `TRY` lines** — which is the observable proof the gate no longer retries.

Seven falsifiable cases on the retained guard: a retrying `[profile.ci]` is rejected; a non-retrying one passes; a commented-out line is documentation not configuration; the inherited `[profile.default]` is rejected; an override that retries is rejected; and a profile the gate does *not* inherit may retry without being flagged. Each is killed by reverting the section list — `hygiene 44/44`.

## Platforms

`not applicable` — configuration and a repo-local hygiene tool.

## Perf impact

Removes up to one silent re-run per failing test from the required gate, so a genuinely failing run now fails faster.

Refs KEL-112, KEL-115.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - CI verification no longer retries failed tests, ensuring flaky or failing tests are reported immediately.
  - Updated checks prevent retry settings from being reintroduced into the required CI test profiles.

- **Documentation**
  - Updated engineering decisions, development guidance, and reference materials to describe the no-retry CI policy.
  - Clarified that any test failure causes the verification gate to fail without automatic retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

