### PR TITLE
ci: enforce required merge admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,3 +387,46 @@ jobs:
       - name: Render Mermaid docs in pinned isolated container
         if: needs.changes.outputs.docs == 'true'
         run: tools/mermaid_render_check.sh
+
+  required:
+    name: CI required
+    if: ${{ always() }}
+    needs:
+      - changes
+      - fmt
+      - check
+      - bun-test
+      - linux-gui-smoke
+      - msrv
+      - deny
+      - secrets
+      - hygiene
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Verify required CI results
+        env:
+          KELD_RESULT_CHANGES: ${{ needs.changes.result }}
+          KELD_RESULT_FMT: ${{ needs.fmt.result }}
+          KELD_RESULT_CHECK: ${{ needs.check.result }}
+          KELD_RESULT_BUN: ${{ needs['bun-test'].result }}
+          KELD_RESULT_GUI: ${{ needs['linux-gui-smoke'].result }}
+          KELD_RESULT_MSRV: ${{ needs.msrv.result }}
+          KELD_RESULT_DENY: ${{ needs.deny.result }}
+          KELD_RESULT_SECRETS: ${{ needs.secrets.result }}
+          KELD_RESULT_HYGIENE: ${{ needs.hygiene.result }}
+        run: |
+          tools/ci_required.sh test
+          tools/ci_required.sh check \
+            "$KELD_RESULT_CHANGES" \
+            "$KELD_RESULT_FMT" \
+            "$KELD_RESULT_CHECK" \
+            "$KELD_RESULT_BUN" \
+            "$KELD_RESULT_GUI" \
+            "$KELD_RESULT_MSRV" \
+            "$KELD_RESULT_DENY" \
+            "$KELD_RESULT_SECRETS" \
+            "$KELD_RESULT_HYGIENE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,6 +418,13 @@ jobs:
           KELD_RESULT_DENY: ${{ needs.deny.result }}
           KELD_RESULT_SECRETS: ${{ needs.secrets.result }}
           KELD_RESULT_HYGIENE: ${{ needs.hygiene.result }}
+          KELD_ROUTE_RUST: ${{ needs.changes.outputs.rust }}
+          KELD_ROUTE_TS: ${{ needs.changes.outputs.ts }}
+          KELD_ROUTE_GUI: ${{ needs.changes.outputs.gui }}
+          KELD_ROUTE_MSRV: ${{ needs.changes.outputs.msrv }}
+          KELD_ROUTE_DENY: ${{ needs.changes.outputs.deny }}
+          KELD_ROUTE_HYGIENE: ${{ needs.changes.outputs.hygiene }}
+          KELD_ROUTE_DOCS: ${{ needs.changes.outputs.docs }}
         run: |
           tools/ci_required.sh test
           tools/ci_required.sh check \
@@ -429,4 +436,11 @@ jobs:
             "$KELD_RESULT_MSRV" \
             "$KELD_RESULT_DENY" \
             "$KELD_RESULT_SECRETS" \
-            "$KELD_RESULT_HYGIENE"
+            "$KELD_RESULT_HYGIENE" \
+            "$KELD_ROUTE_RUST" \
+            "$KELD_ROUTE_TS" \
+            "$KELD_ROUTE_GUI" \
+            "$KELD_ROUTE_MSRV" \
+            "$KELD_ROUTE_DENY" \
+            "$KELD_ROUTE_HYGIENE" \
+            "$KELD_ROUTE_DOCS"

--- a/.github/workflows/keldbot.yml
+++ b/.github/workflows/keldbot.yml
@@ -20,7 +20,6 @@ permissions: {}                  # DEFAULT-DENY! Har job apna kaam ROBOKELD_TOKE
 
 jobs:
   gatekeeper:                    # job ka internal naam
-    if: github.event.action != 'synchronize'   # template sirf opened/edited pe check karo, har push pe nahi
     runs-on: ubuntu-latest       # GitHub ki free VM — Linux box
     steps:
       - name: Check PR template sections
@@ -141,7 +140,6 @@ jobs:
             core.info(`${changed} lines changed -> ${tier.name}`);
 
   title-lint:                    # teesra job — PR title ko conventional-commit format se match karo
-    if: github.event.action != 'synchronize'   # title sirf opened/edited pe badalta hai, har push pe nahi
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title format

