### PR TITLE
docs(research): update canonical research paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,7 +308,7 @@ Repeat this block for each remaining OS/device criterion:
 - Ticket status: In Progress | Blocked
 ```
 
-First-principles + YAGNI (MUST; `docs/research/27-first-principles-yagni.md`):
+First-principles + YAGNI (MUST; `docs/research/library/agents-tooling/27-first-principles-yagni.md`):
 1. Apply the Engineering principles above across host / Bun child / webview; Keld-specific architecture additionally changes who owns a handle, who can crash whom, or who can mint a principal. If it changes none of those facts, it is not architecture.
 2. Agents MUST treat wry layout, Tauri ACL, Electron docs, and platform event loops as evidence of facts — not templates. Copying crate graphs, tokio-in-core, ACL wildcards, or in-process Node is cargo-cult.
 3. Agents MUST protect four uniques only: prebuilt host, supervised Bun process family with zero ambient OS authority per strict-profile principal, kipc, default-deny (generated, host-enforced). MUST NOT invent a fifth.
@@ -348,7 +348,7 @@ Forbidden when a test, gate, or check fails:
 
 When the real fix is genuinely out of scope, agents MUST stop and say so — name the cause, propose the fix, and let a human choose. A disclosed limitation is acceptable; a silent workaround is not. A required failing check MUST be fixed before merge. If its contract is wrong, the rule/test change requires explicit human approval and lands before or with the dependent implementation; approval alone MUST NOT waive the check.
 
-Nested `crates/<crate>/AGENTS.md` (`docs/research/26-agents-md-cloudflare-rfc.md`):
+Nested `crates/<crate>/AGENTS.md` (`docs/research/library/agents-tooling/26-agents-md-cloudflare-rfc.md`):
 - A crate MUST have `AGENTS.md` when it has invariants not in this file: `unsafe`/WebEngine, `keld-guard` default-deny, kipc wire protocol. Nested files MUST add constraints; they MUST NOT silently weaken root. Root wins on conflict unless the crate file names a documented exception with justification.
 - Agents MUST NOT add hollow stubs; MUST NOT add files for crates whose invariants are all stated here (`keld-core`, `keld-native`, `keld-runtime`, `keld-host`) or for the skeletons (`keld-update`, `keld-pack`); MUST NOT add one for `keld-cli` — the root § Rust rules already govern it (`expect` only at its binary top-level, never in libs); MUST NOT add one under `packages/` until a TS package carries invariants not stated in § TypeScript (`@keld/electron` exists and is governed there). Point at the spec in the repo-map table instead.
 - Enforcement: `just agents-md` — fails if a crate with `unsafe` / `allow(unsafe_code)` has no `AGENTS.md`. Not a Codex.

--- a/crates/keld-wv/AGENTS.md
+++ b/crates/keld-wv/AGENTS.md
@@ -1,6 +1,6 @@
 # keld-wv — adds root AGENTS.md
 
-Spec: `docs/architecture/05-webview-and-native.md`. Platform truth: `docs/research/06-webview-reality.md`. v0 trait: `src/engine.rs` (not the full spec 05 sketch).
+Spec: `docs/architecture/05-webview-and-native.md`. Platform truth: `docs/research/library/host-platforms/06-webview-reality.md`. v0 trait: `src/engine.rs` (not the full spec 05 sketch).
 
 - `unsafe` MAY appear in platform backends only. Those modules MUST `deny(unsafe_op_in_unsafe_fn)` and MUST cite a platform contract in `// SAFETY:`.
 - All engine/window mutations MUST run on the UI thread (today: tao's main-thread event loop; later: keld-core command queue). Agents MUST NOT touch platform handles from I/O or pool threads.

--- a/docs/agents/learnings.md
+++ b/docs/agents/learnings.md
@@ -25,13 +25,13 @@ small — it is loaded by every agent session.
 
 ## Log
 
-- 2026-07-08 [process] Perplexity exports in docs/research/from-outside/ are raw inputs; the polished numbered docs in docs/research/ are the citable corpus — never cite from-outside directly. (evidence: docs/research/00-landscape.md header)
+- 2026-07-08 [process] Perplexity exports in docs/research/inputs/external/legacy-2026-08/ are raw inputs; canonical notes under docs/research/library/ are the citable corpus — never cite raw inputs directly. (evidence: docs/research/library/compatibility-competitors/00-landscape.md header)
 - 2026-07-08 [build] `cargo clippy --workspace --all-targets -- -D warnings` is the CI form; pedantic is already on via workspace lints, do not re-enable it per-crate. (evidence: Cargo.toml [workspace.lints])
 - 2026-07-08 [ipc] Wire-size constants (HEADER_LEN=16) are protocol facts tested independently of struct layout — change requires a version bump + review gate. (evidence: crates/keld-ipc/src/frame.rs tests)
 - 2026-07-08 [tooling] cargo-deny `unmaintained` accepts `all|workspace|transitive|none`, not `warn`. (evidence: deny.toml, cargo-deny 0.19)
 - 2026-07-08 [wv/macos] Phase 1 hello window uses tao+wry as interim scaffolding; replace with direct objc2 bindings per arch/05. (evidence: crates/keld-wv/src/wkwebview/mod.rs)
 - 2026-08-08 [wv] wry compiles open_devtools/close_devtools only under cfg(any(debug_assertions, feature="devtools")) — keld-wv pins the `devtools` feature or release builds fail. (evidence: competitors/wry/src/lib.rs `pub fn open_devtools`, crates/keld-wv/Cargo.toml)
-- 2026-08-12 [process] IETF RFC 2119 keywords bind agents in AGENTS.md / docs/agents/* only — not architecture prose or Rust comments. (evidence: docs/research/28-post-integration-audit.md, RFC 2119)
+- 2026-08-12 [process] IETF RFC 2119 keywords bind agents in AGENTS.md / docs/agents/* only — not architecture prose or Rust comments. (evidence: docs/research/library/agents-tooling/28-post-integration-audit.md, RFC 2119)
 - 2026-08-12 [wv/macos] Unit tests must not call `WkWebViewEngine::new` / tao `EventLoop::new` (starts AppKit). Smoke title/HTML/spec instead; `just hello` is the GUI check. (evidence: KEL-26)
 - 2026-08-12 [wv/macos] tao 0.35 `EventLoopExtMacOS` already defaults to `NSApplicationActivationPolicyRegular`; do not set it again. (evidence: tao-0.35.3 `platform/macos.rs` trait docs)
 - 2026-08-13 [ipc] postcard `from_bytes` ignores trailing bytes; a no-op echo test must assert re-encoded output ≠ input, not expect a codec error. (evidence: crates/keld-ipc/src/echo.rs `echo_roundtrip_copies_fields_not_input_bytes`)

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -1,7 +1,7 @@
 # Agent development workflow
 
 How Keld is developed by parallel agents with human architectural review. Rationale
-and sources: `docs/research/07-agent-first.md`. Rules here bind agents and humans.
+and sources: `docs/research/library/agents-tooling/07-agent-first.md`. Rules here bind agents and humans.
 Task-specific playbooks are routed from `.agents/index.md`; load only matching entries.
 
 ## The loop (one issue, one agent, one concern)

--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -84,7 +84,7 @@ Three principal classes, with host-minted instances inside each class:
 3. **Webviews** (system or pinned engine): untrusted UI documents. Talk to the host over
    the native bridge; talk to the app process only through host-mediated routed channels.
 
-Why this shape (each competitor fails differently — see `docs/research/00-landscape.md`):
+Why this shape (each competitor fails differently — see `docs/research/library/compatibility-competitors/00-landscape.md`):
 - Electron: privileged JS **in-process** with window ownership → bloat + checklist security.
 - Tauri: native ownership correct, but no JS main process → adoption cliff.
 - Electrobun / Deno Desktop: JS main process, but it *owns* the native layer / shares the

--- a/docs/architecture/02-ipc.md
+++ b/docs/architecture/02-ipc.md
@@ -166,7 +166,7 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   request/response with streaming bodies (WKURLSchemeHandler / WebView2
   WebResourceRequested / WebKitGTK 2.40+ streams), which engines serve off the UI
   thread and can hand to us as counted buffers. postMessage stays control-only
-  (string-typed on WebView2 — see research/06).
+  (string-typed on WebView2 — see `docs/research/library/host-platforms/06-webview-reality.md`).
 - Renderer→app-role file-ish transfers (the Electron `send(bigBuffer)` pattern) are
   routed through the host with bounded credit. A platform adapter MAY forward into that
   role's ring, but the actual engine path reports its copies; choosing a binary codec

--- a/docs/architecture/04-electron-compat.md
+++ b/docs/architecture/04-electron-compat.md
@@ -1,7 +1,8 @@
 # Electron Compatibility — Keld's Go-To-Market Spec
 
 The falsifiable promise: **a median Electron app runs on Keld by changing configuration,
-not code.** This is the Rspack/Rolldown lesson applied to desktop (see research/05).
+not code.** This is the Rspack/Rolldown lesson applied to desktop (see
+`docs/research/library/agents-tooling/05-rust-wave.md`).
 "Median" is defined and measured, not vibed: we maintain a corpus of open-source
 Electron apps and publish per-app compat scores.
 

--- a/docs/architecture/05-webview-and-native.md
+++ b/docs/architecture/05-webview-and-native.md
@@ -52,13 +52,14 @@ If it lands, binaries are fetched at build time and the selected app/vendor owns
 security updates. Verso/Servo remain later conformance candidates only when embedding
 stabilizes—the trait is the insurance policy, not evidence that those backends ship.
 
-Linux resilience (research/06): GPU-driver probe at startup → auto-apply
+Linux resilience (`docs/research/library/host-platforms/06-webview-reality.md`): GPU-driver probe at startup → auto-apply
 safe-mode. **Implemented (KEL-28):** `webkitgtk::probe_gpu_stack` detects
 NVIDIA + Wayland and sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` programmatically
 before any GTK/WebKit call — never by asking users to export env vars — and
 returns a `GpuSafeMode` apps can read (`is_degraded()` / `reason()`) as the
 structured degraded-rendering fact. **Not yet built:** a `keld doctor` line
-surfacing that result, and the fuller version-matrix probe research/06
+surfacing that result, and the fuller version-matrix probe in
+`docs/research/library/host-platforms/06-webview-reality.md`
 describes (today's probe is driver + session type only).
 
 ## 2. Renderer bridge contract (`window.keld`)

--- a/docs/architecture/07-agent-experience.md
+++ b/docs/architecture/07-agent-experience.md
@@ -1,6 +1,6 @@
 # Agent Experience (AX) — Keld as an Agent-First Framework
 
-> Normative for v0.x. Research basis: `docs/research/07-agent-first.md` (AX shipped by
+> Normative for v0.x. Research basis: `docs/research/library/agents-tooling/07-agent-first.md` (AX shipped by
 > frameworks, MCP tool-design guidance, error/docs design evidence, vibe-coding failure
 > modes). Position: **agents are a primary user persona** alongside humans. Most Keld
 > apps will be written at least partly by coding agents; the framework is designed so
@@ -116,7 +116,8 @@ pinned models/harnesses, run nightly and per docs/API-touching PR:
 
 ## 6. Guardrails for vibe-coded apps (Keld-enforced APIs)
 
-Threat model: the app author's agent wrote code nobody carefully read (research/07 §6:
+Threat model: the app author's agent wrote code nobody carefully read
+(`docs/research/library/agents-tooling/07-agent-first.md` §6:
 secrets leak ~2× human rate, ~55% of unguided AI code fails security checks, missing
 authz is endemic). Keld's stance — **Keld-enforced APIs** hold even when review
 doesn't. That is the host-checked capability manifest, network allowlist, webview

--- a/docs/engineering/alignment-audit-2026-07-08.md
+++ b/docs/engineering/alignment-audit-2026-07-08.md
@@ -19,8 +19,8 @@ landings, duplicate AX/tooling issues, and the verification gate still documente
 |-----------|-------|-------|
 | 1. Vision ↔ Architecture | **Aligned** | README, ROADMAP, arch/01–07 agree on host/child, kipc, permissions, webview policy, compat path, config files (`keld.config.ts`, `keld.permissions.jsonc`, etc.). |
 | 2. Architecture ↔ Crate skeleton | **Aligned** | All 11 `keld-*` crates in `AGENTS.md` repo map exist; no orphan crates. `packages/` empty as documented ("upcoming"). |
-| 3. Research ↔ Decisions | **Aligned** | research/00–08 conclusions (compat-first, supervised Bun child not in-process, kipc as product, per-platform engine policy) are normative in architecture. |
-| 4. Agent-first ↔ Artifacts | **Partial** | AGENTS.md, docs/agents/, arch/07, research/07, llms.txt, per-crate AGENTS.md align. Gaps: llms.txt hand-maintained (arch/07 §3 says CI-generated); `DenyReason` lacks fix text (arch/07 §2); KEL-20 awaiting sign-off; duplicate Linear AX issues. |
+| 3. Research ↔ Decisions | **Aligned** | The categorized Phase-0 corpus routed by `docs/research/INDEX.md` supports the compat-first, supervised-Bun, kipc, and per-platform-engine decisions now normative in architecture. |
+| 4. Agent-first ↔ Artifacts | **Partial** | AGENTS.md, docs/agents/, arch/07, `docs/research/library/agents-tooling/07-agent-first.md`, llms.txt, and per-crate AGENTS.md align. Gaps: llms.txt hand-maintained (arch/07 §3 says CI-generated); `DenyReason` lacks fix text (arch/07 §2); KEL-20 awaiting sign-off; duplicate Linear AX issues. |
 | 5. Tooling ↔ AGENTS.md gate | **Partial** | CI + justfile: fmt, clippy `-D warnings`, nextest, deny, 3-OS matrix, MSRV — strong. AGENTS.md verification gate still says `cargo test`; tooling-audit.md still lists nextest as deferred; KEL-34/KEL-41 open despite landings. |
 | 6. Linear ↔ ROADMAP | **Partial** | Issue coverage is good; **phase numbering diverges** (see below). Several landings (workspace, CI, docs) not reflected in issue status. Duplicate issues for MCP, eval, guard fixtures. |
 | 7. Naming conventions | **Partial** | Repo uses `keld-ipc`, `keld-native` consistently. Linear KEL-12/13/22 still reference `keld-bridge`, `keld-native-apis`. License: `Cargo.toml`/`deny.toml` = MIT OR Apache-2.0; ROADMAP/README = TBD. |
@@ -53,7 +53,7 @@ landings, duplicate AX/tooling issues, and the verification gate still documente
 - CI hard gates: CODEOWNERS, secret scan, no-placeholder CI check — ROADMAP Phase 0, KEL-39.
 - Guard manifest parsing / enforcement — v0 scope note in `keld-guard` crate docs.
 - kipc beyond framing (`frame.rs`) — Phase 1/2 per ROADMAP.
-- Formal KEL-11 synthesis document — research corpus (`docs/research/00-landscape.md`) partially substitutes.
+- Formal KEL-11 synthesis document — research corpus (`docs/research/library/compatibility-competitors/00-landscape.md`) partially substitutes.
 
 ### Accidental (should fix)
 
@@ -98,7 +98,7 @@ work — add a "Program" standing track or Meta section in ROADMAP.
 
 | Issue | vs artifacts | Drift |
 |-------|--------------|-------|
-| KEL-11 synthesis | Todo; `docs/research/00-landscape.md` is de facto synthesis | Formal deliverable + Phase 1 RFC links missing |
+| KEL-11 synthesis | Todo; `docs/research/library/compatibility-competitors/00-landscape.md` is de facto synthesis | Formal deliverable + Phase 1 RFC links missing |
 | KEL-20 agentic | In Progress; artifacts landed | Needs human sign-off → Done |
 | KEL-25 hello-world | Backlog; no webview backends yet | Correct dependency state |
 | KEL-34 tooling | P0 nextest/llms unchecked | nextest + llms.txt partially done |
@@ -135,4 +135,4 @@ Not run locally: 3-OS CI matrix, `cargo deny check` (requires cargo-deny install
 
 - `/competitors/` is in `.gitignore` ✓
 - Local clones present: electron, tauri, electrobun, deno, wry, tao ✓
-- Used by research/08; not part of the shipping repo ✓
+- Used by `docs/research/library/compatibility-competitors/08-competitor-source-audit.md`; not part of the shipping repo ✓

--- a/docs/engineering/decisions.md
+++ b/docs/engineering/decisions.md
@@ -10,7 +10,7 @@ This file is **not** a new RFC 2119 layer. Binding agent rules stay in
 [`docs/agents/learnings.md`](../agents/learnings.md). This document is the onboarding
 pointer for *why* the current engineering looks like this.
 
-Numbered `docs/research/` notes are exploratory evidence. They are not required
+Canonical categorized `docs/research/library/` notes are exploratory evidence. They are not required
 reading and must not be treated as a second spec. Cite architecture, `AGENTS.md`,
 and `docs/engineering/` instead.
 
@@ -347,7 +347,7 @@ hooks reliably. A laptop hook cannot replace GitHub Actions. Putting clippy,
 nextest, or gitleaks in pre-commit is the wrong gate (slow; gitleaks is
 GitHub-only). Optional later: an Oxc-style **untracked** format-only hook, not
 a committed Husky tree. Evidence (exploratory, not required reading):
-`docs/research/42-git-hooks-and-precommit.md`.
+`docs/research/library/agents-tooling/42-git-hooks-and-precommit.md`.
 
 **Why.** Fmt/clippy/nextest are the contract testers can paste. `just ci` catches
 docs corpus drift, crate-`AGENTS.md` for `unsafe`, CODEOWNERS/template/SHA hygiene,

--- a/docs/engineering/tooling-audit.md
+++ b/docs/engineering/tooling-audit.md
@@ -1,8 +1,8 @@
 # Keld Tooling Audit — Senior Engineer Review
 
 > Audit date: July 2026. Baseline: pre-alpha 11-crate workspace, no `packages/` yet.
-> Competitor comparison: `docs/research/08-competitor-source-audit.md`.
-> Context7 refresh: `docs/research/09-tooling-context7-audit.md`.
+> Competitor comparison: `docs/research/library/compatibility-competitors/08-competitor-source-audit.md`.
+> Context7 refresh: `docs/research/library/agents-tooling/09-tooling-context7-audit.md`.
 
 ## Executive summary
 
@@ -73,7 +73,7 @@ automation (nothing to ship); cargo-vet (deny.toml covers advisories/licenses fo
 
 ### Phase B (coordinator run — P0 from Context7 audit)
 
-- `deny.toml`: `[graph].targets` for linux-gnu, macOS, windows-msvc; `unmaintained = "warn"`
+- `deny.toml`: `[graph].targets` for linux-gnu, macOS, windows-msvc; `unmaintained = "workspace"`
 - `.github/workflows/ci.yml`: `rust-cache` on fmt + deny jobs; `cache-on-failure: true` on matrix
 - `justfile`: `ci` recipe includes `deny`
 

--- a/docs/onboarding/01-project-summary.md
+++ b/docs/onboarding/01-project-summary.md
@@ -37,7 +37,7 @@ is the single most important thing to understand about this repo.
 ## The problem Keld exists to solve
 
 Every current Electron alternative asks you to rewrite. That is the whole thesis in one
-sentence, and [`docs/research/00-landscape.md`](../research/00-landscape.md) breaks it
+sentence, and [`docs/research/library/compatibility-competitors/00-landscape.md`](../research/library/compatibility-competitors/00-landscape.md) breaks it
 into five structural problems that no shipping framework has solved *together*:
 
 1. **The migration cliff.** Ten years of Electron apps; Tauri, Electrobun, and Deno
@@ -53,7 +53,7 @@ into five structural problems that no shipping framework has solved *together*:
    (Tauri) or ship Chromium everywhere (Electron). Reality is uneven: WebView2 is
    evergreen Chromium and basically fine, WKWebView is acceptable on recent macOS, and
    WebKitGTK on Linux is the problem child. See
-   [`docs/research/06-webview-reality.md`](../research/06-webview-reality.md).
+   [`docs/research/library/host-platforms/06-webview-reality.md`](../research/library/host-platforms/06-webview-reality.md).
 4. **IPC as an afterthought.** Chatty structured-clone JSON (Electron), serde-JSON
    `invoke` (Tauri), a localhost WebSocket on port 50000+ (Electrobun).
 5. **Security either optional or hostile.** Electron: remember five code patterns or ship
@@ -66,7 +66,7 @@ manifest (03).
 ## Competitive positioning — each competitor fails differently
 
 From [`docs/architecture/01-overview.md`](../architecture/01-overview.md) §1 and the
-head-to-head matrix in [`docs/research/00-landscape.md`](../research/00-landscape.md):
+head-to-head matrix in [`docs/research/library/compatibility-competitors/00-landscape.md`](../research/library/compatibility-competitors/00-landscape.md):
 
 | Framework | Architecture | The specific failure Keld targets |
 |---|---|---|
@@ -81,7 +81,7 @@ nice-to-have: architecture principle #1 says the Electron surface is "a protocol
 implement," and every design must answer "how does this behave under `@keld/electron`?"
 Second, Keld's differentiation against Tauri is explicitly *not* "lighter than Tauri" —
 it's Tauri-class footprint without giving up the JS main process, without a Rust
-toolchain, and with an Electron on-ramp ([`docs/research/02-tauri.md`](../research/02-tauri.md)).
+toolchain, and with an Electron on-ramp ([`docs/research/library/compatibility-competitors/02-tauri.md`](../research/library/compatibility-competitors/02-tauri.md)).
 
 ## The shape of the system
 
@@ -137,7 +137,7 @@ flowchart TB
 Everything else in the architecture follows from that ownership split. Hot paths (kipc,
 event loop, guard) are callback/state-machine code with no async runtime and no
 steady-state allocation — the lesson taken from Bun's Rust rewrite
-([`docs/research/05-rust-wave.md`](../research/05-rust-wave.md), enforced by
+([`docs/research/library/agents-tooling/05-rust-wave.md`](../research/library/agents-tooling/05-rust-wave.md), enforced by
 [`AGENTS.md`](../../AGENTS.md) § Rust).
 
 ## Who it's for
@@ -309,10 +309,9 @@ error-message, or API bug*.
   [`docs/engineering/linear-roadmap-mapping.md`](../engineering/linear-roadmap-mapping.md)
   to translate; getting this wrong is a known source of confusion (it was flagged in the
   2026-07-08 alignment audit).
-- **[`task.md`](../../task.md)** at the repo root is a **ledger of a Linear harness run**
-  dated 2026-07-10 — an inventory of issues, per-ticket blueprints, execution order, and
-  the gate output at the time (`12/12` tests then; the tree is at 17/17 now). Read it as a
-  point-in-time record of what was closed and why, not as a live to-do list.
+- Historical execution evidence lives in Linear issue comments and dated engineering
+  audits such as [`alignment-audit-2026-07-08.md`](../engineering/alignment-audit-2026-07-08.md).
+  Read those as point-in-time records, never as a live to-do list.
 - **Features need an approved spec** before implementation
   ([`docs/agents/spec-template.md`](../agents/spec-template.md)), and the development loop
   — worktree isolation, verification gate, review gates, PR shape — is in
@@ -338,11 +337,11 @@ error-message, or API bug*.
 
 ## Sources used in this document
 
-`README.md` · `AGENTS.md` · `ROADMAP.md` · `task.md` · `Cargo.toml` · `rust-toolchain.toml` ·
+`README.md` · `AGENTS.md` · `ROADMAP.md` · `docs/engineering/alignment-audit-2026-07-08.md` · `Cargo.toml` · `rust-toolchain.toml` ·
 `justfile` · `.gitignore` · `.github/workflows/ci.yml` ·
 `docs/architecture/01-overview.md` (§1, §2, §5, §6) · `docs/architecture/03-security.md` §6 ·
 `docs/architecture/04-electron-compat.md` §2 · `docs/architecture/06-runtime-and-tooling.md` §2 ·
-`docs/architecture/07-agent-experience.md` §2 · `docs/research/00-landscape.md` ·
-`docs/research/14-phase0-synthesis.md` · `docs/engineering/linear-roadmap-mapping.md` ·
+`docs/architecture/07-agent-experience.md` §2 · `docs/research/library/compatibility-competitors/00-landscape.md` ·
+`docs/research/library/execution-governance/14-phase0-synthesis.md` (from the separately tracked nested research checkout after `just research-sync`) · `docs/engineering/linear-roadmap-mapping.md` ·
 `crates/*/src/**` · `crates/*/AGENTS.md` · `git log`, `git ls-files`,
 `cargo nextest run --workspace --profile ci` (all run 2026-08-10).

--- a/docs/onboarding/02-architecture-guide.md
+++ b/docs/onboarding/02-architecture-guide.md
@@ -522,7 +522,7 @@ no DRM or anti-tamper claims.
 ### 8a. Engine policy: system by default, pinned where the system fails
 
 Normative source: [`05` §1](../architecture/05-webview-and-native.md); the evidence behind it is
-[`06-webview-reality.md`](../research/06-webview-reality.md), which grades the three system
+[`06-webview-reality.md`](../research/library/host-platforms/06-webview-reality.md), which grades the three system
 engines honestly:
 
 | Platform | Engine | Grade | Consequence for Keld |

--- a/docs/onboarding/04-wire-formats-and-contracts.md
+++ b/docs/onboarding/04-wire-formats-and-contracts.md
@@ -305,7 +305,7 @@ the 12+ a fixed-width or self-describing encoding would need.
 
 ### Why postcard and not JSON
 
-The evaluation is in [`10-ipc-state-of-the-art.md`](../research/10-ipc-state-of-the-art.md) and the
+The evaluation is in [`10-ipc-state-of-the-art.md`](../research/library/ipc-runtime/10-ipc-state-of-the-art.md) and the
 decision is normative in [`02` §2](../architecture/02-ipc.md):
 
 | Candidate | Verdict |

--- a/docs/onboarding/05-development-guide.md
+++ b/docs/onboarding/05-development-guide.md
@@ -426,16 +426,17 @@ reach for them:
 | How do I write a spec? | [`docs/agents/spec-template.md`](../agents/spec-template.md) |
 | What has already bitten someone? | [`docs/agents/learnings.md`](../agents/learnings.md) |
 | What is the system supposed to be? | [`docs/architecture/01..07-*.md`](../architecture/) |
-| Why did we choose this? | [`docs/engineering/decisions.md`](../engineering/decisions.md) (engineering narrative, not RFC 2119). [`AGENTS.md`](../../AGENTS.md) still binds. Numbered `docs/research/` is exploratory evidence, not required reading. |
+| Why did we choose this? | [`docs/engineering/decisions.md`](../engineering/decisions.md) (engineering narrative, not RFC 2119). [`AGENTS.md`](../../AGENTS.md) still binds. Canonical categorized `docs/research/library/` is exploratory evidence, not required reading. |
 | When does feature X land? | [`ROADMAP.md`](../../ROADMAP.md) |
 | Which of these actually binds me? | [`06-documentation-map.md`](./06-documentation-map.md) |
 
 There is no `.claude/project-calibration.json` and no `project-conventions` skill in this
 repo — if something points you at one, it is describing a different project.
 
-> **Tracked versus local-only.** Architecture, onboarding, agent, engineering, and
-> research docs under `docs/` are tracked, as are the generated `llms.txt` and
-> `llms-full.txt`. The generated corpus deliberately excludes research and every
+> **Tracked versus local-only.** Keld tracks its architecture, onboarding, agent, and
+> engineering docs plus generated `llms.txt` and `llms-full.txt`. `docs/research/` is
+> tracked by its separate nested `0monish/keld-research` checkout and ignored by the
+> Keld monorepo. The generated corpus deliberately excludes research and every
 > unlisted source. `/competitors/`, `/ROADMAP.md`, and `/.claude/` remain
 > local-only under [`.gitignore`](../../.gitignore). `.github/` is tracked (KEL-39).
 

--- a/docs/onboarding/06-documentation-map.md
+++ b/docs/onboarding/06-documentation-map.md
@@ -15,13 +15,13 @@
 | **Architecture specs** | The agreed design for v0.x. Changing one requires a design PR. Code that disagrees with a spec is a bug in one of the two — fix both in the same PR or state why. | [`docs/architecture/01..07-*.md`](../architecture/) |
 | **Feature specs** | A scoped implementation contract created from the approved template and tied to Linear. `approved`, `implementing`, and `done` specs may govern work at their stated phase; `draft` specs do not authorize implementation. | [`docs/specs/`](../specs/) |
 | **Engineering narrative** | What we chose, why, what we rejected, and what is not next. **Not** RFC 2119 — [`AGENTS.md`](../../AGENTS.md) still binds. Onboarding pointer for “why.” | [`docs/engineering/decisions.md`](../engineering/decisions.md) |
-| **Exploratory / historical** | Informs decisions, does not bind them. Dated. Cite it as evidence, never as a requirement. | [`docs/research/`](../research/), other [`docs/engineering/`](../engineering/) audits, [`task.md`](../../task.md) |
+| **Exploratory / historical** | Informs decisions, does not bind them. Dated. Cite it as evidence, never as a requirement. | [`docs/research/`](../research/), other [`docs/engineering/`](../engineering/) audits, and historical Linear comments |
 
 Two rules that follow directly from that table, both from
 [`docs/agents/learnings.md`](../agents/learnings.md) and [`AGENTS.md`](../../AGENTS.md):
 
-- **Never cite `docs/research/from-outside/` in your work.** Those are raw external
-  research exports. Numbered `docs/research/` notes are exploratory evidence, not
+- **Never cite `docs/research/inputs/external/` in your work.** Those are raw external
+  research exports. Canonical `docs/research/library/` notes are exploratory evidence, not
   required onboarding — the why-pointer is
   [`docs/engineering/decisions.md`](../engineering/decisions.md).
 - **Numbered docs are paths.** If you renumber a doc, you must update every reference to
@@ -29,10 +29,11 @@ Two rules that follow directly from that table, both from
 
 ### A note on what is actually in the git repo
 
-Documentation under `/docs/` is tracked, including status-bearing feature contracts in
-`docs/specs/`, along with generated `llms.txt` and `llms-full.txt`.
-[`.gitignore`](../../.gitignore) keeps `/competitors/`, `/ROADMAP.md`,
-`/docs/research/`, and `/.claude/` local-only. `.github/` is tracked (KEL-39). The
+Keld tracks its architecture, agent, engineering, onboarding, and feature-contract
+documentation plus generated `llms.txt` and `llms-full.txt`. `docs/research/` is a
+separate nested checkout tracked by `0monish/keld-research` and ignored by the Keld
+monorepo. [`.gitignore`](../../.gitignore) also keeps `/competitors/`, `/ROADMAP.md`,
+and `/.claude/` local-only. `.github/` is tracked (KEL-39). The
 generated corpus is narrower than the tracked docs tree: its ordered allowlist excludes
 research and all unlisted documents. The engineering decision log is on that allowlist;
 numbered research is not.
@@ -45,7 +46,6 @@ numbered research is not.
 | [`README.md`](../../README.md) | The 30-second pitch, the intended `migrate → dev → build` flow, the workspace layout, and the two commands that work today. | First five minutes. |
 | [`docs/engineering/linear-roadmap-mapping.md`](../engineering/linear-roadmap-mapping.md) | Tracked phase map between Linear project numbers and the local `ROADMAP.md` (gitignored). Use this, not an untracked file, as required reading for “what is in scope now.” | When you want to know whether the thing you're about to build is in scope *now*. |
 | [`llms.txt`](../../llms.txt) · [`llms-full.txt`](../../llms-full.txt) | Generated agent-readable documentation: a compact curated index and the corresponding concatenated corpus. `tools/llms_docs.rs` fixes source order and excludes research/local-only paths; `just llms-check` rejects drift. | When wiring up agent tooling, bulk-ingesting the authoritative docs corpus, or checking what the official MCP docs search embeds. |
-| [`task.md`](../../task.md) | A **ledger** of a Linear harness run dated 2026-07-10: issue inventory by status, per-ticket blueprints and acceptance criteria, execution order, gate commands, and the results at the time (12/12 tests then). Historical, not a live to-do list. | When you need to know why a Linear issue was closed, or what "COMPLETE" meant for a given ticket. |
 | [`justfile`](../../justfile) · [`Cargo.toml`](../../Cargo.toml) · [`clippy.toml`](../../clippy.toml) · [`deny.toml`](../../deny.toml) · [`rustfmt.toml`](../../rustfmt.toml) · [`rust-toolchain.toml`](../../rust-toolchain.toml) · [`.config/nextest.toml`](../../.config/nextest.toml) | Not prose, but they are the enforcement layer behind `AGENTS.md`. `just ci` runs every gate CI would run. Workspace lints (pedantic clippy, `missing_docs`, `unsafe_code = "deny"`) live in `Cargo.toml`, with comments explaining each choice. | When a lint fails and you want to know whether it's negotiable (it usually isn't). |
 
 ## `docs/architecture/` — normative for v0.x
@@ -88,37 +88,37 @@ This directory is **not** required onboarding; the why-pointer is
 
 | Doc | Subject |
 |---|---|
-| [`00-landscape.md`](../research/00-landscape.md) | **Entry point.** Executive summary: the field one line each, the head-to-head matrix, the five structural problems nobody has solved together, a "steal list" of what each competitor genuinely got right, and Keld's five falsifiable theses. |
-| [`01-electron.md`](../research/01-electron.md) | The incumbent Keld must replace *and* stay compatible with — architecture recap and issue catalog. Two postures: attack the architecture, adopt the API surface. |
-| [`02-tauri.md`](../research/02-tauri.md) | The strongest technical competitor and closest philosophical cousin. Explains why the differentiation is not "lighter than Tauri." |
-| [`03-electrobun.md`](../research/03-electrobun.md) | Closest existing implementation of the Bun-main-process thesis; updated 2026-08-08 for its 2.0 multi-runtime architecture. |
-| [`04-deno-desktop.md`](../research/04-deno-desktop.md) | The newest and strategically most dangerous entrant — a subcommand of a runtime people already have. Steal its distribution insights, attack its architectural shortcuts. |
-| [`15-wails.md`](../research/15-wails.md) | Wails (Go + system webviews): same single-native-process shape as Tauri with a mandatory Go backend; v3 beta August 2026. |
+| [`00-landscape.md`](../research/library/compatibility-competitors/00-landscape.md) | **Entry point.** Executive summary: the field one line each, the head-to-head matrix, the five structural problems nobody has solved together, a "steal list" of what each competitor genuinely got right, and Keld's five falsifiable theses. |
+| [`01-electron.md`](../research/library/compatibility-competitors/01-electron.md) | The incumbent Keld must replace *and* stay compatible with — architecture recap and issue catalog. Two postures: attack the architecture, adopt the API surface. |
+| [`02-tauri.md`](../research/library/compatibility-competitors/02-tauri.md) | The strongest technical competitor and closest philosophical cousin. Explains why the differentiation is not "lighter than Tauri." |
+| [`03-electrobun.md`](../research/library/compatibility-competitors/03-electrobun.md) | Closest existing implementation of the Bun-main-process thesis; updated 2026-08-08 for its 2.0 multi-runtime architecture. |
+| [`04-deno-desktop.md`](../research/library/compatibility-competitors/04-deno-desktop.md) | The newest and strategically most dangerous entrant — a subcommand of a runtime people already have. Steal its distribution insights, attack its architectural shortcuts. |
+| [`15-wails.md`](../research/library/compatibility-competitors/15-wails.md) | Wails (Go + system webviews): same single-native-process shape as Tauri with a mandatory Go backend; v3 beta August 2026. |
 
 ### Ecosystem and domain surveys
 
 | Doc | Subject |
 |---|---|
-| [`05-rust-wave.md`](../research/05-rust-wave.md) | What the 2024–2026 Rust rewrites of the JS toolchain teach Keld, each lesson mapped to a Keld decision. The source of the "compatibility-first wins an incumbent's users" (Rspack/Rolldown) and "state machines, no async runtime in hot paths" (Bun) principles. |
-| [`06-webview-reality.md`](../research/06-webview-reality.md) | The honest per-platform accounting of system webviews. **The platform truth table** — this is the doc that shapes the per-platform engine policy. |
-| [`07-agent-first.md`](../research/07-agent-first.md) | Research basis for the agentic system, with two consumers: how Keld is built (agents write, humans architect and review) and how Keld serves agents as users. Feeds `AGENTS.md`, `docs/agents/`, and architecture 07. |
-| [`10-ipc-state-of-the-art.md`](../research/10-ipc-state-of-the-art.md) | Schema-first bridge survey: comparison table, serialization candidates, codegen approaches, transport per leg, hot-path design, prior-art pain to avoid. Feeds architecture 02. |
-| [`11-security-model.md`](../research/11-security-model.md) | Competitor security models, OS primitives available, the recommended Keld model, ranked risks and mitigations. Feeds architecture 03. |
-| [`12-distribution.md`](../research/12-distribution.md) | Signing and notarization reality in 2026, framework update stacks, packaging formats users and IT actually want, and the pain points to preserve as design constraints. Feeds `keld-pack` / `keld-update` and Phase 3. |
-| [`13-electron-api-usage.md`](../research/13-electron-api-usage.md) | Which Electron modules real apps use, expressed as frequency tiers; hardest migration surfaces; native-module risk. Feeds the compat tiers in architecture 04. |
-| [`17-native-frameworks.md`](../research/17-native-frameworks.md) | AppKit/SwiftUI, WinUI 3/WPF, Qt/QML, GTK4, Flutter Desktop, Compose Multiplatform — and from them "the native-parity bar": what native gives for free, where it chronically fails, and what Keld must match, can beat, or must refuse to copy. |
+| [`05-rust-wave.md`](../research/library/agents-tooling/05-rust-wave.md) | What the 2024–2026 Rust rewrites of the JS toolchain teach Keld, each lesson mapped to a Keld decision. The source of the "compatibility-first wins an incumbent's users" (Rspack/Rolldown) and "state machines, no async runtime in hot paths" (Bun) principles. |
+| [`06-webview-reality.md`](../research/library/host-platforms/06-webview-reality.md) | The honest per-platform accounting of system webviews. **The platform truth table** — this is the doc that shapes the per-platform engine policy. |
+| [`07-agent-first.md`](../research/library/agents-tooling/07-agent-first.md) | Research basis for the agentic system, with two consumers: how Keld is built (agents write, humans architect and review) and how Keld serves agents as users. Feeds `AGENTS.md`, `docs/agents/`, and architecture 07. |
+| [`10-ipc-state-of-the-art.md`](../research/library/ipc-runtime/10-ipc-state-of-the-art.md) | Schema-first bridge survey: comparison table, serialization candidates, codegen approaches, transport per leg, hot-path design, prior-art pain to avoid. Feeds architecture 02. |
+| [`11-security-model.md`](../research/library/security-permissions/11-security-model.md) | Competitor security models, OS primitives available, the recommended Keld model, ranked risks and mitigations. Feeds architecture 03. |
+| [`12-distribution.md`](../research/library/auth-distribution/12-distribution.md) | Signing and notarization reality in 2026, framework update stacks, packaging formats users and IT actually want, and the pain points to preserve as design constraints. Feeds `keld-pack` / `keld-update` and Phase 3. |
+| [`13-electron-api-usage.md`](../research/library/compatibility-competitors/13-electron-api-usage.md) | Which Electron modules real apps use, expressed as frequency tiers; hardest migration surfaces; native-module risk. Feeds the compat tiers in architecture 04. |
+| [`17-native-frameworks.md`](../research/library/host-platforms/17-native-frameworks.md) | AppKit/SwiftUI, WinUI 3/WPF, Qt/QML, GTK4, Flutter Desktop, Compose Multiplatform — and from them "the native-parity bar": what native gives for free, where it chronically fails, and what Keld must match, can beat, or must refuse to copy. |
 
 ### Audits and synthesis
 
 | Doc | Subject |
 |---|---|
-| [`08-competitor-source-audit.md`](../research/08-competitor-source-audit.md) | Ground-truth survey of the vendored clones in `competitors/`: pinned commit inventory, per-repo layout/CI/core-machinery/steal-or-avoid notes, a consolidated adopt/adapt/avoid list, an **implementer reading order** into competitor source, stated limitations, and a 2026-08-08 refresh log of what changed upstream. Read before you go looking in `competitors/`. |
-| [`09-tooling-context7-audit.md`](../research/09-tooling-context7-audit.md) | Per-tool best-practice analysis for Keld's stack, recommended toolchain versions, CI pipeline recommendation, tools to adopt and to skip. |
-| [`14-phase0-synthesis.md`](../research/14-phase0-synthesis.md) | **The capstone.** Market gap statement, ranked ~10× opportunities, ranked risks with mitigations, one-paragraph guidance per Phase 1 RFC, the frozen benchmark baseline table, and the Phase 0 exit checklist. If you read only two research docs, read `00` and this. |
-| [`20-vscode-on-keld.md`](../research/20-vscode-on-keld.md) | VS Code north-star feasibility and local Bun/native probes. It is a demanding showcase, not Keld's product denominator. |
-| [`46-vscode-north-star-framework-synthesis.md`](../research/46-vscode-north-star-framework-synthesis.md) | Audited P01–P20 synthesis: separates reusable framework contracts from VS Code-only work, records evidence gaps and maps the findings into roadmap/Linear. Read this instead of treating raw P files as decisions. |
+| [`08-competitor-source-audit.md`](../research/library/compatibility-competitors/08-competitor-source-audit.md) | Ground-truth survey of the vendored clones in `competitors/`: pinned commit inventory, per-repo layout/CI/core-machinery/steal-or-avoid notes, a consolidated adopt/adapt/avoid list, an **implementer reading order** into competitor source, stated limitations, and a 2026-08-08 refresh log of what changed upstream. Read before you go looking in `competitors/`. |
+| [`09-tooling-context7-audit.md`](../research/library/agents-tooling/09-tooling-context7-audit.md) | Per-tool best-practice analysis for Keld's stack, recommended toolchain versions, CI pipeline recommendation, tools to adopt and to skip. |
+| [`14-phase0-synthesis.md`](../research/library/execution-governance/14-phase0-synthesis.md) | **The capstone.** Market gap statement, ranked ~10× opportunities, ranked risks with mitigations, one-paragraph guidance per Phase 1 RFC, the frozen benchmark baseline table, and the Phase 0 exit checklist. If you read only two research docs, read `00` and this. |
+| [`20-vscode-on-keld.md`](../research/campaigns/vscode/reports/20-vscode-on-keld.md) | VS Code north-star feasibility and local Bun/native probes. It is a demanding showcase, not Keld's product denominator. |
+| [`46-vscode-north-star-framework-synthesis.md`](../research/campaigns/vscode/synthesis/46-vscode-north-star-framework-synthesis.md) | Audited P01–P20 synthesis: separates reusable framework contracts from VS Code-only work, records evidence gaps and maps the findings into roadmap/Linear. Read this instead of treating raw P files as decisions. |
 
-### Drafts — `docs/research/drafts/`
+### Drafts — `docs/research/incubator/drafts/`
 
 Four deep risk audits dated 2026-08-08, explicitly marked **draft** and explicitly
 scoped to go deeper and newer than `06-webview-reality.md` without duplicating it. Every
@@ -126,33 +126,35 @@ number is either cited or marked as an estimate.
 
 | Draft | Subject |
 |---|---|
-| [`16a-bun-runtime-risks.md`](../research/drafts/16a-bun-runtime-risks.md) | Bun as the supervised app-process runtime — primary sources only; phase-1 input to revisiting the Bun integration RFC. |
-| [`16b-wkwebview-risks.md`](../research/drafts/16b-wkwebview-risks.md) | WKWebView/WebKit on macOS: what it allows today, hard limits against specs 02/03/05, what changed in the last year, and a source-level costing of bundling our own WebKit. |
-| [`16c-webview2-risks.md`](../research/drafts/16c-webview2-risks.md) | WebView2 on Windows as the `keld-wv` Windows backend. |
-| [`16d-webkitgtk-risks.md`](../research/drafts/16d-webkitgtk-risks.md) | WebKitGTK/WPE on Linux, focused on the question `06` doesn't answer: since this is the one fully open-source system engine Keld targets, is upstream patching or vendoring a real lever, and what does it cost? |
+| [`16a-bun-runtime-risks.md`](../research/incubator/drafts/16a-bun-runtime-risks.md) | Bun as the supervised app-process runtime — primary sources only; phase-1 input to revisiting the Bun integration RFC. |
+| [`16b-wkwebview-risks.md`](../research/incubator/drafts/16b-wkwebview-risks.md) | WKWebView/WebKit on macOS: what it allows today, hard limits against specs 02/03/05, what changed in the last year, and a source-level costing of bundling our own WebKit. |
+| [`16c-webview2-risks.md`](../research/incubator/drafts/16c-webview2-risks.md) | WebView2 on Windows as the `keld-wv` Windows backend. |
+| [`16d-webkitgtk-risks.md`](../research/incubator/drafts/16d-webkitgtk-risks.md) | WebKitGTK/WPE on Linux, focused on the question `06` doesn't answer: since this is the one fully open-source system engine Keld targets, is upstream patching or vendoring a real lever, and what does it cost? |
 
-There is no consolidated `16-*.md`; the drafts are the artifact. Numbering jumps from
-`15` to `17` in the parent directory.
+[`16-engine-runtime-risk-matrix.md`](../research/library/host-platforms/16-engine-runtime-risk-matrix.md)
+is the executive synthesis of 16a–16d. Read the individual incubator drafts for
+source-level detail and the canonical matrix for cross-engine routing.
 
-### Raw external research — `docs/research/from-outside/`
+### Raw external research — `docs/research/inputs/external/legacy-2026-08/`
 
-24 files. Fifteen are Perplexity-style deep-research exports whose filenames are the
+25 files. Fifteen are Perplexity-style deep-research exports whose filenames are the
 truncated prompt (Electron criticisms, Tauri v2 complaints, webview differences, IPC/bridge
 architectures, security models, distribution and auto-update, Electrobun, Deno Desktop,
 Electron API usage, MCP servers, AX, AGENTS.md state of the art, agent-orchestration,
-API/error/docs design for agents, vibe-coding failure modes). Nine are `twiter*.md`
+API/error/docs design for agents, vibe-coding failure modes). `latest.md` is an additional
+captured input, and nine `twiter*.md` files are
 digests of practitioner discourse (the Rust tooling wave, Bun's Rust rewrite, the desktop
 framework conversation, agentic-engineering practitioners, AX leaders).
 
 **These are inputs, not sources.** The rule is explicit in
-[`docs/agents/learnings.md`](../agents/learnings.md): never cite `from-outside/` directly —
+[`docs/agents/learnings.md`](../agents/learnings.md): never cite raw external inputs directly —
 cite the polished numbered doc that consumed it.
 
-`45-P1.md` through `45-P20.md` are another raw external-input set retained at the
-research root because they arrived under those user-owned paths. Their copied `turn…`
-citations are nonportable and P13's ephemeral benchmark artifacts are missing. Each
-file carries a raw-input banner; use `46` for decisions and require a direct source
-ledger before promoting any unresolved claim.
+`45-P1.md` through `45-P20.md` are another source packet, now grouped under
+`docs/research/campaigns/vscode/reports/`. Their copied `turn…` citations are
+nonportable and P13's ephemeral benchmark artifacts are missing. Use canonical
+`46-vscode-north-star-framework-synthesis.md` for decisions and require a direct
+source ledger before promoting any unresolved claim.
 
 ## `docs/agents/` — how work gets done here
 
@@ -212,7 +214,7 @@ reading pinned real implementations instead of guessing. Their count and disk fo
 depend on the current lock/sync state and are not a documentation contract.
 
 Reviewed entries have written teardowns in
-[`08-competitor-source-audit.md`](../research/08-competitor-source-audit.md), with pinned
+[`08-competitor-source-audit.md`](../research/library/compatibility-competitors/08-competitor-source-audit.md), with pinned
 commits and per-repo notes:
 
 | Clone | Why it's here |
@@ -230,7 +232,7 @@ present because they are the primary source for a topic the specs depend on:
 
 | Clone | Topic it backs |
 |---|---|
-| `bun/` | The runtime Keld supervises (and the Rust-rewrite discipline research/05 draws on) |
+| `bun/` | The runtime Keld supervises (and the Rust-rewrite discipline in `docs/research/library/agents-tooling/05-rust-wave.md` draws on) |
 | `chromium-embedded/` | The opt-in pinned-engine path (CEF) in the engine policy |
 | `webkit/` | WebKit upstream — the "patch or vendor?" question in draft 16d, and WKWebView behavior in 16b |
 | `gtk/` | The GTK4 side of the Linux backend and the GTK4 section of `17-native-frameworks.md` |
@@ -327,9 +329,9 @@ the optional external KEL-67 memory pilot should also read
 9. [`docs/agents/workflow.md`](../agents/workflow.md) and
    [`docs/agents/spec-template.md`](../agents/spec-template.md) — how a change gets from
    issue to merge here.
-10. Numbered [`docs/research/`](../research/) (starting with
-    [`00-landscape.md`](../research/00-landscape.md) and
-    [`14-phase0-synthesis.md`](../research/14-phase0-synthesis.md) if they are in your
+10. Canonical categorized [`docs/research/`](../research/) notes (starting with
+    [`00-landscape.md`](../research/library/compatibility-competitors/00-landscape.md) and
+    [`14-phase0-synthesis.md`](../research/library/execution-governance/14-phase0-synthesis.md) if they are in your
     tree) — exploratory evidence behind the architecture, not required reading and not
     a substitute for [`decisions.md`](../engineering/decisions.md).
 11. The two architecture docs closest to your first task — most likely
@@ -342,7 +344,7 @@ the optional external KEL-67 memory pilot should also read
 13. [`docs/architecture/04-electron-compat.md`](../architecture/04-electron-compat.md) —
     because principle #1 says every design must answer how it behaves under
     `@keld/electron`, and you cannot answer that without reading this.
-14. [`docs/research/06-webview-reality.md`](../research/06-webview-reality.md) — the
+14. [`docs/research/library/host-platforms/06-webview-reality.md`](../research/library/host-platforms/06-webview-reality.md) — the
     platform truth table, before you form any opinion about "the webview."
 15. [`docs/engineering/tooling-audit.md`](../engineering/tooling-audit.md) and the
     [`alignment-audit`](../engineering/alignment-audit-2026-07-08.md) — why the toolchain
@@ -350,10 +352,10 @@ the optional external KEL-67 memory pilot should also read
 
 ### As needed, not up front
 
-`docs/research/01–04`, `15`, `17` (open the one whose competitor you're reasoning about);
-`10–13` (open the one matching your domain); `drafts/16a–16d` (before platform-backend
-work); `08-competitor-source-audit.md` (before reading competitor source);
-`docs/research/from-outside/` (rarely — and never as a citation);
+Use the generated research topic catalogs to open the canonical competitor or domain
+note; use `docs/research/incubator/drafts/16a–16d` before platform-backend
+work; `08-competitor-source-audit.md` (before reading competitor source);
+`docs/research/inputs/external/` (rarely — and never as a citation);
 [`07-mcp-server.md`](07-mcp-server.md) (when registering the official Keld MCP);
 [`08-optional-agent-memory.md`](08-optional-agent-memory.md) (only for the approved
-external pilot); [`task.md`](../../task.md) (when you need the history of a Linear issue).
+external pilot). Use Linear itself when you need the history of an issue.

--- a/docs/specs/kel75-principalized-bun-child-roles.md
+++ b/docs/specs/kel75-principalized-bun-child-roles.md
@@ -283,7 +283,7 @@ the failing test.
 T1 adds a cold bootstrap listener and is not a hot-path optimization. T1–T5 measure only after semantic correctness:
 role spawn/restart latency, p99 bounded routed-port latency, queued-byte maxima, CPU and
 RSS. Shared memory is not a baseline or an acceptance condition; see the committed
-P13 new-run evidence and `docs/research/48-p13-new-run-audit.md`.
+P13 new-run evidence and `docs/research/campaigns/vscode/reports/48-p13-new-run-audit.md`.
 
 ## 10. Open questions
 

--- a/docs/specs/keld-mcp-server-v1.md
+++ b/docs/specs/keld-mcp-server-v1.md
@@ -23,12 +23,13 @@ list three tools with declared output schemas, run doctor checks, search the Kel
 corpus, and get a deny explanation with the exact manifest patch — all offline, all
 read-only.
 
-Non-goals (explicit, per `docs/research/21-mcp-standard.md`):
+Non-goals (explicit, per `docs/research/library/agents-tooling/21-mcp-standard.md`):
 
 - **No HTTP transport** (no Streamable HTTP listener, no OAuth resource-server
   surface, no SEP-2243 routing headers). stdio only.
 - **No elicitation / MRTR `input_required`** — every v1 tool is read-only and returns
-  `resultType: "complete"`; the elicitation client-fork risk (research/21 § risks) is
+  `resultType: "complete"`; the elicitation client-fork risk
+  (`docs/research/library/agents-tooling/21-mcp-standard.md` § risks) is
   sidestepped entirely.
 - **No tasks extension** (`io.modelcontextprotocol/tasks`) — all three tools are
   interactive-latency.
@@ -36,7 +37,7 @@ Non-goals (explicit, per `docs/research/21-mcp-standard.md`):
 - **No telemetry** (arch/07 §9: no data leaves the developer's machine).
 - **No write operations**: `keld_permissions_explain` reads manifests and *returns* a
   patch; it never edits a file. A future patch-applying tool is out of scope and would
-  require MRTR consent gating (research/21 §4).
+  require MRTR consent gating (`docs/research/library/agents-tooling/21-mcp-standard.md` §4).
 - **Not in scope**: the remaining six arch/07 §4 tools (`keld_scaffold_app`,
   `keld_migrate_analyze`, `keld_dev_inspect`, `keld_ipc_trace`, `keld_logs_search`,
   `keld_build_errors`). They land in follow-up specs once their substrates exist
@@ -51,7 +52,7 @@ Non-goals (explicit, per `docs/research/21-mcp-standard.md`):
   output), **§7** (CLI contract: `--json`, stable exit codes 0/1/2/3, non-interactive).
 - `docs/architecture/03-security.md` **§2–3** (manifest schema and generated-patch
   philosophy that `keld_permissions_explain` renders).
-- `docs/research/21-mcp-standard.md` (spec revision 2026-07-28, rmcp 3.1.2 readiness,
+- `docs/research/library/agents-tooling/21-mcp-standard.md` (spec revision 2026-07-28, rmcp 3.1.2 readiness,
   v1 transport/primitive decisions — this spec adopts its recommendations verbatim).
 - **Deviation: none.** Arch/07 §4 lists nine v1 tools and §8 Phase 2 bundles
   dev-inspect/trace; this spec *sequences within* Phase 2 — the three tools whose
@@ -153,7 +154,7 @@ pub struct DoctorFinding {
     pub error: Option<KeldErrorObject>, // present iff !ok
 }
 // output: Vec<DoctorFinding> — top-level array, no wrapper (SEP-2106 any-type
-// output; research/21 §3). Wraps keld_cli::doctor::run_checks().
+// output; docs/research/library/agents-tooling/21-mcp-standard.md §3). Wraps keld_cli::doctor::run_checks().
 
 // crates/keld-cli/src/mcp/docs_tool.rs
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -228,7 +229,7 @@ Per root `AGENTS.md` (name, purpose, alternatives):
   (c) community crates (`mcpr` etc.) — not the official SDK, no 2026-07-28 support
   confirmed; rejected.
 - **Risk & mitigation**: rmcp trails Tier 1; wire fixes were still landing in Aug 2026
-  (research/21 § risks). Exact-pin; every version bump re-runs the conformance suite
+  (`docs/research/library/agents-tooling/21-mcp-standard.md` § risks). Exact-pin; every version bump re-runs the conformance suite
   (§7) before merge. Workspace `Cargo.toml` is single-writer (workflow.md) — the dep
   PR carries human review by construction.
 
@@ -322,7 +323,7 @@ stdio framing), so tests await conditions, never timers; **no ports** — stdio 
 nothing to collide; **temp dirs** via `tempfile` for every project/manifest fixture;
 platform-variant doctor findings are shape-checked only (§4 platform notes) so the
 suite is green on all three OSes; rmcp version bumps re-run this whole table
-(research/21: pin + re-verify).
+(`docs/research/library/agents-tooling/21-mcp-standard.md`: pin + re-verify).
 
 ## 8. Review gates triggered
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -377,7 +377,7 @@ the 12+ a fixed-width or self-describing encoding would need.
 
 ### Why postcard and not JSON
 
-The evaluation is in [`10-ipc-state-of-the-art.md`](../research/10-ipc-state-of-the-art.md) and the
+The evaluation is in [`10-ipc-state-of-the-art.md`](../research/library/ipc-runtime/10-ipc-state-of-the-art.md) and the
 decision is normative in [`02` §2](../architecture/02-ipc.md):
 
 | Candidate | Verdict |
@@ -893,7 +893,7 @@ Three principal classes, with host-minted instances inside each class:
 3. **Webviews** (system or pinned engine): untrusted UI documents. Talk to the host over
    the native bridge; talk to the app process only through host-mediated routed channels.
 
-Why this shape (each competitor fails differently — see `docs/research/00-landscape.md`):
+Why this shape (each competitor fails differently — see `docs/research/library/compatibility-competitors/00-landscape.md`):
 - Electron: privileged JS **in-process** with window ownership → bloat + checklist security.
 - Tauri: native ownership correct, but no JS main process → adoption cliff.
 - Electrobun / Deno Desktop: JS main process, but it *owns* the native layer / shares the
@@ -1211,7 +1211,7 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   request/response with streaming bodies (WKURLSchemeHandler / WebView2
   WebResourceRequested / WebKitGTK 2.40+ streams), which engines serve off the UI
   thread and can hand to us as counted buffers. postMessage stays control-only
-  (string-typed on WebView2 — see research/06).
+  (string-typed on WebView2 — see `docs/research/library/host-platforms/06-webview-reality.md`).
 - Renderer→app-role file-ish transfers (the Electron `send(bigBuffer)` pattern) are
   routed through the host with bounded credit. A platform adapter MAY forward into that
   role's ring, but the actual engine path reports its copies; choosing a binary codec
@@ -1475,7 +1475,8 @@ binary); rollback keeps N-1 with the same verification; channel pinning
 # Electron Compatibility — Keld's Go-To-Market Spec
 
 The falsifiable promise: **a median Electron app runs on Keld by changing configuration,
-not code.** This is the Rspack/Rolldown lesson applied to desktop (see research/05).
+not code.** This is the Rspack/Rolldown lesson applied to desktop (see
+`docs/research/library/agents-tooling/05-rust-wave.md`).
 "Median" is defined and measured, not vibed: we maintain a corpus of open-source
 Electron apps and publish per-app compat scores.
 
@@ -1713,13 +1714,14 @@ If it lands, binaries are fetched at build time and the selected app/vendor owns
 security updates. Verso/Servo remain later conformance candidates only when embedding
 stabilizes—the trait is the insurance policy, not evidence that those backends ship.
 
-Linux resilience (research/06): GPU-driver probe at startup → auto-apply
+Linux resilience (`docs/research/library/host-platforms/06-webview-reality.md`): GPU-driver probe at startup → auto-apply
 safe-mode. **Implemented (KEL-28):** `webkitgtk::probe_gpu_stack` detects
 NVIDIA + Wayland and sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` programmatically
 before any GTK/WebKit call — never by asking users to export env vars — and
 returns a `GpuSafeMode` apps can read (`is_degraded()` / `reason()`) as the
 structured degraded-rendering fact. **Not yet built:** a `keld doctor` line
-surfacing that result, and the fuller version-matrix probe research/06
+surfacing that result, and the fuller version-matrix probe in
+`docs/research/library/host-platforms/06-webview-reality.md`
 describes (today's probe is driver + session type only).
 
 ## 2. Renderer bridge contract (`window.keld`)
@@ -2461,7 +2463,7 @@ release missing `full` is part of AC1):
 
 # Agent Experience (AX) — Keld as an Agent-First Framework
 
-> Normative for v0.x. Research basis: `docs/research/07-agent-first.md` (AX shipped by
+> Normative for v0.x. Research basis: `docs/research/library/agents-tooling/07-agent-first.md` (AX shipped by
 > frameworks, MCP tool-design guidance, error/docs design evidence, vibe-coding failure
 > modes). Position: **agents are a primary user persona** alongside humans. Most Keld
 > apps will be written at least partly by coding agents; the framework is designed so
@@ -2577,7 +2579,8 @@ pinned models/harnesses, run nightly and per docs/API-touching PR:
 
 ## 6. Guardrails for vibe-coded apps (Keld-enforced APIs)
 
-Threat model: the app author's agent wrote code nobody carefully read (research/07 §6:
+Threat model: the app author's agent wrote code nobody carefully read
+(`docs/research/library/agents-tooling/07-agent-first.md` §6:
 secrets leak ~2× human rate, ~55% of unguided AI code fails security checks, missing
 authz is endemic). Keld's stance — **Keld-enforced APIs** hold even when review
 doesn't. That is the host-checked capability manifest, network allowlist, webview
@@ -2655,7 +2658,7 @@ This file is **not** a new RFC 2119 layer. Binding agent rules stay in
 [`docs/agents/learnings.md`](../agents/learnings.md). This document is the onboarding
 pointer for *why* the current engineering looks like this.
 
-Numbered `docs/research/` notes are exploratory evidence. They are not required
+Canonical categorized `docs/research/library/` notes are exploratory evidence. They are not required
 reading and must not be treated as a second spec. Cite architecture, `AGENTS.md`,
 and `docs/engineering/` instead.
 
@@ -2992,7 +2995,7 @@ hooks reliably. A laptop hook cannot replace GitHub Actions. Putting clippy,
 nextest, or gitleaks in pre-commit is the wrong gate (slow; gitleaks is
 GitHub-only). Optional later: an Oxc-style **untracked** format-only hook, not
 a committed Husky tree. Evidence (exploratory, not required reading):
-`docs/research/42-git-hooks-and-precommit.md`.
+`docs/research/library/agents-tooling/42-git-hooks-and-precommit.md`.
 
 **Why.** Fmt/clippy/nextest are the contract testers can paste. `just ci` catches
 docs corpus drift, crate-`AGENTS.md` for `unsafe`, CODEOWNERS/template/SHA hygiene,


### PR DESCRIPTION
## Summary
Migrate Keld documentation and generated llms-full references to the categorized keld-research paths. Remove stale root/drafts/raw-input navigation prose.

## Spec refs
No boundary change. KEL-126; docs/research policy and catalog migration.

## Review gates
none — no unsafe, public API, permission model, dependency, or wire protocol change.

## Tests
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo nextest run --workspace --profile ci: 449 passed
- just agents-md
- just llms-check
- just mermaid-test
- just mermaid-check
- just mermaid-render-check: 13 diagrams rendered with pinned Mermaid 11.16.0 image
- Two isolated refuters: layout/reference CLEAN; authority/provenance CLEAN

## Platforms
CI-only documentation/reference migration. Real OS/device acceptance: not applicable.

## Perf impact
None; documentation paths only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to reflect the reorganized research library and categorized source locations.
  * Clarified canonical research, draft, and raw-input references across onboarding, architecture, engineering, and specification materials.
  * Removed outdated historical task-list references and updated related evidence links.
  * Synchronized cross-references in the generated documentation corpus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->