### PR TITLE
test(ipc): pin the Windows os-error mapping the pipe transport depends on (KEL-101)

### DIFF
--- a/crates/keld-ipc/src/lib.rs
+++ b/crates/keld-ipc/src/lib.rs
@@ -170,6 +170,102 @@ impl From<postcard::Error> for IpcError {
     }
 }
 
+/// Windows OS-error codes whose `io::ErrorKind` this crate's behaviour depends
+/// on, pinned so a change in Rust's mapping fails here rather than in a
+/// transport that silently misreports why a peer went away.
+///
+/// KEL-101 replaces the Windows loopback-TCP app-link with a named pipe whose
+/// reads are cancellable. Cancellation surfaces as `ERROR_OPERATION_ABORTED`,
+/// and the mapping below is the reason the future listener MUST NOT try to
+/// recognise it through [`std::io::ErrorKind`].
+#[cfg(windows)]
+#[cfg(test)]
+mod windows_os_error_mapping {
+    use super::IpcError;
+    use std::io::{Error, ErrorKind};
+
+    /// `CancelIoEx` reports `ERROR_OPERATION_ABORTED` (995), and Rust maps it to
+    /// `ErrorKind::TimedOut`. This crate folds `TimedOut` into
+    /// [`IpcError::Timeout`], so a cancelled read is indistinguishable from a
+    /// slow peer at the `IpcError` level: both become `KELD-IPC-006`.
+    ///
+    /// That is not a defect in the mapping, it is a fact about it. It is pinned
+    /// here because the Windows named-pipe listener has to record cancellation
+    /// separately from a deadline (KEL-101 AC6), and the only thing that can
+    /// tell them apart is `raw_os_error()`. A listener written against `kind()`
+    /// would report every host-initiated shutdown as a peer timeout, and no
+    /// test of the happy path would notice.
+    #[test]
+    fn cancellation_is_indistinguishable_from_a_deadline_by_kind_alone() {
+        const ERROR_OPERATION_ABORTED: i32 = 995;
+        const ERROR_SEM_TIMEOUT: i32 = 121;
+
+        let cancelled = Error::from_raw_os_error(ERROR_OPERATION_ABORTED);
+        let timed_out = Error::from_raw_os_error(ERROR_SEM_TIMEOUT);
+
+        assert_eq!(
+            cancelled.kind(),
+            ErrorKind::TimedOut,
+            "ERROR_OPERATION_ABORTED no longer maps to TimedOut; re-derive the \
+             cancellation path in the Windows listener before changing this"
+        );
+        assert_eq!(timed_out.kind(), ErrorKind::TimedOut);
+
+        // Both reach IpcError::Timeout, which is exactly the collision.
+        assert!(matches!(IpcError::from(cancelled), IpcError::Timeout));
+        assert!(matches!(IpcError::from(timed_out), IpcError::Timeout));
+
+        // The raw code is what separates them, so it must survive. Rebuild the
+        // errors: converting into IpcError consumed the originals.
+        assert_ne!(
+            Error::from_raw_os_error(ERROR_OPERATION_ABORTED).raw_os_error(),
+            Error::from_raw_os_error(ERROR_SEM_TIMEOUT).raw_os_error()
+        );
+    }
+
+    /// KEL-101 AC3 asserts that a foreign user's `CreateFileW` is refused by the
+    /// DACL. The spec is explicit that `ConnectionRefused`/not-found is not DACL
+    /// proof, so the test needs a kind that cannot be produced by the pipe
+    /// merely being absent. `ERROR_ACCESS_DENIED` gives one.
+    #[test]
+    fn a_dacl_denial_is_distinguishable_from_an_absent_pipe() {
+        const ERROR_ACCESS_DENIED: i32 = 5;
+        const ERROR_FILE_NOT_FOUND: i32 = 2;
+
+        let denied = Error::from_raw_os_error(ERROR_ACCESS_DENIED);
+        let absent = Error::from_raw_os_error(ERROR_FILE_NOT_FOUND);
+
+        assert_eq!(denied.kind(), ErrorKind::PermissionDenied);
+        assert_eq!(absent.kind(), ErrorKind::NotFound);
+        assert_ne!(denied.kind(), absent.kind());
+
+        // Neither is a timeout, so neither can be swallowed by the fold above.
+        assert!(matches!(IpcError::from(denied), IpcError::Io(_)));
+        assert!(matches!(IpcError::from(absent), IpcError::Io(_)));
+    }
+
+    /// The remaining pipe-lifecycle codes must NOT reach `IpcError::Timeout`,
+    /// or a peer that closed the pipe would be recorded as one that stalled.
+    /// `ERROR_NO_DATA` (232, pipe closing) and `ERROR_BROKEN_PIPE` (109) both
+    /// carry `BrokenPipe`; `ERROR_IO_PENDING` (997), `ERROR_PIPE_NOT_CONNECTED`
+    /// (233), `ERROR_PIPE_LISTENING` (536) and `ERROR_PIPE_BUSY` (231) are
+    /// uncategorised, which is fine as long as they stay out of the fold.
+    #[test]
+    fn no_pipe_lifecycle_code_is_folded_into_timeout() {
+        for code in [232_i32, 109, 997, 233, 536, 231] {
+            let err = Error::from_raw_os_error(code);
+            let kind = err.kind();
+            assert!(
+                !matches!(kind, ErrorKind::TimedOut | ErrorKind::WouldBlock),
+                "os error {code} now maps to {kind:?}, which this crate folds \
+                 into IpcError::Timeout; a closed pipe would be reported as a \
+                 stalled peer"
+            );
+            assert!(matches!(IpcError::from(err), IpcError::Io(_)));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

KEL-101 replaces the Windows loopback-TCP app-link with a named pipe whose reads must be cancellable, and **AC6 requires cancellation to be recorded separately from a deadline.** Whether that is even expressible was left open by the spec's §10. It is now answered, and the answer is the inconvenient one.

`CancelIoEx` reports `ERROR_OPERATION_ABORTED` (995). **Rust 1.97.1 maps it to `ErrorKind::TimedOut`**, and this crate folds `TimedOut` into `IpcError::Timeout` (`crates/keld-ipc/src/lib.rs:149-158`). So a cancelled read and a slow peer are the *same value* at the `IpcError` level — both become `KELD-IPC-006`. `ERROR_SEM_TIMEOUT` (121), an actual timeout, maps there too, so `kind()` cannot separate them at all.

**Only `raw_os_error()` can.**

That is not a defect in the mapping; it is a fact about it. But a listener written against `kind()` would report every host-initiated shutdown as a peer timeout while every happy-path test stayed green — which is exactly the class of failure that gets discovered in production rather than in review.

Measured on this machine (Windows 11 26200, Rust 1.97.1):

| code | meaning | `io::ErrorKind` | folds to `IpcError::Timeout`? |
|---|---|---|---|
| 995 | `ERROR_OPERATION_ABORTED` — cancelled | `TimedOut` | **yes** |
| 121 | `ERROR_SEM_TIMEOUT` — a real timeout | `TimedOut` | **yes** |
| 5 | `ERROR_ACCESS_DENIED` | `PermissionDenied` | no |
| 2 | `ERROR_FILE_NOT_FOUND` | `NotFound` | no |
| 232 | `ERROR_NO_DATA` — pipe closing | `BrokenPipe` | no |
| 109 | `ERROR_BROKEN_PIPE` | `BrokenPipe` | no |
| 997 | `ERROR_IO_PENDING` | `Uncategorized` | no |
| 233 | `ERROR_PIPE_NOT_CONNECTED` | `Uncategorized` | no |
| 536 | `ERROR_PIPE_LISTENING` | `Uncategorized` | no |
| 231 | `ERROR_PIPE_BUSY` | `Uncategorized` | no |

## What the three tests pin

1. **`cancellation_is_indistinguishable_from_a_deadline_by_kind_alone`** — the collision above, stated as the reason the future listener must not recognise cancellation through `ErrorKind`.
2. **`a_dacl_denial_is_distinguishable_from_an_absent_pipe`** — `PermissionDenied` vs `NotFound`. This is what lets AC3 assert a DACL denial on a kind an absent pipe cannot produce; the spec is explicit that *"`ConnectionRefused`/not-found are not DACL proof"*.
3. **`no_pipe_lifecycle_code_is_folded_into_timeout`** — so a closed pipe is never recorded as a stalled peer.

Pinning them means a future change to Rust's mapping fails **in this crate**, where the assumption lives, rather than in a transport that silently misreports why a peer went away.

## The guard was falsified, not assumed

Injecting `121` into the third test's code list makes it fail with its intended diagnostic:

```
os error 121 now maps to TimedOut, which this crate folds into
IpcError::Timeout; a closed pipe would be reported as a stalled peer
```

Reverted before commit. A test that cannot fail is not evidence.

## Spec refs

`docs/specs/kel101-windows-named-pipe-dacl.md` §4.4 (deadline semantics), §6 AC3 and AC6, §10 (open questions — this closes the first of the two non-blocking ones). No boundary change: no public API, no wire format, no dependency, no `unsafe`.

## Review gates

none

These are tests over `std`'s own error mapping. No product code changes.

## Tests

```
cargo fmt --check                                        exit 0
cargo clippy --workspace --all-targets -- -D warnings    exit 0
cargo nextest run --workspace --profile ci               406 passed, 0 skipped
```

406 = 403 before + the three added here. The new module is `#[cfg(windows)]`, so it compiles away on macOS and Linux and those lanes stay at 403.

## Platforms

Windows 11 build 26200 / Ryzen 7 5800H / Rust 1.97.1 for the run above. The tests are Windows-only by construction — they assert Windows OS-error semantics.

## Perf impact

None. Test-only.

## Linear

KEL-101. This is the de-risking half of the plan recorded in that issue's §10.1 decision comment: platform-neutral work that needs no sign-off on the `unsafe` exception, landed ahead of the transport so the Windows PR shrinks to the part that actually needs review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added Windows-specific coverage for named-pipe connection handling.
  - Verified that cancellation and timeout scenarios are reported consistently while remaining distinguishable for diagnostics.
  - Confirmed access-denied and unavailable-pipe conditions produce distinct outcomes.
  - Ensured ordinary pipe lifecycle errors are not incorrectly reported as timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->