### PR TITLE
ci: bump actions/checkout to v7, pinned by SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       # Full history gives the router both PR and push comparison commits. The
       # router falls back to all lanes when either commit is unavailable.
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
@@ -74,7 +74,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -95,7 +95,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -169,7 +169,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.gui == 'true'
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -249,7 +249,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.msrv == 'true'
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -274,7 +274,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.deny == 'true'
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Install gitleaks 8.30.1
@@ -313,7 +313,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.hygiene == 'true' || needs.changes.outputs.docs == 'true'
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05


### PR DESCRIPTION
## Summary

Supersedes **#1**, which did the same bump but replaced the pinned SHA with the **mutable tag** `actions/checkout@v7`.

That is a security regression, not a style preference. Every action in this repo is pinned to an immutable SHA precisely so an upstream tag cannot be repointed at different code that then runs in CI with repository credentials — `keldbot.yml` states the rule in its own comment: *"pinned SHA, not mutable tag"*.

#1 was also unmergeable on its own terms: it branches from this repository's **first commit** and carries only 4 of the 8 checkout steps `main` now has. Rebasing it conflicts with essentially the whole tree, so this replaces it rather than repairing it.

## Verification

**SHAs resolved against upstream tag refs, not trusted from the PR title:**

| SHA | tag |
|---|---|
| `11d5960a…` (before) | v4.4.0 |
| `9c091bb2…` (after) | **v7.0.0** |

**Breaking changes v4 → v7, from the upstream release notes:**

- **v5.0.0** — Node 24; *"⚠️ Minimum Compatible Runner Version: **v2.327.1**"*. Every runner here is GitHub-hosted (`ubuntu-latest`, `macos-latest`, `windows-latest` via `matrix.os`) and is well past that.
- **v6.0.0** — *"Persist creds to a separate file"*. No workflow here reads the credential location.
- **v7.0.0** — *"block checking out fork pr for pull_request_target and workflow_run"*. This is the vulnerable pattern AGENTS.md already forbids, so the new block is **aligned with** this repo rather than a constraint on it — and it reaches nothing here: `ci.yml` triggers on `pull_request`, not `pull_request_target`, and `keldbot.yml` (the only `pull_request_target` workflow) has **zero** checkout steps by design.

**After this change, no action in `.github/workflows` is referenced by a mutable tag** — `grep -rnE "uses: [^ ]+@v[0-9]"` returns nothing.

`ci.yml` parses as YAML.

## Spec refs

No boundary change. This is a CI dependency bump; it changes no job conditions and no routing, so AGENTS.md's CI-routing rules are not engaged.

## Review gates

**Dependency addition** — an action version bump on an existing dependency. Name: `actions/checkout`. Purpose: unchanged (repository checkout). Alternatives: stay on v4.4.0, which is the status quo and carries no known defect; the case for moving is Node-24 alignment with the rest of the pinned actions and v7's fork-PR hardening.

## Tests

`ci.yml` YAML parses. The change is exercised by CI itself — every job on this PR runs through the new checkout.

## Platforms

All three CI platforms exercise it: `ubuntu-latest`, `macos-latest`, `windows-latest`.

## Perf impact

None expected.