### PR TITLE
fix(guard): reject ambiguous permission manifests

### DIFF
--- a/crates/keld-cli/src/mcp/permissions.rs
+++ b/crates/keld-cli/src/mcp/permissions.rs
@@ -84,7 +84,7 @@ pub struct ManifestPatch {
 pub const MANIFEST_MISSING_CODE: &str = "KELD-MCP010";
 /// Manifest exists but cannot be read.
 pub const MANIFEST_UNREADABLE_CODE: &str = "KELD-MCP013";
-/// Manifest is not valid JSONC.
+/// Manifest is ambiguous, malformed, or exceeds its size ceiling.
 pub const MANIFEST_PARSE_CODE: &str = "KELD-MCP011";
 /// Principal is not `app` (v0 evaluate is app-process grants only).
 pub const UNKNOWN_PRINCIPAL_CODE: &str = "KELD-MCP012";
@@ -190,10 +190,23 @@ fn manifest_error(err: &ManifestError) -> KeldErrorObject {
                 .map_or_else(|| "<memory>".to_owned(), |p| p.display().to_string());
             KeldErrorObject::new(
                 MANIFEST_PARSE_CODE,
-                format!("permissions manifest at `{tried}` is not valid JSONC"),
+                format!("permissions manifest at `{tried}` is ambiguous or not valid JSONC"),
                 format!(
-                    "fix JSON at `{tried}` (comments are allowed; trailing commas are not) — {detail}"
+                    "remove duplicate object keys or fix JSON at `{tried}` \
+                     (comments are allowed; trailing commas are not) — {detail}"
                 ),
+            )
+            .with_cause(err.to_string())
+        }
+        ManifestError::TooLarge { path, max_bytes } => {
+            let tried = path
+                .as_ref()
+                .map_or_else(|| "<memory>".to_owned(), |p| p.display().to_string());
+            let max_kib = max_bytes / 1024;
+            KeldErrorObject::new(
+                MANIFEST_PARSE_CODE,
+                format!("permissions manifest at `{tried}` exceeds {max_kib} KiB"),
+                format!("reduce `{tried}` to {max_kib} KiB or less and retry"),
             )
             .with_cause(err.to_string())
         }
@@ -472,5 +485,24 @@ mod tests {
             permissions_explain(&args(dir.path(), "fs.read", "$APPDATA/x")).expect_err("parse");
         assert_eq!(err.code, MANIFEST_PARSE_CODE);
         assert!(err.fix.contains("keld.permissions.jsonc"), "{}", err.fix);
+    }
+
+    #[test]
+    fn oversized_manifest_is_mcp011_with_guard017_cause() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("keld.permissions.jsonc");
+        fs::write(&path, vec![b' '; 64 * 1024 + 1]).expect("write oversized manifest");
+        let err =
+            permissions_explain(&args(dir.path(), "fs.read", "$APPDATA/x")).expect_err("size");
+        assert_eq!(err.code, MANIFEST_PARSE_CODE);
+        assert!(err.message.contains("64 KiB"), "{}", err.message);
+        assert!(err.fix.contains("64 KiB or less"), "{}", err.fix);
+        assert!(
+            err.cause
+                .as_deref()
+                .is_some_and(|cause| cause.contains("KELD-GUARD017")),
+            "{:?}",
+            err.cause
+        );
     }
 }

--- a/crates/keld-guard/src/jsonc.rs
+++ b/crates/keld-guard/src/jsonc.rs
@@ -1,20 +1,20 @@
 //! Tiny JSONC comment stripper (`//` and `/* */`). Not a JSON parser.
 
-/// Returns `input` with `//` line comments and `/* */` block comments removed.
+/// Returns `input` with `//` line comments and `/* */` block comments replaced.
 ///
 /// Comments inside JSON strings are left untouched so values like
 /// `https://example.com` stay valid. The output is not otherwise rewritten
