### PR TITLE
fix(cli): the echo caller laundered out-of-range counts past its own codec (KEL-121)

### DIFF
--- a/crates/keld-cli/templates/hello/src/kipc.test.ts
+++ b/crates/keld-cli/templates/hello/src/kipc.test.ts
@@ -100,6 +100,17 @@ describe("postcard varint (LEB128)", () => {
     // 0x80 alone has its continuation bit set with nothing following.
     expect(() => decodeVarint(new Uint8Array([0x80]), 0)).toThrow("KELD-IPC-003");
   });
+
+  test("rejects a value above u32::MAX", () => {
+    // The wire field is a Rust u32. encodeVarint rejected negatives and
+    // non-integers but had no upper bound, so 2**32 encoded happily as a
+    // 5-byte varint the peer cannot represent. The bound belongs here, with
+    // the rest of the invariant, not in each caller.
+    expect(() => encodeVarint(0x1_0000_0000)).toThrow("KELD-IPC-003");
+    expect(() => encodeVarint(Number.MAX_SAFE_INTEGER)).toThrow("KELD-IPC-003");
+    // The boundary itself stays valid.
+    expect(Array.from(encodeVarint(0xffff_ffff))).toEqual([0xff, 0xff, 0xff, 0xff, 0x0f]);
+  });
 });
 
 describe("EchoRequest / EchoResponse postcard framing", () => {
@@ -128,6 +139,27 @@ describe("EchoRequest / EchoResponse postcard framing", () => {
     const decoded = decodeEchoResponse(bytes);
     expect(decoded.message).toBe(message);
     expect(decoded.count).toBe(0xffff_ffff);
+  });
+
+  test("rejects an out-of-range count instead of wrapping it", () => {
+    // REGRESSION (KEL-121). encodeEchoRequest encoded `req.count >>> 0`, and
+    // `>>>` converts modulo 2**32 BEFORE encodeVarint's own guard can see the
+    // value. So -1 arrived as 4294967295 and 2**32 arrived as 0: both passed a
+    // validation that was already there, one function away, and the peer
+    // received a different request from the one that was made.
+    //
+    // A wrong-but-well-formed request is worse than a rejected one, because
+    // nothing downstream can tell it happened.
+    expect(() => encodeEchoRequest({ message: "kipc", count: -1 })).toThrow("KELD-IPC-003");
+    expect(() => encodeEchoRequest({ message: "kipc", count: 0x1_0000_0000 })).toThrow("KELD-IPC-003");
+    expect(() => encodeEchoRequest({ message: "kipc", count: 1.5 })).toThrow("KELD-IPC-003");
+  });
+
+  test("count boundary values still encode", () => {
+    expect(Array.from(encodeEchoRequest({ message: "", count: 0 }))).toEqual([0x00, 0x00]);
+    const max = encodeEchoRequest({ message: "", count: 0xffff_ffff });
+    expect(Array.from(max)).toEqual([0x00, 0xff, 0xff, 0xff, 0xff, 0x0f]);
+    expect(decodeEchoResponse(max)).toEqual({ message: "", count: 0xffff_ffff });
   });
 
   test("rejects trailing bytes after a valid EchoResponse", () => {

--- a/crates/keld-cli/templates/hello/src/kipc.ts
+++ b/crates/keld-cli/templates/hello/src/kipc.ts
@@ -123,10 +123,13 @@ export function decodeHeader(bytes: Uint8Array): FrameHeader {
 
 // --- postcard payload codec (varint LEB128 + UTF-8 strings) -----------
 
-/** Encodes a non-negative integer (up to u32 range) as an unsigned LEB128 varint. */
+/** Encodes a `u32` as an unsigned LEB128 varint. Rejects anything outside that range. */
 export function encodeVarint(n: number): Uint8Array {
-  if (!Number.isInteger(n) || n < 0) {
-    throw kipcError("KELD-IPC-003", `varint value must be a non-negative integer, got ${n}`);
+  // The upper bound belongs HERE, with the rest of the invariant, so no caller
+  // has to remember it. Without it this accepted 2**32 and encoded a 5-byte
+  // varint the Rust peer cannot represent as the u32 it declares.
+  if (!Number.isInteger(n) || n < 0 || n > 0xffff_ffff) {
+    throw kipcError("KELD-IPC-003", `varint value must be an integer in [0, 4294967295], got ${n}`);
   }
   const bytes: number[] = [];
   let v = n;
@@ -183,7 +186,12 @@ function decodeString(bytes: Uint8Array, offset: number): [string, number] {
 /** Postcard encoding of `EchoRequest`: struct-as-tuple, field order = declaration order. */
 export function encodeEchoRequest(req: EchoRequest): Uint8Array {
   const message = encodeString(req.message);
-  const count = encodeVarint(req.count >>> 0);
+  // `req.count` is passed UNCHANGED. It used to be `req.count >>> 0`, which
+  // converts modulo 2**32 before encodeVarint's guard can see the value: -1
+  // became 4294967295 and 2**32 became 0, so an out-of-range count produced a
+  // well-formed request for a DIFFERENT number instead of an error. Coercing at
+  // the call site defeats the validation the codec already owns.
+  const count = encodeVarint(req.count);
   const out = new Uint8Array(message.length + count.length);
   out.set(message, 0);
   out.set(count, message.length);


### PR DESCRIPTION
## Summary

`encodeEchoRequest` encoded `req.count >>> 0`. Reading the code, this is **not a missing check — it defeated a check that was already there.**

`encodeVarint` has always rejected negatives and non-integers:

```ts
if (!Number.isInteger(n) || n < 0) {
  throw kipcError("KELD-IPC-003", `varint value must be a non-negative integer, got ${n}`);
}
```

But `>>>` converts modulo 2³² **before** that guard can see the value. So `-1` arrived as `4294967295` and `2**32` arrived as `0`. Both passed validation and produced a well-formed request for a **different number than the caller asked for**. Nothing downstream can tell that happened, which makes it worse than an error.

The same file explains why the operator is wrong, one function above the call site:

```ts
// Division, not `>>>`, so values above 2**31 (still valid u32) are not
// truncated by JS's 32-bit bitwise operators.
```

The caller used one anyway.

**Second half:** `encodeVarint` had no upper bound. It rejected `n < 0` but accepted `2**32` and encoded a 5-byte varint the Rust peer cannot represent as the `u32` it declares.

## The fix, in one place

The bound now lives with the rest of the invariant in `encodeVarint`, so no caller has to remember it; the caller passes `req.count` unchanged so the guard actually runs. Fixing it at the call site instead would have left the next caller free to make the same mistake.

## Tests

Written **first** and observed to fail, per AGENTS.md § Working rules. The failure output is the defect:

```
expect(() => encodeEchoRequest({ message: "kipc", count: -1 })).toThrow("KELD-IPC-003");
                                                                 ^
Received function did not throw
Received value: Uint8Array(10) [ 4, 107, 105, 112, 99, 255, 255, 255, 255, 15 ]
```

That trailing `255, 255, 255, 255, 15` is `4294967295` on the wire, from a request for `-1`.

Now covering:
- `count` of `-1`, `2**32` and `1.5` are rejected with `KELD-IPC-003`
- boundary values `0` and `0xffffffff` still encode and round-trip
- `encodeVarint` rejects `2**32` and `Number.MAX_SAFE_INTEGER`, still encodes `0xffffffff` as `[0xff, 0xff, 0xff, 0xff, 0x0f]`
- the pinned Rust wire vector for `{message:"kipc",count:3}` is unchanged

## Not done here, deliberately

`windows/keld/hello/src/kipc.ts` in `gyldlab/keld-benches` is byte-identical to this template (both `b9929bc8c315a0d6…` before this change) and is now stale against it.

It is **left alone on purpose.** That fixture is pinned to keld `58708bb`, and that binary produced the published MEM-IDLE measurement at `keld-benches@b30d145`. Re-syncing it today would separate the fixture from the binary whose numbers are published, which is the identity claim the fixture exists to carry. It re-syncs with the next measurement, against the binary that takes it.

## Spec refs

No boundary change. The wire format is unchanged — this rejects inputs that could never have been represented correctly, and every previously-valid encoding is byte-identical. `docs/architecture/02-ipc.md` needs no edit.

## Review gates

none

Not a wire-protocol change: no frame, header, or postcard encoding is altered. The set of *accepted* inputs narrows to the set that was already representable.

## Tests

```
cargo fmt --check                                        exit 0
cargo clippy --workspace --all-targets -- -D warnings    exit 0
cargo nextest run --workspace --profile ci               403 passed, 0 skipped
```

The template's own suite runs inside that gate via `crates/keld-cli/tests/bun_echo.rs:200` (`bun test src/kipc.test.ts`): **26 pass, 0 fail**, up from 24 before the two new tests.

## Platforms

Windows 11 / Ryzen 7 5800H for the gate run above. The change is platform-neutral TypeScript in the CLI template; `keld create hello` embeds it via `include_str!` (`crates/keld-cli/src/template.rs:31`), so every generated project gets it.

## Perf impact

None. One comparison added on a cold path that already performed two.

## Linear

KEL-121. Found by CodeRabbit against the byte-identical copy on `gyldlab/keld-benches#12`, where it was deliberately declined because fixing the fixture would have broken its identity claim while leaving the defect shipping in the template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid values outside the supported unsigned 32-bit range are now rejected with a clear codec error.
  * Echo request counts no longer silently wrap to a different value when negative, oversized, or non-integer.
  * Valid boundary values continue to encode and round-trip correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->