--- a/tools/ci_changes.sh
+++ b/tools/ci_changes.sh
@@ -415,22 +415,12 @@ classify_path() {
             docs="$TRUE"
             ;;
 
-        # The router and ci.yml decide which jobs execute. Any edit here must
-        # exercise every conditional lane, otherwise a classification defect can
-        # hide the very job that would expose it.
-        .github/workflows/ci.yml | tools/ci_changes.sh | tools/ci_changes_test.sh | tools/ci_required.sh)
+        # The router, merge evaluator, and every workflow can change the
+        # repository's automation or required-check surface. Any edit here must
+        # exercise every conditional lane, otherwise a workflow can introduce a
+        # false-green check while skipping the contracts that would expose it.
+        .github/workflows/* | tools/ci_changes.sh | tools/ci_changes_test.sh | tools/ci_required.sh)
             mark_all
-            ;;
-
-        # KeldBot owns required PR metadata checks. It cannot affect product
-        # compilation, but the hygiene lane reads and validates that workflow.
-        .github/workflows/keldbot.yml)
-            hygiene="$TRUE"
-            ;;
-
-        # Any other workflow file has no path into the Rust workspace, GUI, or
-        # either repository-owned required workflow. Nothing to mark.
-        .github/workflows/*)
             ;;
 
         # Workspace and toolchain inputs can alter every Rust build, keld-host's

--- a/tools/ci_changes.sh
+++ b/tools/ci_changes.sh
@@ -418,15 +418,18 @@ classify_path() {
         # The router and ci.yml decide which jobs execute. Any edit here must
         # exercise every conditional lane, otherwise a classification defect can
         # hide the very job that would expose it.
-        .github/workflows/ci.yml | tools/ci_changes.sh | tools/ci_changes_test.sh)
+        .github/workflows/ci.yml | tools/ci_changes.sh | tools/ci_changes_test.sh | tools/ci_required.sh)
             mark_all
             ;;
 
-        # Any other workflow file (e.g. an unrelated bot automation) has no path
-        # into the Rust workspace, GUI, or the ci.yml router itself -- ci_hygiene.rs
-        # only reads .github/workflows/ci.yml by name, so it cannot validate these
-        # either. Nothing to mark; a diff touching only such a file legitimately
-        # needs no conditional lane.
+        # KeldBot owns required PR metadata checks. It cannot affect product
+        # compilation, but the hygiene lane reads and validates that workflow.
+        .github/workflows/keldbot.yml)
+            hygiene="$TRUE"
+            ;;
+
+        # Any other workflow file has no path into the Rust workspace, GUI, or
+        # either repository-owned required workflow. Nothing to mark.
         .github/workflows/*)
             ;;
 

--- a/tools/ci_changes_test.sh
+++ b/tools/ci_changes_test.sh
@@ -163,12 +163,12 @@ expect_flags "workflow input exercises all jobs; GTK apt stays on GUI smoke only
 expect_output_package_token "workflow input exercises the Bun lane over every suite" ts_packages packages/@keld/electron "$workflow_classification"
 
 keldbot_workflow_classification="$(result_for_paths .github/workflows/keldbot.yml)"
-expect_flags "KeldBot workflow runs the hygiene contract only" "$hygiene_only" "$keldbot_workflow_classification"
-expect_empty_packages "KeldBot workflow selects no package" "$keldbot_workflow_classification"
+expect_flags "KeldBot workflow exercises every conditional lane" "$workflow_all" "$keldbot_workflow_classification"
+expect_output_package_token "KeldBot workflow exercises the Bun lane over every suite" ts_packages packages/@keld/electron "$keldbot_workflow_classification"
 
 other_workflow_classification="$(result_for_paths .github/workflows/unrelated-bot.yml)"
-expect_flags "unrelated bot workflow has no path into any conditional lane" "$all_false" "$other_workflow_classification"
-expect_empty_packages "unrelated bot workflow selects no package" "$other_workflow_classification"
+expect_flags "every workflow edit exercises every conditional lane" "$workflow_all" "$other_workflow_classification"
+expect_output_package_token "new workflow exercises the Bun lane over every suite" ts_packages packages/@keld/electron "$other_workflow_classification"
 
 router_script_classification="$(result_for_paths tools/ci_changes.sh)"
 expect_flags "router script edit still exercises all jobs" "$workflow_all" "$router_script_classification"

--- a/tools/ci_changes_test.sh
+++ b/tools/ci_changes_test.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
 router="$repo_root/tools/ci_changes.sh"
+required="$repo_root/tools/ci_required.sh"
+
+"$required" test
 
 result_for_paths() {
     printf '%s\0' "$@" | "$router" classify
@@ -159,7 +162,11 @@ workflow_classification="$(result_for_paths .github/workflows/ci.yml)"
 expect_flags "workflow input exercises all jobs; GTK apt stays on GUI smoke only" "$workflow_all" "$workflow_classification"
 expect_output_package_token "workflow input exercises the Bun lane over every suite" ts_packages packages/@keld/electron "$workflow_classification"
 
-other_workflow_classification="$(result_for_paths .github/workflows/keldbot.yml)"
+keldbot_workflow_classification="$(result_for_paths .github/workflows/keldbot.yml)"
+expect_flags "KeldBot workflow runs the hygiene contract only" "$hygiene_only" "$keldbot_workflow_classification"
+expect_empty_packages "KeldBot workflow selects no package" "$keldbot_workflow_classification"
+
+other_workflow_classification="$(result_for_paths .github/workflows/unrelated-bot.yml)"
 expect_flags "unrelated bot workflow has no path into any conditional lane" "$all_false" "$other_workflow_classification"
 expect_empty_packages "unrelated bot workflow selects no package" "$other_workflow_classification"
 
@@ -168,6 +175,9 @@ expect_flags "router script edit still exercises all jobs" "$workflow_all" "$rou
 
 router_test_classification="$(result_for_paths tools/ci_changes_test.sh)"
 expect_flags "router test edit still exercises all jobs" "$workflow_all" "$router_test_classification"
+
+required_script_classification="$(result_for_paths tools/ci_required.sh)"
+expect_flags "required-result evaluator edit still exercises all jobs" "$workflow_all" "$required_script_classification"
 
 actual_host_dirs="$(cd "$repo_root" && "$router" host-dirs | sort)"
 for required_dir in crates/keld-host crates/keld-core crates/keld-guard crates/keld-ipc crates/keld-runtime crates/keld-wv; do

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -316,6 +316,174 @@ fn workflow_job_block<'a>(text: &'a str, job_name: &str) -> Option<String> {
     found.then_some(block)
 }
 
+fn workflow_job_sequence_values(block: &str, key: &str) -> Option<Vec<String>> {
+    let expected_key = format!("{key}:");
+    let mut sequence_indent = None;
+    let mut values = Vec::new();
+
+    for line in block.lines() {
+        let Some((indent, content)) = yaml_content(line) else {
+            continue;
+        };
+        if sequence_indent.is_none() {
+            if indent == 4 && content == expected_key {
+                sequence_indent = Some(indent);
+            }
+            continue;
+        }
+        let sequence = sequence_indent?;
+        if indent <= sequence {
+            break;
+        }
+        if indent == sequence + 2 {
+            values.push(content.strip_prefix("- ")?.to_owned());
+        }
+    }
+
+    sequence_indent.map(|_| values)
+}
+
+fn workflow_named_step_env_value(text: &str, step_name: &str, key: &str) -> Option<String> {
+    let expected_name = format!("- name: {step_name}");
+    let expected_key = format!("{key}:");
+    let mut step_indent = None;
+    let mut env_indent = None;
+
+    for line in text.lines() {
+        let Some((indent, content)) = yaml_content(line) else {
+            continue;
+        };
+        if step_indent.is_none() {
+            if content == expected_name {
+                step_indent = Some(indent);
+            }
+            continue;
+        }
+        let step = step_indent?;
+        if indent <= step {
+            break;
+        }
+        if env_indent.is_none() {
+            if content == "env:" {
+                env_indent = Some(indent);
+            }
+            continue;
+        }
+        let env = env_indent?;
+        if indent <= env {
+            return None;
+        }
+        if indent == env + 2 {
+            if let Some(value) = content.strip_prefix(&expected_key) {
+                return Some(value.trim().to_owned());
+            }
+        }
+    }
+    None
+}
+
+fn workflow_named_step_shell_commands(text: &str, step_name: &str) -> Option<Vec<String>> {
+    let expected_name = format!("- name: {step_name}");
+    let mut step_indent = None;
+    let mut run_indent = None;
+    let mut command_text = None::<String>;
+    let mut commands = Vec::new();
+
+    for line in text.lines() {
+        let Some((indent, content)) = yaml_content(line) else {
+            continue;
+        };
+        if step_indent.is_none() {
+            if content == expected_name {
+                step_indent = Some(indent);
+            }
+            continue;
+        }
+        let step = step_indent?;
+        if indent <= step {
+            break;
+        }
+        if run_indent.is_none() {
+            if content.starts_with("run: |") {
+                run_indent = Some(indent);
+                continue;
+            }
+            continue;
+        }
+        let run = run_indent?;
+        if indent <= run {
+            break;
+        }
+        if let Some(current) = command_text.as_mut() {
+            current.push(' ');
+            current.push_str(content.trim_end_matches('\\').trim_end());
+            if !content.ends_with('\\') {
+                commands.push(command_text.take()?);
+            }
+            continue;
+        }
+        let continued = content.ends_with('\\');
+        let command = content.trim_end_matches('\\').trim_end().to_owned();
+        if continued {
+            command_text = Some(command);
+        } else {
+            commands.push(command);
+        }
+    }
+    if let Some(command) = command_text {
+        if command.is_empty() {
+            return None;
+        }
+        commands.push(command);
+    }
+    run_indent.map(|_| commands)
+}
+
+fn workflow_job_level_property(block: &str, key: &str) -> Option<String> {
+    let expected_key = format!("{key}:");
+    for line in block.lines() {
+        let Some((indent, content)) = yaml_content(line) else {
+            continue;
+        };
+        if content == "steps:" {
+            return None;
+        }
+        if indent == 4 {
+            if let Some(value) = content.strip_prefix(&expected_key) {
+                return Some(value.trim().to_owned());
+            }
+        }
+    }
+    None
+}
+
+fn workflow_named_step_direct_keys(text: &str, step_name: &str) -> Option<Vec<String>> {
+    let expected_name = format!("- name: {step_name}");
+    let mut step_indent = None;
+    let mut keys = Vec::new();
+
+    for line in text.lines() {
+        let Some((indent, content)) = yaml_content(line) else {
+            continue;
+        };
+        if step_indent.is_none() {
+            if content == expected_name {
+                step_indent = Some(indent);
+            }
+            continue;
+        }
+        let step = step_indent?;
+        if indent <= step {
+            break;
+        }
+        if indent == step + 2 {
+            let (key, _) = content.split_once(':')?;
+            keys.push(key.trim().trim_matches(['\'', '"']).to_owned());
+        }
+    }
+    step_indent.map(|_| keys)
+}
+
 fn workflow_job_level_if(block: &str) -> Option<String> {
     for line in block.lines() {
         let Some((_indent, content)) = yaml_content(line) else {
@@ -500,39 +668,96 @@ fn check_required_job(text: &str) -> Result<(), String> {
             "CI-HYGIENE: `{WORKFLOW}` `required` must use job-level `if: ${{{{ always() }}}}`. Otherwise a failed/cancelled dependency skips the merge decision instead of making it fail."
         ));
     }
-    for needed in [
-        "- changes",
-        "- fmt",
-        "- check",
-        "- bun-test",
-        "- linux-gui-smoke",
-        "- msrv",
-        "- deny",
-        "- secrets",
-        "- hygiene",
+    if workflow_job_level_property(&block, "continue-on-error").is_some() {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `required` must not set `continue-on-error`; the merge decision must preserve a failing exit status."
+        ));
+    }
+    let evaluator_keys = workflow_named_step_direct_keys(&block, "Verify required CI results")
+        .unwrap_or_default();
+    if evaluator_keys != ["env", "run"] {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `required` evaluator step may contain only direct `env` and `run` keys; got `{}`. Conditions, custom shells, and continue-on-error can erase its failing status.",
+            evaluator_keys.join(", ")
+        ));
+    }
+    let expected_needs = [
+        "changes",
+        "fmt",
+        "check",
+        "bun-test",
+        "linux-gui-smoke",
+        "msrv",
+        "deny",
+        "secrets",
+        "hygiene",
+    ];
+    let actual_needs = workflow_job_sequence_values(&block, "needs").ok_or_else(|| {
+        format!(
+            "CI-HYGIENE: `{WORKFLOW}` `required` must declare a structured `needs` sequence."
+        )
+    })?;
+    if actual_needs != expected_needs {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `required.needs` must be exactly `{}`; got `{}`. The result must observe every routed lane plus unconditional gitleaks.",
+            expected_needs.join(", "),
+            actual_needs.join(", ")
+        ));
+    }
+    for (key, expression) in [
+        ("KELD_RESULT_CHANGES", "${{ needs.changes.result }}"),
+        ("KELD_RESULT_FMT", "${{ needs.fmt.result }}"),
+        ("KELD_RESULT_CHECK", "${{ needs.check.result }}"),
+        ("KELD_RESULT_BUN", "${{ needs['bun-test'].result }}"),
+        (
+            "KELD_RESULT_GUI",
+            "${{ needs['linux-gui-smoke'].result }}",
+        ),
+        ("KELD_RESULT_MSRV", "${{ needs.msrv.result }}"),
+        ("KELD_RESULT_DENY", "${{ needs.deny.result }}"),
+        ("KELD_RESULT_SECRETS", "${{ needs.secrets.result }}"),
+        ("KELD_RESULT_HYGIENE", "${{ needs.hygiene.result }}"),
+        ("KELD_ROUTE_RUST", "${{ needs.changes.outputs.rust }}"),
+        ("KELD_ROUTE_TS", "${{ needs.changes.outputs.ts }}"),
+        ("KELD_ROUTE_GUI", "${{ needs.changes.outputs.gui }}"),
+        ("KELD_ROUTE_MSRV", "${{ needs.changes.outputs.msrv }}"),
+        ("KELD_ROUTE_DENY", "${{ needs.changes.outputs.deny }}"),
+        (
+            "KELD_ROUTE_HYGIENE",
+            "${{ needs.changes.outputs.hygiene }}",
+        ),
+        ("KELD_ROUTE_DOCS", "${{ needs.changes.outputs.docs }}"),
     ] {
-        if !uncommented_line_contains(&block, needed) {
+        if workflow_named_step_env_value(&block, "Verify required CI results", key).as_deref()
+            != Some(expression)
+        {
             return Err(format!(
-                "CI-HYGIENE: `{WORKFLOW}` `required.needs` is missing `{needed}`. The required result must observe every routed lane plus unconditional gitleaks."
+                "CI-HYGIENE: `{WORKFLOW}` `required` must bind `{key}: {expression}` in the evaluator step's `env` mapping. Do not let a missing or spoofed handoff erase the merge gate."
             ));
         }
     }
-    for command in ["tools/ci_required.sh test", "tools/ci_required.sh check"] {
-        if !workflow_named_step_contains(&block, "Verify required CI results", command) {
-            return Err(format!(
-                "CI-HYGIENE: `{WORKFLOW}` `required` must execute `{command}` in `Verify required CI results`. Mentioning or running it in another job does not decide the exact head."
-            ));
-        }
-    }
-    for expression in [
-        "KELD_RESULT_BUN: ${{ needs['bun-test'].result }}",
-        "KELD_RESULT_GUI: ${{ needs['linux-gui-smoke'].result }}",
-    ] {
-        if !uncommented_line_contains(&block, expression) {
-            return Err(format!(
-                "CI-HYGIENE: `{WORKFLOW}` `required` is missing `{expression}`. Hyphenated job ids require bracket access in GitHub expressions; do not let a syntax error erase the merge gate."
-            ));
-        }
+    let expected_check_command = concat!(
+        "tools/ci_required.sh check ",
+        "\"$KELD_RESULT_CHANGES\" \"$KELD_RESULT_FMT\" \"$KELD_RESULT_CHECK\" ",
+        "\"$KELD_RESULT_BUN\" \"$KELD_RESULT_GUI\" \"$KELD_RESULT_MSRV\" ",
+        "\"$KELD_RESULT_DENY\" \"$KELD_RESULT_SECRETS\" \"$KELD_RESULT_HYGIENE\" ",
+        "\"$KELD_ROUTE_RUST\" \"$KELD_ROUTE_TS\" \"$KELD_ROUTE_GUI\" ",
+        "\"$KELD_ROUTE_MSRV\" \"$KELD_ROUTE_DENY\" \"$KELD_ROUTE_HYGIENE\" ",
+        "\"$KELD_ROUTE_DOCS\""
+    );
+    let expected_commands = [
+        "tools/ci_required.sh test".to_owned(),
+        expected_check_command.to_owned(),
+    ];
+    let actual_commands = workflow_named_step_shell_commands(
+        &block,
+        "Verify required CI results",
+    )
+    .unwrap_or_default();
+    if actual_commands != expected_commands {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `required` evaluator run block must contain only its self-test and the exact ordered 16-argument check, without control flow, reassignment, wrappers, or exit-status suppression."
+        ));
     }
     if !workflow_has_checkout_persist_credentials_false(&block) {
         return Err(format!(
@@ -1186,11 +1411,31 @@ mod tests {
             "          persist-credentials: false",
             "      - name: Verify required CI results",
             "        env:",
+            "          KELD_RESULT_CHANGES: ${{ needs.changes.result }}",
+            "          KELD_RESULT_FMT: ${{ needs.fmt.result }}",
+            "          KELD_RESULT_CHECK: ${{ needs.check.result }}",
             "          KELD_RESULT_BUN: ${{ needs['bun-test'].result }}",
             "          KELD_RESULT_GUI: ${{ needs['linux-gui-smoke'].result }}",
+            "          KELD_RESULT_MSRV: ${{ needs.msrv.result }}",
+            "          KELD_RESULT_DENY: ${{ needs.deny.result }}",
+            "          KELD_RESULT_SECRETS: ${{ needs.secrets.result }}",
+            "          KELD_RESULT_HYGIENE: ${{ needs.hygiene.result }}",
+            "          KELD_ROUTE_RUST: ${{ needs.changes.outputs.rust }}",
+            "          KELD_ROUTE_TS: ${{ needs.changes.outputs.ts }}",
+            "          KELD_ROUTE_GUI: ${{ needs.changes.outputs.gui }}",
+            "          KELD_ROUTE_MSRV: ${{ needs.changes.outputs.msrv }}",
+            "          KELD_ROUTE_DENY: ${{ needs.changes.outputs.deny }}",
+            "          KELD_ROUTE_HYGIENE: ${{ needs.changes.outputs.hygiene }}",
+            "          KELD_ROUTE_DOCS: ${{ needs.changes.outputs.docs }}",
             "        run: |",
             "          tools/ci_required.sh test",
-            "          tools/ci_required.sh check success skipped skipped skipped skipped skipped skipped success skipped",
+            "          tools/ci_required.sh check \\",
+            "            \"$KELD_RESULT_CHANGES\" \"$KELD_RESULT_FMT\" \"$KELD_RESULT_CHECK\" \\",
+            "            \"$KELD_RESULT_BUN\" \"$KELD_RESULT_GUI\" \"$KELD_RESULT_MSRV\" \\",
+            "            \"$KELD_RESULT_DENY\" \"$KELD_RESULT_SECRETS\" \"$KELD_RESULT_HYGIENE\" \\",
+            "            \"$KELD_ROUTE_RUST\" \"$KELD_ROUTE_TS\" \"$KELD_ROUTE_GUI\" \\",
+            "            \"$KELD_ROUTE_MSRV\" \"$KELD_ROUTE_DENY\" \\",
+            "            \"$KELD_ROUTE_HYGIENE\" \"$KELD_ROUTE_DOCS\"",
             "",
         ]
         .join("\n")
@@ -1300,6 +1545,150 @@ mod tests {
         );
         let error = check(temp.path()).expect_err("missing gitleaks dependency must fail");
         assert!(error.contains("secrets"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow()
+                .replacen("      - secrets\n", "", 1)
+                .replacen(
+                    "      - name: Verify required CI results\n        env:\n",
+                    "      - name: Verify required CI results\n        env:\n          SPOOF: '- secrets'\n",
+                    1,
+                ),
+        );
+        let error = check(temp.path()).expect_err("needs text in env must not count");
+        assert!(error.contains("secrets"), "{error}");
+    }
+
+    #[test]
+    fn required_result_must_receive_router_applicability() {
+        let temp = complete_fixture();
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "          KELD_ROUTE_RUST: ${{ needs.changes.outputs.rust }}\n",
+                "",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("missing router output must fail");
+        assert!(error.contains("KELD_ROUTE_RUST"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen("\"$KELD_ROUTE_TS\"", "false", 1),
+        );
+        let error = check(temp.path()).expect_err("unused router output must fail");
+        assert!(error.contains("16-argument"), "{error}");
+    }
+
+    #[test]
+    fn required_evaluator_text_must_be_executed() {
+        let temp = complete_fixture();
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "          tools/ci_required.sh check \\",
+                "          echo tools/ci_required.sh check \\",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("echoed evaluator text must fail");
+        assert!(error.contains("run block"), "{error}");
+    }
+
+    #[test]
+    fn required_evaluator_rejects_false_green_shell_shapes() {
+        let temp = complete_fixture();
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "          KELD_RESULT_SECRETS: ${{ needs.secrets.result }}",
+                "          KELD_RESULT_SECRETS: success",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("literal gitleaks success must fail");
+        assert!(error.contains("KELD_RESULT_SECRETS"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "            \"$KELD_ROUTE_HYGIENE\" \"$KELD_ROUTE_DOCS\"",
+                "            \"$KELD_ROUTE_HYGIENE\" \"$KELD_ROUTE_DOCS\" || true",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("exit-status suppression must fail");
+        assert!(error.contains("run block"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "      - name: Verify required CI results\n        env:",
+                "      - name: Verify required CI results\n        continue-on-error: true\n        env:",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("continue-on-error must fail");
+        assert!(error.contains("continue-on-error"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "  required:\n    name: CI required",
+                "  required:\n    name: CI required\n    continue-on-error: true",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("job continue-on-error must fail");
+        assert!(error.contains("continue-on-error"), "{error}");
+
+        for (property, label) in [
+            ("if: ${{ false }}", "skipped evaluator"),
+            ("shell: bash {0} || true", "failure-suppressing shell"),
+            ("\"if\": ${{ false }}", "quoted skipped evaluator"),
+            (
+                "\"shell\": bash {0} || true",
+                "quoted failure-suppressing shell",
+            ),
+        ] {
+            temp.write(
+                WORKFLOW,
+                &valid_workflow().replacen(
+                    "      - name: Verify required CI results\n        env:",
+                    &format!(
+                        "      - name: Verify required CI results\n        {property}\n        env:"
+                    ),
+                    1,
+                ),
+            );
+            let error = check(temp.path()).expect_err(label);
+            assert!(error.contains("only direct"), "{error}");
+        }
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "          tools/ci_required.sh check \\",
+                "          if false; then\n          tools/ci_required.sh check \\",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("unreachable check must fail");
+        assert!(error.contains("run block"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "          tools/ci_required.sh check \\",
+                "          KELD_RESULT_SECRETS=success\n          tools/ci_required.sh check \\",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("result reassignment must fail");
+        assert!(error.contains("run block"), "{error}");
     }
 
     #[test]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -13,6 +13,8 @@ const CODEOWNERS: &str = ".github/CODEOWNERS";
 const PR_TEMPLATE: &str = ".github/PULL_REQUEST_TEMPLATE.md";
 const ISSUE_DIR: &str = ".github/ISSUE_TEMPLATE";
 const WORKFLOW: &str = ".github/workflows/ci.yml";
+const KELDBOT_WORKFLOW: &str = ".github/workflows/keldbot.yml";
+const CI_REQUIRED_EVALUATOR: &str = "tools/ci_required.sh";
 const GITIGNORE: &str = ".gitignore";
 const NEXTEST_CONFIG: &str = ".config/nextest.toml";
 const MERMAID_CHECKER: &str = "tools/mermaid_docs.rs";
@@ -314,6 +316,21 @@ fn workflow_job_block<'a>(text: &'a str, job_name: &str) -> Option<String> {
     found.then_some(block)
 }
 
+fn workflow_job_level_if(block: &str) -> Option<String> {
+    for line in block.lines() {
+        let Some((_indent, content)) = yaml_content(line) else {
+            continue;
+        };
+        if content == "steps:" {
+            return None;
+        }
+        if let Some(value) = content.strip_prefix("if:") {
+            return Some(value.trim().to_owned());
+        }
+    }
+    None
+}
+
 fn check_change_router_job(text: &str) -> Result<(), String> {
     let Some(block) = workflow_job_block(text, "changes") else {
         return Err(format!(
@@ -462,6 +479,119 @@ fn check_bun_test_job(text: &str) -> Result<(), String> {
     if uncommented_line_contains(&block, "apt-get") {
         return Err(format!(
             "CI-HYGIENE: `{WORKFLOW}` `bun-test` must not call `apt-get`. Bun ships from `oven-sh/setup-bun`; a second live Ubuntu apt lane contends with Linux GUI smoke on the Azure mirrors."
+        ));
+    }
+    Ok(())
+}
+
+fn check_required_job(text: &str) -> Result<(), String> {
+    let Some(block) = workflow_job_block(text, "required") else {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` has no `required` job. Add one always-created merge-admission result that consumes every conditional lane plus unconditional gitleaks."
+        ));
+    };
+    if !uncommented_line_contains(&block, "name: CI required") {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `required` must publish the stable check name `CI required` for branch protection."
+        ));
+    }
+    if workflow_job_level_if(&block).as_deref() != Some("${{ always() }}") {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `required` must use job-level `if: ${{{{ always() }}}}`. Otherwise a failed/cancelled dependency skips the merge decision instead of making it fail."
+        ));
+    }
+    for needed in [
+        "- changes",
+        "- fmt",
+        "- check",
+        "- bun-test",
+        "- linux-gui-smoke",
+        "- msrv",
+        "- deny",
+        "- secrets",
+        "- hygiene",
+    ] {
+        if !uncommented_line_contains(&block, needed) {
+            return Err(format!(
+                "CI-HYGIENE: `{WORKFLOW}` `required.needs` is missing `{needed}`. The required result must observe every routed lane plus unconditional gitleaks."
+            ));
+        }
+    }
+    for command in ["tools/ci_required.sh test", "tools/ci_required.sh check"] {
+        if !workflow_named_step_contains(&block, "Verify required CI results", command) {
+            return Err(format!(
+                "CI-HYGIENE: `{WORKFLOW}` `required` must execute `{command}` in `Verify required CI results`. Mentioning or running it in another job does not decide the exact head."
+            ));
+        }
+    }
+    for expression in [
+        "KELD_RESULT_BUN: ${{ needs['bun-test'].result }}",
+        "KELD_RESULT_GUI: ${{ needs['linux-gui-smoke'].result }}",
+    ] {
+        if !uncommented_line_contains(&block, expression) {
+            return Err(format!(
+                "CI-HYGIENE: `{WORKFLOW}` `required` is missing `{expression}`. Hyphenated job ids require bracket access in GitHub expressions; do not let a syntax error erase the merge gate."
+            ));
+        }
+    }
+    if !workflow_has_checkout_persist_credentials_false(&block) {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `required` checkout must set `persist-credentials: false`; the merge-decision job needs repository bytes, not push authority."
+        ));
+    }
+    Ok(())
+}
+
+fn check_keldbot_workflow(root: &Path) -> Result<(), String> {
+    let text = read(root, KELDBOT_WORKFLOW)?;
+    for needle in [
+        "pull_request_target:",
+        "types: [opened, edited, synchronize]",
+        "permissions: {}",
+    ] {
+        if !uncommented_line_contains(&text, needle) {
+            return Err(format!(
+                "CI-HYGIENE: `{KELDBOT_WORKFLOW}` is missing `{needle}`. Keep final-head metadata validation on opened, edited, and synchronize with a default-deny token."
+            ));
+        }
+    }
+    if uncommented_line_contains(&text, "actions/checkout@")
+        || uncommented_line_contains(&text, "run:")
+    {
+        return Err(format!(
+            "CI-HYGIENE: `{KELDBOT_WORKFLOW}` uses `pull_request_target` with a repository checkout or shell `run:` step. Keep PR-controlled code off this secret-bearing workflow; validate proposed workflow bytes in unprivileged CI instead."
+        ));
+    }
+    for job in ["gatekeeper", "title-lint"] {
+        let Some(block) = workflow_job_block(&text, job) else {
+            return Err(format!(
+                "CI-HYGIENE: `{KELDBOT_WORKFLOW}` has no `{job}` job. Restore the required PR metadata check."
+            ));
+        };
+        if let Some(condition) = workflow_job_level_if(&block) {
+            return Err(format!(
+                "CI-HYGIENE: `{KELDBOT_WORKFLOW}` `{job}` has job-level `if: {condition}`. Required metadata checks must run again on synchronize; a skipped job satisfies branch protection without revalidating the final head."
+            ));
+        }
+    }
+    for heading in [
+        "Summary",
+        "Spec refs",
+        "Review gates",
+        "Tests",
+        "Platforms",
+        "Perf impact",
+    ] {
+        if !text.contains(&format!("\"{heading}\"")) {
+            return Err(format!(
+                "CI-HYGIENE: `{KELDBOT_WORKFLOW}` gatekeeper omits required PR heading `{heading}`. Keep it aligned with `{PR_TEMPLATE}`."
+            ));
+        }
+    }
+    let unpinned = action_uses_unpinned(&text);
+    if !unpinned.is_empty() {
+        return Err(format!(
+            "CI-HYGIENE: `{KELDBOT_WORKFLOW}` has unpinned `uses:` entries. Pin every action to a 40-character commit SHA; offenders: {unpinned:?}"
         ));
     }
     Ok(())
@@ -729,7 +859,11 @@ fn gate_section_setting_retries(text: &str) -> Option<String> {
             }
             continue;
         }
-        if line.split('=').next().is_some_and(|key| key.trim() == "retries") {
+        if line
+            .split('=')
+            .next()
+            .is_some_and(|key| key.trim() == "retries")
+        {
             if let Some(header) = current.clone() {
                 return Some(header);
             }
@@ -811,6 +945,7 @@ fn check_issue_templates(root: &Path) -> Result<(), String> {
 
 fn check_workflow(root: &Path) -> Result<(), String> {
     let text = read(root, WORKFLOW)?;
+    let _required_evaluator = read(root, CI_REQUIRED_EVALUATOR)?;
     for needle in WORKFLOW_TEXT_NEEDLES {
         if !uncommented_line_contains(&text, needle) {
             return Err(format!(
@@ -832,6 +967,7 @@ fn check_workflow(root: &Path) -> Result<(), String> {
     check_check_job_if_avoids_matrix(&text)?;
     check_msrv_avoids_apt(&text)?;
     check_bun_test_job(&text)?;
+    check_required_job(&text)?;
     for needle in WORKFLOW_RUN_NEEDLES {
         if !workflow_has_executable_run_needle(&text, needle) {
             return Err(format!(
@@ -902,6 +1038,7 @@ fn check(root: &Path) -> Result<(), String> {
     check_pr_template(root)?;
     check_issue_templates(root)?;
     check_workflow(root)?;
+    check_keldbot_workflow(root)?;
     check_mermaid_gate_files(root)?;
     Ok(())
 }
@@ -1030,6 +1167,57 @@ mod tests {
             "      - run: rustc --edition=2024 --test tools/mermaid_docs.rs",
             "      - run: mermaid-docs check .",
             "      - run: tools/mermaid_render_check.sh # sha256:29077c6bd02f14bdfdd5fee552d9c00fe68d4fab3cd84952d21e2d1faf2fadaf",
+            "  required:",
+            "    name: CI required",
+            "    if: ${{ always() }}",
+            "    needs:",
+            "      - changes",
+            "      - fmt",
+            "      - check",
+            "      - bun-test",
+            "      - linux-gui-smoke",
+            "      - msrv",
+            "      - deny",
+            "      - secrets",
+            "      - hygiene",
+            "    steps:",
+            "      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
+            "        with:",
+            "          persist-credentials: false",
+            "      - name: Verify required CI results",
+            "        env:",
+            "          KELD_RESULT_BUN: ${{ needs['bun-test'].result }}",
+            "          KELD_RESULT_GUI: ${{ needs['linux-gui-smoke'].result }}",
+            "        run: |",
+            "          tools/ci_required.sh test",
+            "          tools/ci_required.sh check success skipped skipped skipped skipped skipped skipped success skipped",
+            "",
+        ]
+        .join("\n")
+    }
+
+    fn valid_keldbot_workflow() -> String {
+        [
+            "name: KeldBot",
+            "on:",
+            "  pull_request_target:",
+            "    types: [opened, edited, synchronize]",
+            "permissions: {}",
+            "jobs:",
+            "  gatekeeper:",
+            "    runs-on: ubuntu-latest",
+            "    steps:",
+            "      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0",
+            "        with:",
+            "          script: |",
+            "            const REQUIRED = [\"Summary\", \"Spec refs\", \"Review gates\", \"Tests\", \"Platforms\", \"Perf impact\"];",
+            "  title-lint:",
+            "    runs-on: ubuntu-latest",
+            "    steps:",
+            "      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0",
+            "        with:",
+            "          script: |",
+            "            core.info('title');",
             "",
         ]
         .join("\n")
@@ -1064,6 +1252,8 @@ mod tests {
             "name: Bug\nbody:\n  - type: markdown\n",
         );
         temp.write(WORKFLOW, &valid_workflow());
+        temp.write(KELDBOT_WORKFLOW, &valid_keldbot_workflow());
+        temp.write(CI_REQUIRED_EVALUATOR, "#!/usr/bin/env bash\nexit 0\n");
         temp.write(MERMAID_CHECKER, "fn main() {}\n");
         temp.write(NEXTEST_CONFIG, "[profile.ci]\n");
         temp.write(
@@ -1081,6 +1271,72 @@ mod tests {
     fn complete_fixture_passes() {
         let temp = complete_fixture();
         check(temp.path()).expect("complete KEL-39 fixture must pass");
+    }
+
+    #[test]
+    fn required_result_job_is_mandatory_and_always_created() {
+        let temp = complete_fixture();
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen("  required:\n", "  removed-required:\n", 1),
+        );
+        let error = check(temp.path()).expect_err("missing required result must fail");
+        assert!(error.contains("required"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen("    if: ${{ always() }}", "    if: ${{ success() }}", 1),
+        );
+        let error = check(temp.path()).expect_err("non-always required result must fail");
+        assert!(error.contains("always"), "{error}");
+    }
+
+    #[test]
+    fn required_result_must_observe_unconditional_gitleaks() {
+        let temp = complete_fixture();
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen("      - secrets\n", "", 1),
+        );
+        let error = check(temp.path()).expect_err("missing gitleaks dependency must fail");
+        assert!(error.contains("secrets"), "{error}");
+    }
+
+    #[test]
+    fn keldbot_required_jobs_revalidate_synchronized_heads() {
+        let temp = complete_fixture();
+        temp.write(
+            KELDBOT_WORKFLOW,
+            &valid_keldbot_workflow().replacen(
+                "  gatekeeper:\n",
+                "  gatekeeper:\n    if: github.event.action != 'synchronize'\n",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("skipped gatekeeper must fail");
+        assert!(error.contains("synchronize"), "{error}");
+
+        temp.write(
+            KELDBOT_WORKFLOW,
+            &valid_keldbot_workflow().replace(", synchronize", ""),
+        );
+        let error = check(temp.path()).expect_err("missing synchronize trigger must fail");
+        assert!(error.contains("synchronize"), "{error}");
+    }
+
+    #[test]
+    fn keldbot_pull_request_target_never_checks_out_or_runs_pr_code() {
+        let temp = complete_fixture();
+        temp.write(
+            KELDBOT_WORKFLOW,
+            &valid_keldbot_workflow().replacen(
+                "    steps:\n",
+                "    steps:\n      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262\n",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("secret-bearing checkout must fail");
+        assert!(error.contains("checkout"), "{error}");
     }
 
     #[test]
@@ -1135,8 +1391,8 @@ mod tests {
                 NEXTEST_CONFIG,
                 &format!("[profile.ci]\n\n{header}\ncount = 2\nbackoff = \"fixed\"\n"),
             );
-            let error = check(temp.path())
-                .expect_err("a retries sub-table retries the mandated gate");
+            let error =
+                check(temp.path()).expect_err("a retries sub-table retries the mandated gate");
             assert!(error.contains(header), "{error}");
         }
     }
@@ -1175,7 +1431,10 @@ mod tests {
         // A message hard-coding `[profile.ci]` sends the reader to the wrong
         // line when the key is under the profile `ci` inherits.
         let temp = complete_fixture();
-        temp.write(NEXTEST_CONFIG, "[profile.default]\nretries = 2\n\n[profile.ci]\n");
+        temp.write(
+            NEXTEST_CONFIG,
+            "[profile.default]\nretries = 2\n\n[profile.ci]\n",
+        );
         let error = check(temp.path()).expect_err("inherited retries bind the gate");
         assert!(error.contains("[profile.default]"), "{error}");
         assert!(
@@ -1195,8 +1454,8 @@ mod tests {
             NEXTEST_CONFIG,
             "[profile.shared]\nretries = 2\n\n[profile.ci]\ninherits = \"shared\"\n",
         );
-        let error = check(temp.path())
-            .expect_err("a parent this check cannot follow must fail closed");
+        let error =
+            check(temp.path()).expect_err("a parent this check cannot follow must fail closed");
         assert!(error.contains("shared"), "{error}");
         assert!(error.contains("cannot follow"), "{error}");
     }
@@ -1244,7 +1503,10 @@ mod tests {
     #[test]
     fn commented_out_retries_is_not_a_retry() {
         let temp = complete_fixture();
-        temp.write(NEXTEST_CONFIG, "[profile.ci]\n# retries = 1 (removed, KEL-112)\n");
+        temp.write(
+            NEXTEST_CONFIG,
+            "[profile.ci]\n# retries = 1 (removed, KEL-112)\n",
+        );
         check(temp.path()).expect("a comment is documentation, not configuration");
     }
 

--- a/tools/ci_required.sh
+++ b/tools/ci_required.sh
@@ -15,32 +15,51 @@ require_success() {
     fi
 }
 
-require_success_or_skip() {
+require_routed_result() {
     local label="$1"
     local result="$2"
-    case "$result" in
-        success | skipped) ;;
+    local selected="$3"
+    case "$selected" in
+        true)
+            require_success "$label" "$result"
+            ;;
+        false)
+            if [[ "$result" != "skipped" ]]; then
+                fail "$label must report skipped when the router marks it inapplicable, got '$result'. Keep the job condition and router output aligned."
+            fi
+            ;;
         *)
-            fail "$label must succeed when selected or report skipped when the router proves it inapplicable, got '$result'. Fix or re-run the exact failing head."
+            fail "$label received invalid router applicability '$selected'. The router must emit exactly 'true' or 'false'."
             ;;
     esac
 }
 
 check_results() {
-    if [[ "$#" -ne 9 ]]; then
-        fail "expected 9 job results (changes, fmt, check, bun-test, linux-gui-smoke, msrv, deny, secrets, hygiene), got $#; restore the required job's complete needs handoff."
+    if [[ "$#" -ne 16 ]]; then
+        fail "expected 9 job results plus 7 router outputs, got $#; restore the required job's complete needs and applicability handoff."
         return
     fi
 
     require_success "change router" "$1" || return 1
-    require_success_or_skip "rustfmt" "$2" || return 1
-    require_success_or_skip "cross-platform clippy + test" "$3" || return 1
-    require_success_or_skip "Bun TypeScript tests" "$4" || return 1
-    require_success_or_skip "Linux GUI smoke" "$5" || return 1
-    require_success_or_skip "MSRV" "$6" || return 1
-    require_success_or_skip "cargo-deny" "$7" || return 1
+    require_routed_result "rustfmt" "$2" "${10}" || return 1
+    require_routed_result "cross-platform clippy + test" "$3" "${10}" || return 1
+    require_routed_result "Bun TypeScript tests" "$4" "${11}" || return 1
+    require_routed_result "Linux GUI smoke" "$5" "${12}" || return 1
+    require_routed_result "MSRV" "$6" "${13}" || return 1
+    require_routed_result "cargo-deny" "$7" "${14}" || return 1
     require_success "gitleaks" "$8" || return 1
-    require_success_or_skip "documentation and repository hygiene" "$9" || return 1
+    case "${15}:${16}" in
+        true:true | true:false | false:true)
+            require_routed_result "documentation and repository hygiene" "$9" true || return 1
+            ;;
+        false:false)
+            require_routed_result "documentation and repository hygiene" "$9" false || return 1
+            ;;
+        *)
+            fail "documentation and repository hygiene received invalid router applicability '${15}:${16}'. Both router outputs must be exactly 'true' or 'false'."
+            return 1
+            ;;
+    esac
 }
 
 expect_pass() {
@@ -61,20 +80,36 @@ expect_fail() {
 
 self_test() {
     expect_pass "all applicable jobs succeed" \
-        success success success success success success success success success
+        success success success success success success success success success \
+        true true true true true true true
     expect_pass "router-proven inapplicable jobs skip" \
-        success skipped skipped skipped skipped skipped skipped success skipped
+        success skipped skipped skipped skipped skipped skipped success skipped \
+        false false false false false false false
 
     expect_fail "missing gitleaks is not green" \
-        success skipped skipped skipped skipped skipped skipped skipped skipped
+        success skipped skipped skipped skipped skipped skipped skipped skipped \
+        false false false false false false false
     expect_fail "cancelled gitleaks is not green" \
-        success skipped skipped skipped skipped skipped skipped cancelled skipped
+        success skipped skipped skipped skipped skipped skipped cancelled skipped \
+        false false false false false false false
     expect_fail "failed selected test is not green" \
-        success success failure skipped skipped success skipped success success
+        success success failure skipped skipped success skipped success success \
+        true false false true false true false
+    expect_fail "selected job cannot disappear as skipped" \
+        success skipped skipped skipped skipped skipped skipped success skipped \
+        true false false false false false false
+    expect_fail "unselected job cannot silently run" \
+        success success skipped skipped skipped skipped skipped success skipped \
+        false false false false false false false
+    expect_fail "invalid router output is not evidence" \
+        success skipped skipped skipped skipped skipped skipped success skipped \
+        missing false false false false false false
     expect_fail "cancelled router cannot skip everything green" \
-        cancelled skipped skipped skipped skipped skipped skipped success skipped
+        cancelled skipped skipped skipped skipped skipped skipped success skipped \
+        false false false false false false false
     expect_fail "missing result handoff is rejected" \
-        success skipped skipped skipped skipped skipped skipped success
+        success skipped skipped skipped skipped skipped skipped success skipped \
+        false false false false false false
 
     echo "ci-required contract tests ok"
 }
@@ -93,7 +128,7 @@ case "${1:-}" in
         self_test
         ;;
     *)
-        fail "unknown or missing command '${1:-}'. Use 'check' with 9 job results, or 'test'."
+        fail "unknown or missing command '${1:-}'. Use 'check' with 9 job results and 7 router outputs, or 'test'."
         exit 1
         ;;
 esac

--- a/tools/ci_required.sh
+++ b/tools/ci_required.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# One observable merge-admission decision over the jobs in ci.yml.
+set -euo pipefail
+
+fail() {
+    echo "CI-REQUIRED: $1" >&2
+    return 1
+}
+
+require_success() {
+    local label="$1"
+    local result="$2"
+    if [[ "$result" != "success" ]]; then
+        fail "$label must succeed, got '$result'. Re-run the exact head after the CI service is healthy; do not treat missing, skipped, cancelled, or failed evidence as a pass."
+    fi
+}
+
+require_success_or_skip() {
+    local label="$1"
+    local result="$2"
+    case "$result" in
+        success | skipped) ;;
+        *)
+            fail "$label must succeed when selected or report skipped when the router proves it inapplicable, got '$result'. Fix or re-run the exact failing head."
+            ;;
+    esac
+}
+
+check_results() {
+    if [[ "$#" -ne 9 ]]; then
+        fail "expected 9 job results (changes, fmt, check, bun-test, linux-gui-smoke, msrv, deny, secrets, hygiene), got $#; restore the required job's complete needs handoff."
+        return
+    fi
+
+    require_success "change router" "$1" || return 1
+    require_success_or_skip "rustfmt" "$2" || return 1
+    require_success_or_skip "cross-platform clippy + test" "$3" || return 1
+    require_success_or_skip "Bun TypeScript tests" "$4" || return 1
+    require_success_or_skip "Linux GUI smoke" "$5" || return 1
+    require_success_or_skip "MSRV" "$6" || return 1
+    require_success_or_skip "cargo-deny" "$7" || return 1
+    require_success "gitleaks" "$8" || return 1
+    require_success_or_skip "documentation and repository hygiene" "$9" || return 1
+}
+
+expect_pass() {
+    local label="$1"
+    shift
+    if ! check_results "$@" >/dev/null 2>&1; then
+        fail "self-test '$label' unexpectedly failed"
+    fi
+}
+
+expect_fail() {
+    local label="$1"
+    shift
+    if check_results "$@" >/dev/null 2>&1; then
+        fail "self-test '$label' unexpectedly passed"
+    fi
+}
+
+self_test() {
+    expect_pass "all applicable jobs succeed" \
+        success success success success success success success success success
+    expect_pass "router-proven inapplicable jobs skip" \
+        success skipped skipped skipped skipped skipped skipped success skipped
+
+    expect_fail "missing gitleaks is not green" \
+        success skipped skipped skipped skipped skipped skipped skipped skipped
+    expect_fail "cancelled gitleaks is not green" \
+        success skipped skipped skipped skipped skipped skipped cancelled skipped
+    expect_fail "failed selected test is not green" \
+        success success failure skipped skipped success skipped success success
+    expect_fail "cancelled router cannot skip everything green" \
+        cancelled skipped skipped skipped skipped skipped skipped success skipped
+    expect_fail "missing result handoff is rejected" \
+        success skipped skipped skipped skipped skipped skipped success
+
+    echo "ci-required contract tests ok"
+}
+
+case "${1:-}" in
+    check)
+        shift
+        check_results "$@"
+        echo "ci-required ok"
+        ;;
+    test)
+        if [[ "$#" -ne 1 ]]; then
+            fail "test takes no additional arguments. Run 'tools/ci_required.sh test'."
+            exit 1
+        fi
+        self_test
+        ;;
+    *)
+        fail "unknown or missing command '${1:-}'. Use 'check' with 9 job results, or 'test'."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Add one always-created `CI required` result over every routed lane plus unconditional gitleaks.
- Revalidate KeldBot title/template checks on every synchronized final head.
- Bind router applicability to result status and structurally reject false-green YAML/shell shapes.
- Preserve an explicit human outage decision as governance work; this PR does not misclassify PR #97 as unreviewed or accidental.

## Spec refs

No boundary change. KEL-81 CI routing contract; KEL-128 merge-admission contract.

## Review gates

none

CI workflows and repository gate tooling are shared human-review files.

## Tests

- `cargo fmt --all --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo nextest run --workspace --profile ci` — 558 passed, 0 skipped
- `bun test` in `packages/@keld/electron` — 32 passed, 0 failed
- `tools/ci_required.sh test` — passed
- `tools/ci_changes_test.sh` — passed all router/event/fail-safe cases
- `tools/ci_hygiene.rs` — 61 passed, 0 failed; checkout check passed
- rustdoc, cargo-deny, llms tests/check, Mermaid tests/check, agents-md — passed
- CodeRabbit CLI pre-final reviews — 0 findings; current-tip review rate-limited
- Current-head adversarial isolated-context review — clean after all findings were fixed and re-falsified (PR comment has exact controls)

## Platforms

Local verification: macOS 26.5.1 arm64. The workflow/router edit deliberately schedules all conditional CI lanes; Ubuntu, macOS, and Windows results are required before merge. No product OS acceptance applies.

## Perf impact

No application-runtime impact. One small Ubuntu aggregation job runs after existing CI jobs; KeldBot rechecks unchanged title/body metadata on synchronize.

## Linear

KEL-128. Parent convergence graph: KEL-127. KEL-146 records a separate pre-existing macOS guardian test-oracle defect exposed by the new aggregate gate.
