### PR TITLE
docs(engineering): the measured conhost is the CLI's, not the shipping host's

### DIFF
--- a/docs/engineering/budget-scoreboard.md
+++ b/docs/engineering/budget-scoreboard.md
@@ -344,8 +344,14 @@ subsystem and Windows attaches a `conhost.exe`; the Tauri fixture sets
 30 of 30 Tauri samples in every session measured. Confirmed by direct
 observation of a live `keld dev` tree and by the PE subsystem byte: `keld.exe`
 and `keld-host.exe` are `CONSOLE (3)`, `tauri-hello.exe` is `GUI (2)`.
-`keld-host` is the shipping host binary, so this is a product question tracked
-separately, not resolved here.
+
+**The conhost measured here is `keld.exe`'s, not the shipping host's.** The Keld
+arm runs `keld dev`, and `keld dev` does not spawn `keld-host` — it *is* the host
+process. A terminal tool having a console is correct, so this is not a product
+defect; it is a concrete consequence of the scope mismatch this document already
+discloses, a dev CLI flow measured against a packaged release exe. `keld-host`
+being console subsystem is a separate, forward-looking product question, and it
+is **not** what was measured here.
 
 **The scored comparison is unaffected by any of it.** The headline scores each
 arm's native host process, read directly from the host PID rather than from the

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4400,8 +4400,14 @@ subsystem and Windows attaches a `conhost.exe`; the Tauri fixture sets
 30 of 30 Tauri samples in every session measured. Confirmed by direct
 observation of a live `keld dev` tree and by the PE subsystem byte: `keld.exe`
 and `keld-host.exe` are `CONSOLE (3)`, `tauri-hello.exe` is `GUI (2)`.
-`keld-host` is the shipping host binary, so this is a product question tracked
-separately, not resolved here.
+
+**The conhost measured here is `keld.exe`'s, not the shipping host's.** The Keld
+arm runs `keld dev`, and `keld dev` does not spawn `keld-host` — it *is* the host
+process. A terminal tool having a console is correct, so this is not a product
+defect; it is a concrete consequence of the scope mismatch this document already
+discloses, a dev CLI flow measured against a packaged release exe. `keld-host`
+being console subsystem is a separate, forward-looking product question, and it
+is **not** what was measured here.
 
 **The scored comparison is unaffected by any of it.** The headline scores each
 arm's native host process, read directly from the host PID rather than from the


### PR DESCRIPTION
## Summary

The Windows MEM-IDLE section reported a measured `conhost.exe` and then said *"`keld-host` is the shipping host binary, so this is a product question tracked separately."* Those are **two different binaries**, and the sentence let a measurement of one stand as evidence about the other.

**The Keld arm runs `keld dev`, and `keld dev` does not spawn `keld-host` — it *is* the host process, which is `keld.exe`.**

Verified:
- `grep -rn "keld-host\|keld_host" crates/keld-cli/src/` returns a single doc-comment mention and nothing else
- the harness runs `$KeldExe` with `args = @('dev')` (`Measure-WindowsGuiSession.ps1:83-84`), and the measurement passed `target/release/keld.exe`

So `keld-host.exe` was **never measured**. The 10,146 KiB conhost belongs to the CLI.

## Why that changes the reading

A terminal tool having a console is correct. The measured conhost is therefore **not a product defect** — it is a concrete consequence of the scope mismatch this document *already* discloses: a dev CLI flow measured against a packaged release exe. Naming it that way sharpens the disclosure instead of implying a shipping-app cost nobody has observed.

`keld-host` being console subsystem is still real and still forward-looking — the PE subsystem byte is `CONSOLE (3)`. It stays on KEL-122, where the memory argument has now been removed from the ticket because it rested on this same wrong attribution.

## What does not change

- The scored comparison. The headline reads each arm's host process directly from the host PID, never through the descendant walk; `conhost.exe` is neither arm's host.
- Every number in the section. Only the sentence attributing them changes.

## Spec refs

No boundary change. Docs only.

## Review gates

none

## Tests

`just llms-check` green after regeneration (`budget-scoreboard.md` is an included corpus source). No code touched, so the Rust gates are unaffected; `main` was verified green after the five merges that preceded this branch (fmt 0, clippy 0, 410/410).

## Platforms

Platform-neutral documentation edit. The facts it corrects were established on Windows 11 build 26200.

## Perf impact

None.

## Linear

KEL-122 — filed by me with this same conflation, corrected there in the same pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Windows console memory measurements apply to the development CLI host process, not the packaged host binary.
  * Separated development-flow measurements from the outstanding product decision about the packaged host’s console subsystem.
  * Documented the scope difference between development and packaged release environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->