### PR TITLE
docs(ipc): state the one-session app link and what keld dev does about it (KEL-105)

### DIFF
--- a/docs/architecture/02-ipc.md
+++ b/docs/architecture/02-ipc.md
@@ -102,7 +102,9 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   ledger and exits 1 with `KELD-CORE-033` quoting the nested `KELD-RUNTIME-*`
   cause (KEL-105 option (a), SURFACE). Minting a fresh link generation so the
   restarted child can re-handshake is option (b), RECOVER — KEL-96 AC5, and not
-  this path.
+  this path. The detection is not yet total: a generation that ends itself with
+  exit status 0 is not entered in the crash ledger at all, so that death is still
+  reported as success (KEL-116).
 - **v0 session:** one `HELLO` per connection, then N `CALL`/`REPLY` pairs until
   stream EOF. `echo_call` is the one-shot helper (deadline + handshake + one
   CALL). Further CALLs on the same stream use `echo_invoke` and must not send a

--- a/docs/architecture/02-ipc.md
+++ b/docs/architecture/02-ipc.md
@@ -91,6 +91,18 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   dispatch, virtual ports, role grants, and Windows named-pipe/DACL bootstrap remain
   destination work.
   Channel-table exchange remains later work.
+- **v0 app link is one session, not one endpoint.** On successful authentication
+  `BootstrapListener` unlinks the socket path immediately
+  (`crates/keld-ipc/src/bootstrap.rs`), so the accepted stream stays live but the
+  locator is gone. A supervised app child that dies and is restarted therefore
+  cannot re-enter the session: its `connect` fails at the OS
+  (`ErrorKind::NotFound`, asserted by `authenticated_bind_unlinks_stale_locator`),
+  not at the handshake. `keld dev` does not paper over that. It reports the death
+  rather than pretending the app is alive: teardown reads the supervisor's crash
+  ledger and exits 1 with `KELD-CORE-033` quoting the nested `KELD-RUNTIME-*`
+  cause (KEL-105 option (a), SURFACE). Minting a fresh link generation so the
+  restarted child can re-handshake is option (b), RECOVER — KEL-96 AC5, and not
+  this path.
 - **v0 session:** one `HELLO` per connection, then N `CALL`/`REPLY` pairs until
   stream EOF. `echo_call` is the one-shot helper (deadline + handshake + one
   CALL). Further CALLs on the same stream use `echo_invoke` and must not send a

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1136,6 +1136,18 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   dispatch, virtual ports, role grants, and Windows named-pipe/DACL bootstrap remain
   destination work.
   Channel-table exchange remains later work.
+- **v0 app link is one session, not one endpoint.** On successful authentication
+  `BootstrapListener` unlinks the socket path immediately
+  (`crates/keld-ipc/src/bootstrap.rs`), so the accepted stream stays live but the
+  locator is gone. A supervised app child that dies and is restarted therefore
+  cannot re-enter the session: its `connect` fails at the OS
+  (`ErrorKind::NotFound`, asserted by `authenticated_bind_unlinks_stale_locator`),
+  not at the handshake. `keld dev` does not paper over that. It reports the death
+  rather than pretending the app is alive: teardown reads the supervisor's crash
+  ledger and exits 1 with `KELD-CORE-033` quoting the nested `KELD-RUNTIME-*`
+  cause (KEL-105 option (a), SURFACE). Minting a fresh link generation so the
+  restarted child can re-handshake is option (b), RECOVER — KEL-96 AC5, and not
+  this path.
 - **v0 session:** one `HELLO` per connection, then N `CALL`/`REPLY` pairs until
   stream EOF. `echo_call` is the one-shot helper (deadline + handshake + one
   CALL). Further CALLs on the same stream use `echo_invoke` and must not send a

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1147,7 +1147,9 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   ledger and exits 1 with `KELD-CORE-033` quoting the nested `KELD-RUNTIME-*`
   cause (KEL-105 option (a), SURFACE). Minting a fresh link generation so the
   restarted child can re-handshake is option (b), RECOVER — KEL-96 AC5, and not
-  this path.
+  this path. The detection is not yet total: a generation that ends itself with
+  exit status 0 is not entered in the crash ledger at all, so that death is still
+  reported as success (KEL-116).
 - **v0 session:** one `HELLO` per connection, then N `CALL`/`REPLY` pairs until
   stream EOF. `echo_call` is the one-shot helper (deadline + handshake + one
   CALL). Further CALLs on the same stream use `echo_invoke` and must not send a


### PR DESCRIPTION
## Summary

KEL-105's spec-honesty acceptance names one file specifically:

> Spec honesty: `docs/architecture/02-ipc.md` v0 app-link paragraph states the one-session listener and the chosen behaviour.

PR #84 documented the behaviour in `docs/architecture/06-runtime-and-tooling.md` instead, which left that criterion unmet. This closes it where the ticket asked for it.

The paragraph states the mechanism as **verified, not inferred**: `BootstrapListener` unlinks the socket path on successful authentication (`crates/keld-ipc/src/bootstrap.rs`), so a supervised app child that dies and restarts cannot re-enter the session — its `connect` fails at the OS with `ErrorKind::NotFound`, not at the handshake. Two independent confirmations:

1. The existing `authenticated_bind_unlinks_stale_locator` test asserts exactly that (`NotFound | ConnectionRefused`).
2. A live macOS `keld dev` run during KEL-105: the restarted generations reported `errno: -2, code: "ENOENT"`.

It is worth recording because the opposite theory is plausible and wrong — a connect into a *bound but unaccepted* listener would succeed through the kernel backlog and hang on the HELLO read. That cannot happen here, because the locator no longer exists. That distinction changes which failure a fix must handle, and it was asserted the wrong way round during KEL-105's review.

The paragraph also names what `keld dev` does about it (option (a) SURFACE — exit 1 with `KELD-CORE-033` quoting the nested `KELD-RUNTIME-*` cause) and what it deliberately does not do (option (b) RECOVER — minting a fresh link generation, which is KEL-96 AC5).

## Spec refs

`docs/architecture/02-ipc.md` (v0 app link). No boundary change — documentation only, no code touched.

## Review gates

none — no `unsafe`, no public API change, no permission-model change, no dependency addition, no wire-protocol change. The wire protocol is described here, not altered.

## Tests

No code changed, so no new tests. `just llms-check` clean (`llms-full.txt` regenerated with `just llms`), `just mermaid-check` clean.

The claims added are backed by an existing test (`authenticated_bind_unlinks_stale_locator`, `crates/keld-ipc/src/bootstrap.rs`) rather than by prose alone.

## Platforms

Not applicable — documentation. The `ErrorKind::NotFound` claim is Unix-specific and is attributed to the Unix `BootstrapListener` in the text rather than stated as cross-platform.

## Perf impact

None — documentation only.

Refs KEL-105.