-/// (no trailing-comma support).
-pub(crate) fn strip_jsonc_comments(input: &str) -> String {
+/// (no trailing-comma support). Comment bytes become spaces while newlines are
+/// retained, preserving token separation and useful parser locations.
+pub(crate) fn strip_jsonc_comments(input: &str) -> Result<String, &'static str> {
     let bytes = input.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
+    let mut out = bytes.to_vec();
     let mut i = 0;
     let mut in_string = false;
     let mut escape = false;
     while i < bytes.len() {
         let b = bytes[i];
         if in_string {
-            out.push(b);
             if escape {
                 escape = false;
             } else if b == b'\\' {
@@ -27,7 +27,6 @@ pub(crate) fn strip_jsonc_comments(input: &str) -> String {
         }
         if b == b'"' {
             in_string = true;
-            out.push(b);
             i += 1;
             continue;
         }
@@ -35,27 +34,41 @@ pub(crate) fn strip_jsonc_comments(input: &str) -> String {
             && let Some(next) = bytes.get(i + 1).copied()
         {
             if next == b'/' {
+                out[i] = b' ';
+                out[i + 1] = b' ';
                 i += 2;
-                while i < bytes.len() && bytes[i] != b'\n' {
+                while i < bytes.len() && bytes[i] != b'\n' && bytes[i] != b'\r' {
+                    out[i] = b' ';
                     i += 1;
                 }
                 continue;
             }
             if next == b'*' {
+                let comment_start = i;
+                out[i] = b' ';
+                out[i + 1] = b' ';
                 i += 2;
                 while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    if bytes[i] != b'\n' && bytes[i] != b'\r' {
+                        out[i] = b' ';
+                    }
                     i += 1;
                 }
                 if i + 1 < bytes.len() {
+                    out[i] = b' ';
+                    out[i + 1] = b' ';
                     i += 2;
                 } else {
-                    i = bytes.len();
+                    return Err(if comment_start == 0 {
+                        "unterminated block comment at byte 0"
+                    } else {
+                        "unterminated block comment"
+                    });
                 }
                 continue;
             }
         }
-        out.push(b);
         i += 1;
     }
-    String::from_utf8(out).unwrap_or_default()
+    String::from_utf8(out).map_err(|_| "JSONC comment stripping produced invalid UTF-8")
 }

--- a/crates/keld-guard/src/lib.rs
+++ b/crates/keld-guard/src/lib.rs
@@ -31,16 +31,19 @@
 mod admit;
 mod jsonc;
 mod probe;
+mod unique_json;
 
 use std::fmt;
-use std::fs;
-use std::io;
+use std::fs::File;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use serde_json::{Map, Value};
 
 use crate::jsonc::strip_jsonc_comments;
+
+const MAX_MANIFEST_BYTES: usize = 64 * 1024;
 
 pub use admit::{
     AdmissionError, AdmissionRequest, ArchiveId, ArtifactDigest, CURRENT_POLICY_GENERATION,
@@ -265,6 +268,13 @@ pub enum ManifestError {
         /// `serde_json` error text.
         detail: String,
     },
+    /// The input exceeded the bounded permissions-manifest size.
+    TooLarge {
+        /// Path when loading from disk; `None` for [`parse_manifest`].
+        path: Option<PathBuf>,
+        /// Maximum accepted byte length.
+        max_bytes: usize,
+    },
 }
 
 impl fmt::Display for ManifestError {
@@ -286,15 +296,33 @@ impl fmt::Display for ManifestError {
                 Some(p) => write!(
                     f,
                     "KELD-GUARD005: permissions manifest at `{}` is not valid JSONC — {detail}. \
-                     Fix the JSON (comments are allowed; trailing commas are not).",
+                     Fix the JSON or remove duplicate object keys \
+                     (comments are allowed; trailing commas are not).",
                     p.display()
                 ),
                 None => write!(
                     f,
                     "KELD-GUARD005: permissions manifest is not valid JSONC — {detail}. \
-                     Fix the JSON (comments are allowed; trailing commas are not)."
+                     Fix the JSON or remove duplicate object keys \
+                     (comments are allowed; trailing commas are not)."
                 ),
             },
+            Self::TooLarge { path, max_bytes } => {
+                let max_kib = max_bytes / 1024;
+                match path {
+                    Some(path) => write!(
+                        f,
+                        "KELD-GUARD017: permissions manifest at `{}` exceeds the {max_kib} KiB limit. \
+                         Reduce the manifest to {max_kib} KiB or less and retry.",
+                        path.display()
+                    ),
+                    None => write!(
+                        f,
+                        "KELD-GUARD017: permissions manifest exceeds the {max_kib} KiB limit. \
+                         Reduce the manifest to {max_kib} KiB or less and retry."
+                    ),
+                }
+            }
         }
     }
 }
@@ -329,9 +357,11 @@ pub fn json_pointer_for(capability: &str) -> String {
 ///
 /// # Errors
 ///
-/// Returns [`ManifestError::Parse`] when the comment-stripped text is not JSON
-/// or is not a JSON object.
+/// Returns [`ManifestError::TooLarge`] when `text` exceeds 64 KiB, or
+/// [`ManifestError::Parse`] when the comment-stripped text is ambiguous,
+/// malformed, or not a JSON object.
 pub fn parse_manifest(text: &str) -> Result<PermissionsManifest, ManifestError> {
+    ensure_manifest_size(text.len(), None)?;
     parse_manifest_at(text, None)
 }
 
@@ -340,10 +370,11 @@ pub fn parse_manifest(text: &str) -> Result<PermissionsManifest, ManifestError> 
 /// # Errors
 ///
 /// Returns [`ManifestError::NotFound`] when the file is missing,
-/// [`ManifestError::Read`] on other I/O errors, or [`ManifestError::Parse`]
-/// when the contents are not JSONC.
+/// [`ManifestError::Read`] on other I/O/encoding errors,
+/// [`ManifestError::TooLarge`] above 64 KiB, or [`ManifestError::Parse`] when
+/// the contents are ambiguous or malformed JSONC.
 pub fn load_manifest(path: &Path) -> Result<PermissionsManifest, ManifestError> {
-    let text = fs::read_to_string(path).map_err(|e| {
+    let file = File::open(path).map_err(|e| {
         if e.kind() == io::ErrorKind::NotFound {
             ManifestError::NotFound {
                 path: path.to_path_buf(),
@@ -355,15 +386,53 @@ pub fn load_manifest(path: &Path) -> Result<PermissionsManifest, ManifestError> 
             }
         }
     })?;
+    let bytes = read_manifest_bytes(file, path)?;
+    let text = String::from_utf8(bytes).map_err(|error| ManifestError::Read {
+        path: path.to_path_buf(),
+        detail: error.to_string(),
+    })?;
     parse_manifest_at(&text, Some(path))
+}
+
+pub(crate) fn read_manifest_bytes<R: Read>(
+    reader: R,
+    path: &Path,
+) -> Result<Vec<u8>, ManifestError> {
+    let mut bytes = Vec::with_capacity(MAX_MANIFEST_BYTES + 1);
+    reader
+        .take((MAX_MANIFEST_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| ManifestError::Read {
+            path: path.to_path_buf(),
+            detail: error.to_string(),
+        })?;
+    ensure_manifest_size(bytes.len(), Some(path))?;
+    Ok(bytes)
+}
+
+fn ensure_manifest_size(length: usize, path: Option<&Path>) -> Result<(), ManifestError> {
+    if length > MAX_MANIFEST_BYTES {
+        return Err(ManifestError::TooLarge {
+            path: path.map(Path::to_path_buf),
+            max_bytes: MAX_MANIFEST_BYTES,
+        });
+    }
+    Ok(())
 }
 
 fn parse_manifest_at(
     text: &str,
     path: Option<&Path>,
 ) -> Result<PermissionsManifest, ManifestError> {
-    let stripped = strip_jsonc_comments(text);
-    serde_json::from_str(&stripped).map_err(|e| ManifestError::Parse {
+    let stripped = strip_jsonc_comments(text).map_err(|detail| ManifestError::Parse {
+        path: path.map(Path::to_path_buf),
+        detail: detail.to_owned(),
+    })?;
+    let value = unique_json::parse(&stripped).map_err(|e| ManifestError::Parse {
+        path: path.map(Path::to_path_buf),
+        detail: e.to_string(),
+    })?;
+    serde_json::from_value(value).map_err(|e| ManifestError::Parse {
         path: path.map(Path::to_path_buf),
         detail: e.to_string(),
     })
@@ -460,7 +529,42 @@ fn path_in_scope(path: &str, pattern: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
     use super::*;
+
+    struct CountingReader {
+        remaining: usize,
+        bytes_read: Rc<Cell<usize>>,
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            let count = buffer.len().min(self.remaining);
+            buffer[..count].fill(b' ');
+            self.remaining -= count;
+            self.bytes_read.set(self.bytes_read.get() + count);
+            Ok(count)
+        }
+    }
+
+    #[test]
+    fn bounded_reader_stops_after_limit_plus_one_byte() {
+        let bytes_read = Rc::new(Cell::new(0));
+        let reader = CountingReader {
+            remaining: MAX_MANIFEST_BYTES * 16,
+            bytes_read: Rc::clone(&bytes_read),
+        };
+        let path = Path::new("keld.permissions.jsonc");
+        let error = read_manifest_bytes(reader, path).expect_err("oversize input must fail");
+        assert!(matches!(error, ManifestError::TooLarge { .. }), "{error}");
+        assert_eq!(
+            bytes_read.get(),
+            MAX_MANIFEST_BYTES + 1,
+            "the reader must not consume the rest of an oversized source"
+        );
+    }
 
     #[test]
     fn deny_reasons_render_actionable_text() {

--- a/crates/keld-guard/src/unique_json.rs
+++ b/crates/keld-guard/src/unique_json.rs
@@ -1,0 +1,101 @@
+//! JSON decoding that rejects duplicate object keys at every depth.
+
+use std::fmt;
+
+use serde::de::Error as _;
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde_json::{Map, Number, Value};
+
+pub(crate) fn parse(text: &str) -> Result<Value, serde_json::Error> {
+    let mut deserializer = serde_json::Deserializer::from_str(text);
+    let value = UniqueValue::deserialize(&mut deserializer)?.0;
+    deserializer.end()?;
+    Ok(value)
+}
+
+struct UniqueValue(Value);
+
+impl<'de> Deserialize<'de> for UniqueValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(UniqueValueVisitor)
+    }
+}
+
+struct UniqueValueVisitor;
+
+impl<'de> Visitor<'de> for UniqueValueVisitor {
+    type Value = UniqueValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value with unique object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(UniqueValue(Value::Bool(value)))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(UniqueValue(Value::Number(Number::from(value))))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(UniqueValue(Value::Number(Number::from(value))))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Number::from_f64(value)
+            .map(Value::Number)
+            .map(UniqueValue)
+            .ok_or_else(|| E::custom("JSON number is not finite"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(UniqueValue(Value::String(value.to_owned())))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(UniqueValue(Value::String(value)))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(UniqueValue(Value::Null))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(UniqueValue(Value::Null))
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element::<UniqueValue>()? {
+            values.push(value.0);
+        }
+        Ok(UniqueValue(Value::Array(values)))
+    }
+
+    fn visit_map<A>(self, mut object: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = Map::new();
+        while let Some(key) = object.next_key::<String>()? {
+            if values.contains_key(&key) {
+                return Err(A::Error::custom(format!(
+                    "duplicate object key `{key}` is ambiguous"
+                )));
+            }
+            let value = object.next_value::<UniqueValue>()?;
+            values.insert(key, value.0);
+        }
+        Ok(UniqueValue(Value::Object(values)))
+    }
+}

--- a/crates/keld-guard/tests/manifest_parser.rs
+++ b/crates/keld-guard/tests/manifest_parser.rs
@@ -1,0 +1,146 @@
+//! Hostile-input contracts for the single permissions-manifest parser.
+
+#![allow(clippy::expect_used, clippy::panic)] // test setup/cleanup failures are assertion oracles
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use keld_guard::{Decision, Principal, evaluate, load_manifest, parse_manifest};
+
+const MAX_MANIFEST_BYTES: usize = 64 * 1024;
+
+fn manifest_with_size(size: usize) -> String {
+    const PREFIX: &str = r#"{"ignored":""#;
+    const SUFFIX: &str = r#""}"#;
+    assert!(size >= PREFIX.len() + SUFFIX.len());
+    format!(
+        "{PREFIX}{}{SUFFIX}",
+        "x".repeat(size - PREFIX.len() - SUFFIX.len())
+    )
+}
+
+struct TempManifest(PathBuf);
+
+impl TempManifest {
+    fn new() -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock is after Unix epoch")
+            .as_nanos();
+        Self(std::env::temp_dir().join(format!(
+            "keld-guard-manifest-parser-{}-{nonce}.jsonc",
+            std::process::id()
+        )))
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempManifest {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_file(&self.0)
+            && error.kind() != std::io::ErrorKind::NotFound
+            && !std::thread::panicking()
+        {
+            panic!("remove temporary manifest {}: {error}", self.0.display());
+        }
+    }
+}
+
+#[test]
+fn duplicate_keys_reject_recursively_after_json_decoding() {
+    let cases = [
+        r#"{"app":{"fs":{"read":[],"read":["/outside/**"]}}}"#,
+        r#"{"app":{"fs":{"read":["/outside/**"],"read":[]}}}"#,
+        r#"{"app":{"fs":{"read":[],"\u0072ead":["/outside/**"]}}}"#,
+        r#"{"app":{"fs":{"\u0072ead":["/outside/**"],"read":[]}}}"#,
+        r#"{"app":{"fs":{"read":[]/* split */,"read":["/outside/**"]}}}"#,
+        r#"{"app":{},"app":{"fs":{"read":["/outside/**"]}}}"#,
+        r#"{"windows":{"main":{"channels":[],"channels":["fs.read"]}}}"#,
+        r#"{"audit":[{"log":"deny","log":"all"}]}"#,
+    ];
+
+    for text in cases {
+        let error = parse_manifest(text)
+            .expect_err("decoded duplicate key must reject before policy construction");
+        let rendered = error.to_string();
+        assert!(rendered.contains("KELD-GUARD005"), "{rendered}: {text}");
+        assert!(rendered.contains("duplicate object key"), "{rendered}");
+    }
+
+    let dangerous = r#"{"app":{"fs":{"read":[],"read":["/outside/**"]}}}"#;
+    if let Ok(manifest) = parse_manifest(dangerous) {
+        assert_ne!(
+            evaluate(
+                &manifest,
+                Principal::AppProcess,
+                "fs.read",
+                "/outside/secret"
+            ),
+            Decision::Allow,
+            "last-wins decoding must never turn an ambiguous manifest into authority"
+        );
+    }
+}
+
+#[test]
+fn comment_removal_cannot_join_two_json_tokens() {
+    let error = parse_manifest(r#"{"ignored":1/* separator */2}"#)
+        .expect_err("a comment cannot turn two adjacent numbers into one value");
+    assert!(error.to_string().contains("KELD-GUARD005"), "{error}");
+}
+
+#[test]
+fn line_comments_end_at_cr_only_and_crlf_terminators() {
+    let cr_only = "{\r// comment\r\"app\":{}}";
+    let crlf = "{\r\n// comment\r\n\"app\":{}}";
+    parse_manifest(cr_only).expect("CR must terminate a line comment");
+    parse_manifest(crlf).expect("CRLF must terminate a line comment without swallowing content");
+}
+
+#[test]
+fn unterminated_block_comment_rejects_instead_of_truncating_to_valid_json() {
+    let error = parse_manifest(r#"{"app":{}} /* unterminated"#)
+        .expect_err("EOF inside a block comment must reject");
+    let rendered = error.to_string();
+    assert!(rendered.contains("KELD-GUARD005"), "{rendered}");
+    assert!(
+        rendered.contains("unterminated block comment"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn memory_and_disk_inputs_enforce_the_same_64_kib_boundary() {
+    let exact = manifest_with_size(MAX_MANIFEST_BYTES);
+    let over = manifest_with_size(MAX_MANIFEST_BYTES + 1);
+    assert_eq!(exact.len(), MAX_MANIFEST_BYTES);
+    assert_eq!(over.len(), MAX_MANIFEST_BYTES + 1);
+    parse_manifest(&exact).expect("exactly 64 KiB remains valid");
+
+    let memory_error = parse_manifest(&over).expect_err("64 KiB + 1 must reject in memory");
+    let memory_rendered = memory_error.to_string();
+    assert!(
+        memory_rendered.contains("KELD-GUARD017"),
+        "{memory_rendered}"
+    );
+    assert!(memory_rendered.contains("64 KiB"), "{memory_rendered}");
+
+    let temp = TempManifest::new();
+    let path = temp.path();
+    fs::write(path, &exact).expect("write exact-boundary manifest");
+    load_manifest(path).expect("disk input at exactly 64 KiB remains valid");
+    fs::write(path, &over).expect("write over-boundary manifest");
+    let disk_error = load_manifest(path).expect_err("disk input at 64 KiB + 1 must reject");
+
+    let disk_rendered = disk_error.to_string();
+    assert!(disk_rendered.contains("KELD-GUARD017"), "{disk_rendered}");
+    assert!(disk_rendered.contains("64 KiB"), "{disk_rendered}");
+    assert!(
+        disk_rendered.contains(&path.display().to_string()),
+        "{disk_rendered}"
+    );
+}

--- a/docs/architecture/03-security.md
+++ b/docs/architecture/03-security.md
@@ -59,6 +59,13 @@ cannot grant any authority.
 
 One file. Reviewed like a lockfile. Wildcards allowed but linted loudly.
 
+**v0 parser boundary:** `parse_manifest`, disk `load_manifest`, and MCP permission
+explain accept at most 64 KiB. JSONC block comments must terminate, and decoded object
+keys must be unique recursively (including escaped-equivalent spellings); ambiguity is
+`KELD-GUARD005`, while oversize input is `KELD-GUARD017`. KEL-102's verified
+retained-handle loader must reuse this parser and byte ceiling rather than add a second
+manifest decoder.
+
 ```jsonc
 {
   "$schema": "https://keld.dev/schemas/permissions-1.json",

--- a/docs/engineering/keld-error-codes.md
+++ b/docs/engineering/keld-error-codes.md
@@ -250,8 +250,8 @@ match the crate that already emits the code. Do not invent a third spelling.
 ## KELD-MCP011
 
 - crate: keld-cli
-- message: Permissions manifest is not valid JSONC
-- fix: Fix the JSON (comments are allowed; trailing commas are not).
+- message: Permissions manifest is ambiguous, malformed, or exceeds 64 KiB
+- fix: Remove duplicate keys, fix the JSONC, or reduce the file to 64 KiB or less.
 
 ## KELD-MCP012
 
@@ -304,8 +304,8 @@ match the crate that already emits the code. Do not invent a third spelling.
 ## KELD-GUARD005
 
 - crate: keld-guard
-- message: Permissions manifest is not valid JSONC
-- fix: Fix the JSON (comments are allowed; trailing commas are not).
+- message: Permissions manifest is ambiguous or not valid JSONC
+- fix: Fix the JSON or remove duplicate object keys (comments are allowed; trailing commas are not).
 
 ## KELD-GUARD006
 
@@ -366,6 +366,12 @@ match the crate that already emits the code. Do not invent a third spelling.
 - crate: keld-guard
 - message: Strict archive row used the wrong layer or oracle (Display names recorded oracle, not only layer)
 - fix: Do not start a child and do not restart unsandboxed; keep requested=Strict or declare explicit Keld legacy.
+
+## KELD-GUARD017
+
+- crate: keld-guard
+- message: Permissions manifest exceeds the 64 KiB input limit
+- fix: Reduce keld.permissions.jsonc to 64 KiB or less and retry.
 
 ## KELD-DOCS001
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1388,6 +1388,13 @@ cannot grant any authority.
 
 One file. Reviewed like a lockfile. Wildcards allowed but linted loudly.
 
+**v0 parser boundary:** `parse_manifest`, disk `load_manifest`, and MCP permission
+explain accept at most 64 KiB. JSONC block comments must terminate, and decoded object
+keys must be unique recursively (including escaped-equivalent spellings); ambiguity is
+`KELD-GUARD005`, while oversize input is `KELD-GUARD017`. KEL-102's verified
+retained-handle loader must reuse this parser and byte ceiling rather than add a second
+manifest decoder.
+
 ```jsonc
 {
   "$schema": "https://keld.dev/schemas/permissions-1.json",
@@ -3869,8 +3876,8 @@ match the crate that already emits the code. Do not invent a third spelling.
 ## KELD-MCP011
 
 - crate: keld-cli
-- message: Permissions manifest is not valid JSONC
-- fix: Fix the JSON (comments are allowed; trailing commas are not).
+- message: Permissions manifest is ambiguous, malformed, or exceeds 64 KiB
+- fix: Remove duplicate keys, fix the JSONC, or reduce the file to 64 KiB or less.
 
 ## KELD-MCP012
 
@@ -3923,8 +3930,8 @@ match the crate that already emits the code. Do not invent a third spelling.
 ## KELD-GUARD005
 
 - crate: keld-guard
-- message: Permissions manifest is not valid JSONC
-- fix: Fix the JSON (comments are allowed; trailing commas are not).
+- message: Permissions manifest is ambiguous or not valid JSONC
+- fix: Fix the JSON or remove duplicate object keys (comments are allowed; trailing commas are not).
 
 ## KELD-GUARD006
 
@@ -3985,6 +3992,12 @@ match the crate that already emits the code. Do not invent a third spelling.
 - crate: keld-guard
 - message: Strict archive row used the wrong layer or oracle (Display names recorded oracle, not only layer)
 - fix: Do not start a child and do not restart unsandboxed; keep requested=Strict or declare explicit Keld legacy.
+
+## KELD-GUARD017
+
+- crate: keld-guard
+- message: Permissions manifest exceeds the 64 KiB input limit
+- fix: Reduce keld.permissions.jsonc to 64 KiB or less and retry.
 
 ## KELD-DOCS001
 


### PR DESCRIPTION
## Summary

- reject duplicate JSON object keys recursively after decoding, including escaped-equivalent spellings and ignored/nested objects
- reject unterminated JSONC block comments and preserve CR, LF, and CRLF line-comment boundaries without joining adjacent tokens
- bound every in-memory and disk permissions manifest at 64 KiB; disk reads stop after exactly 64 KiB + 1 and return typed `KELD-GUARD017`
- keep `parse_manifest`, `load_manifest`, MCP permission explain, and the forthcoming KEL-102 verified loader on one parser contract

## Spec refs

- Linear: KEL-131
- Relation: must land before KEL-102 verified manifest startup authority (PR #115)
- Governing contract: `docs/architecture/03-security.md` §2
- Bug-fix scope; no separate feature spec required
- Base: `d9a2d1bf74e0b217a7340ffe322f5132e5ef9c69`
- Merge intent: `merge-when-CI-green` under the repository owner's explicit delegated instruction to proceed

## Review gates

- unsafe: none
- public API: yes — adds `ManifestError::TooLarge { path, max_bytes }`
- permission model: yes — ambiguous/oversized policy bytes can no longer become authority
- dependency addition: none; the implementation reuses Serde/serde_json already owned by `keld-guard`
- wire protocol: none
- existing abstraction reused: the one guard parser, existing `ManifestError`, existing MCP error object, and Serde's semantic decoder; no raw-text duplicate scanner or second parser
- CodeRabbit CLI 0.7.5 reviewed exact head `6e20e68e6ea4552777b92f0302e53bd249aae94e`; CR/CRLF and panic-safe temp-cleanup findings were fixed; final pass has 0 findings

## Tests

- failure-first on unfixed base: 3/3 new hostile-input tests failed (last-wins duplicate authority, unterminated-comment acceptance, and 64 KiB + 1 acceptance)
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo nextest run --workspace --profile ci` — 565 passed, 0 skipped
- `cargo nextest run -p keld-guard --profile ci` — 47 passed, 0 skipped
- CLI permission-focused tests — 14 passed
- error registry — 7 passed
- `just llms-check` and `just agents-md` — passed
- negative controls failed as required: restore serde_json last-wins decode; accept EOF block comment; loosen the 64 KiB acceptance boundary by one; read one byte beyond the bounded source limit

## Platforms

- CI-only parser contract; no real OS/device acceptance applies
- standard-library file/reader tests exercise real temporary disk input and bounded reads

## Perf impact

No speedup is claimed. Parsing remains cold-path work and is capped at 64 KiB. Duplicate detection adds one bounded semantic decode into `serde_json::Value` before the existing manifest conversion; disk input uses one fixed bounded buffer and never reads beyond 65,537 bytes.
