### PR TITLE
test(cli): the shipping host binary was outside the error-code registry

### DIFF
--- a/crates/keld-cli/tests/error_registry.rs
+++ b/crates/keld-cli/tests/error_registry.rs
@@ -28,6 +28,12 @@ const SCAN_REL: &[&str] = &[
     "crates/keld-native/src",
     "crates/keld-compat/src",
     "crates/keld-core/src",
+    // keld-host was absent from this list, so the shipping host binary's error
+    // codes sat outside the registry contract entirely. It emits KELD-CLI-044
+    // today (main.rs:17), which is registered only because keld-cli/src/flags.rs
+    // emits it too and IS scanned -- the coverage was accidental. A code added
+    // to keld-host and nowhere else would have shipped unregistered.
+    "crates/keld-host/src",
     "tools",
 ];
 


### PR DESCRIPTION
## Summary

`crates/keld-host/src` was **absent** from the scanned directories in `crates/keld-cli/tests/error_registry.rs:22-31`. Nine crate source dirs are listed; the shipping host binary is not among them, so its error codes sat outside the registry contract entirely.

Its one code today — `KELD-CLI-044` at `keld-host/src/main.rs:17` — *is* registered, but **only because `keld-cli/src/flags.rs` emits the same code and is scanned.** The coverage was accidental. A code added to `keld-host` and nowhere else would have shipped with no registry entry, no message and no fix, which is precisely what KEL-35 built this test to prevent.

## Falsified, not assumed

Adding an unregistered `KELD-HOST-999` to `keld-host` makes the test fail with its intended diagnostic:

```
codes emitted in scanned crates/tools but missing from
docs/engineering/keld-error-codes.md: ["KELD-HOST-999"]
```

Reverted before commit. All 7 `error_registry` tests pass on the real tree — adding a source dir can only add emitted codes, never remove them, so the "registry lists a code nothing emits" direction is unaffected.

## Spec refs

No boundary change. Test-only; extends an existing KEL-35 contract to a directory it should always have covered.

## Review gates

none

## Tests

```
cargo nextest run -p keld-cli -E 'binary(error_registry)'   7 passed, 0 skipped
```

## Platforms

Platform-neutral. Run on Windows 11 build 26200.

## Perf impact

None. Test-only.

## Linear

Found while evaluating KEL-122 and independent of that decision, which is to fold the subsystem change into KEL-96 rather than ship it standalone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded error-registry coverage checks to include errors emitted by the host component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->