### PR TITLE
docs(process): require atomic problem decomposition

### DIFF
--- a/.agents/index.md
+++ b/.agents/index.md
@@ -16,7 +16,7 @@ do not silently choose the less restrictive rule.
 
 | Task or path | Read |
 |---|---|
-| Any implementation or review | Root `AGENTS.md`, [`docs/agents/workflow.md`](../docs/agents/workflow.md), relevant architecture section, nearest crate `AGENTS.md`, and [`docs/agents/learnings.md`](../docs/agents/learnings.md) |
+| Any non-trivial design, diagnosis, review, or implementation | Root `AGENTS.md` § Atomic problem-solving protocol, [`docs/agents/workflow.md`](../docs/agents/workflow.md), relevant architecture section, nearest crate `AGENTS.md`, and [`docs/agents/learnings.md`](../docs/agents/learnings.md) |
 | Creating/using a git branch, opening a PR, or deciding merge intent across devices | Root `AGENTS.md` § Branch + Linear handoff (Prompt Tracker paste chrome: `0monish/prompt-tracker` `prompts/SHARED/branch-linear-handoff.md`) |
 | Starting work on an issue when another agent or device may also hold it | `docs/agents/workflow.md` § Agent claim |
 | Addressing CodeRabbit PR feedback or resolving review threads | Root `AGENTS.md` § Commits & PRs (CodeRabbit review threads); [`autofix/SKILL.md`](skills/autofix/SKILL.md) and [`autofix/github.md`](skills/autofix/github.md) § Resolve review threads |

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -6,6 +6,12 @@ evidence only when a plausible defect can make it fail.
 
 ## Failure-first proof
 
+- Root `AGENTS.md` § Atomic problem-solving protocol owns the decomposition. Before
+  selecting a regression, conformance, benchmark, or negative control, the author MUST
+  bind it to one named atom's observable contract and state why its oracle is independent
+  of the implementation and the other atoms. Every negative control MUST name the one
+  fault or mutation that falsifies that atom; one atom's pass MUST NOT stand in for proof
+  of another.
 - When feasible, a bug fix MUST first prove its regression test fails on the unfixed
   code and then passes with the fix. If that proof is infeasible, record the exact
   platform, environment, or historical limitation instead of implying it ran.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,13 @@ jobs:
         with:
           toolchain: 1.97.1
           components: rustfmt, clippy
+      - name: Atomic problem-solving protocol contract
+        run: |
+          mkdir -p target/atomic-protocol
+          rustc --edition=2024 -D warnings --test tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol-test
+          target/atomic-protocol/atomic-protocol-test
+          rustc --edition=2024 -D warnings tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol
+          target/atomic-protocol/atomic-protocol check .
       - name: Contract tests
         if: needs.changes.outputs.hygiene == 'true'
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,36 @@ The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in
 - Diagnose the root cause and keep execution scoped; park adjacent cleanup.
 - Ask one focused question only when a user-owned choice would materially change the result; otherwise take the smallest reversible path.
 
+## Atomic problem-solving protocol (MUST)
+
+Before selecting a design, answer or fix for any non-trivial design, diagnosis, review
+or implementation, agents MUST decompose the problem into atomic reasoning units. This
+is a decision input, not a retrospective explanation. Small obvious tasks MAY record it
+concisely, but no boundary or gate failure may skip it.
+
+1. **Decompose before deciding (MUST).** Split the problem into decision-bearing atoms
+   small enough that one observable can falsify each atom without relying on the final
+   conclusion.
+2. **State the logical component (MUST).** Each atom MUST name its owner, boundary and
+   inputs/outputs, failure mode, and observable contract.
+3. **Validate independence (MUST).** Changing or falsifying one atom MUST NOT silently
+   alter another. Hidden coupling MUST be promoted into its own atom or an explicit edge
+   between atoms.
+4. **Verify correctness (MUST).** Each atom MUST have direct evidence or a falsifiable
+   test or negative control. Prose, comments, mocks, or another atom's pass are not proof
+   of that atom.
+5. **Synthesize only after proof (MUST).** Agents MUST NOT synthesize an answer, design
+   or fix until every decision-bearing atom is passed, explicitly unknown, or named as a
+   blocker. If the synthesis contradicts a passed atom, agents MUST stop and correct the
+   model; they MUST NOT average away the contradiction.
+
+Performance decompositions MUST separate census, work, queue/copy, clock, statistic and
+artifact. Security decompositions MUST separate identity, authentication, authorization,
+OS containment, lifecycle/revocation and evidence provenance.
+
+Enforcement: `just atomic-protocol` validates the canonical stages and the narrower
+workflow, testing and routing references. It MUST pass after changing any of those files.
+
 ## Engineering principles — non-negotiable
 
 For every architecture, public-contract, process, IPC, permission, lifecycle or
@@ -34,9 +64,10 @@ language rewrite, and a passing happy path are not evidence that a design is cor
 secure or fast. For smaller changes, agents MUST state `No boundary change` when that
 distinction would otherwise be ambiguous.
 
-1. **Start from facts, not analogies.** Decompose the change into ownership, process,
-   memory, I/O, lifecycle, trust and failure facts. State who owns each handle, who can
-   mint each identity, what can crash independently, where copies/queues occur, and
+1. **Start from facts, not analogies.** Apply the Atomic problem-solving protocol above.
+   For Keld architecture and public-contract work, the atoms MUST cover ownership,
+   process, memory, I/O, lifecycle, trust and failure facts: who owns each handle, who
+   can mint each identity, what can crash independently, where copies/queues occur, and
    what observable contract proves the result. An unmeasured performance claim or an
    uncited platform assumption MUST NOT decide architecture.
 2. **Reuse before rewrite.** Agents MUST search for and evaluate the existing shared
@@ -97,6 +128,7 @@ cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings \
   && cargo nextest run --workspace --profile ci    # verification gate — all three before "done"
 cargo nextest run -p <crate> [-- <filter>]         # single crate/test
 just llms-check                                    # generated docs are current
+just atomic-protocol                               # atomic problem-solving docs contract
 just mermaid-check                                 # Mermaid accessibility/type/palette contract
 just mermaid-render-check                          # digest-pinned isolated SVG render
 # Fallback: cargo test --workspace
@@ -321,16 +353,13 @@ Agents MUST follow `.agents/testing.md`. Tests MUST be falsifiable: a real contr
 No workarounds (MUST):
 Agents MUST fix causes, not symptoms — in code, tests, builds, docs, and tooling alike. When something resists, the reflex MUST be "why is this happening", never "how do I get past this". Agents MUST NOT make the signal fit the change.
 
-**Failure decomposition protocol (MUST):** before selecting any fix for a failed gate,
-CI dependency, platform behavior, build, test, security control, or runtime fault,
-agents MUST decompose the problem into atomic reasoning units. For each atom they MUST
-(1) state the logical component, (2) validate its independence from the other atoms,
-and (3) verify correctness with a falsifiable observation. Only then MAY they synthesize
-the atoms into a root-cause design and implementation. A timeout increase, retry,
-bypass, flag, skip, mock, hard-coded exception, test weakening, broader permission, or
-environment override is forbidden when it merely makes a symptom disappear; it is
-permitted only when the decomposed root cause proves that it is the owned correctness
-mechanism, its compatibility fallback is explicit, and a test falsifies its removal.
+For a failed gate, CI dependency, platform behavior, build, test, security control or
+runtime fault, agents MUST apply the Atomic problem-solving protocol above before
+selecting a fix. A timeout increase, retry, bypass, flag, skip, mock, hard-coded
+exception, test weakening, broader permission or environment override is forbidden when
+it merely makes a symptom disappear. It is permitted only when the verified root cause
+proves that it is the owned correctness mechanism, its compatibility fallback is
+explicit, and a test falsifies its removal.
 
 Forbidden in general:
 - Special-casing an input, hardcoding a value, or branching on a specific case to make one caller work, when the underlying rule is what is wrong.

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -34,6 +34,11 @@ Task-specific playbooks are routed from `.agents/index.md`; load only matching e
    comment MUST include `## OS acceptance` with the required OS/device, exact observable
    check, and current availability. A CI lane on that OS is not user-facing product
    evidence unless the approved issue/spec explicitly says it is.
+   For non-trivial work, that same first comment MUST record the decision-bearing atoms
+   required by root `AGENTS.md` § Atomic problem-solving protocol. Record each atom's
+   owner, boundary and inputs/outputs, failure mode, observable contract, independence
+   from the other atoms, and first falsifier. This is the working model before a design
+   or fix is selected, not a rationale added after implementation.
 2. **Spec gate.** Larger than a bug fix and no spec? Write one from
    `docs/agents/spec-template.md` and stop for human approval. Never implement from an
    unapproved spec. Bug fixes skip the spec but not the regression test.
@@ -45,10 +50,13 @@ Task-specific playbooks are routed from `.agents/index.md`; load only matching e
    refresh Linear to pick up other-agent changes. Post a Linear progress comment after
    every contract decision, material pass/fail, blocker, scope change, and substantial
    milestone; name completed work, evidence, remaining work, risks and the next
-   acceptance check. Small commits, conventional messages. No placeholder code on the
-   branch tip. A *material decision* changes a public API, permission, wire protocol,
-   dependency, architecture-spec interpretation, or crate/path boundary. A *substantial
-   milestone* is a named task or acceptance checkpoint in the issue/spec. On duplicate,
+   acceptance check. A material-decision comment MUST also record every atom changed or
+   added by the decision, its independence edges and first falsifier; synthesis waits
+   until each decision-bearing atom is passed, explicitly unknown, or a named blocker.
+   Small commits, conventional messages. No placeholder code on the branch tip. A
+   *material decision* changes a public API, permission, wire protocol, dependency,
+   architecture-spec interpretation, or crate/path boundary. A *substantial milestone*
+   is a named task or acceptance checkpoint in the issue/spec. On duplicate,
    blocker, supersession or another active owner, stop the overlap, record the conflict
    on the agent's own issue (or handoff), and notify the human/orchestrator; a worktree
    does not authorize competing architecture decisions. For a real OS/device criterion,

--- a/docs/engineering/decisions.md
+++ b/docs/engineering/decisions.md
@@ -327,11 +327,10 @@ retry, because a retry reports a flaky test green and hides its first failure
 (KEL-112). Workspace clippy is already pedantic; do not re-enable it per crate
 (learnings 2026-07-08).
 
-**Chose — local mirror of CI (`justfile`).** `just ci` runs, in order:
-`agents-md` → `mermaid-test` → `mermaid-check` → `mermaid-render-check` → `llms-test` →
-`llms-check` → `hygiene` (KEL-39) → `fmt-check` → `clippy` → `test` → `doc` → `deny`.
-Gitleaks is **not** in `just ci`; the justfile
-says it stays GitHub-only (checksum-pinned OSS CLI in `.github/workflows/ci.yml`).
+**Chose — local mirror of CI (`justfile`).** The `ci` recipe in the justfile is the
+single source of truth for the exact local gate inventory and order; prose MUST NOT copy
+that executable list. `just ci` runs the current inventory. Gitleaks stays GitHub-only
+(checksum-pinned OSS CLI in `.github/workflows/ci.yml`).
 
 **Chose — no Husky / no committed git-hook manager.** Tracked config has no
 husky, lefthook, pre-commit, prek, or cargo-husky. Do not add one to “match

--- a/docs/onboarding/01-project-summary.md
+++ b/docs/onboarding/01-project-summary.md
@@ -280,9 +280,8 @@ Local `ROADMAP.md` remains gitignored; the tracked map is
 [`docs/engineering/linear-roadmap-mapping.md`](../engineering/linear-roadmap-mapping.md).
 A `bench/` harness is still absent (YAGNI until a live microbench).
 
-[`justfile`](../../justfile) mirrors the gates locally: `just ci` runs
-agents-md → llms → hygiene → fmt-check → clippy → test → doc → deny (gitleaks stays
-GitHub-only).
+[`justfile`](../../justfile) owns the exact local gate inventory and order; run `just ci`
+to execute the current list. Gitleaks stays GitHub-only.
 
 ## The roadmap in plain terms
 

--- a/docs/onboarding/05-development-guide.md
+++ b/docs/onboarding/05-development-guide.md
@@ -163,7 +163,7 @@ CI's Ubuntu `deny` job evaluates the same macOS dependency set.
 | `just deny` | `cargo deny check` |
 | `just mermaid-test` / `just mermaid-check` / `just mermaid-render-check` | validator tests / tracked structural policy / isolated digest-pinned SVG render |
 | `just llms-test` / `just llms-check` | generated-corpus contract tests / freshness check |
-| `just ci` | agent instructions + Mermaid + generated docs + hygiene + `fmt-check clippy test doc deny` |
+| `just ci` | Full local gate; the `justfile` `ci` recipe is the sole source of its inventory and order. |
 
 `just ci` is the local mirror of CI, minus the three-OS matrix and the manual Mermaid
 visual-inspection/report step. If it is green and you only touched

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ hello:
 
 # Run every CI gate locally (deny requires `cargo install cargo-deny --locked`).
 # gitleaks stays GitHub-only (pinned OSS CLI in .github/workflows/ci.yml).
-ci: agents-md ci-router-test mermaid-test mermaid-check mermaid-render-check llms-test llms-check hygiene fmt-check clippy test doc deny
+ci: agents-md atomic-protocol ci-router-test mermaid-test mermaid-check mermaid-render-check llms-test llms-check hygiene fmt-check clippy test doc deny
 
 # Check playbook routing and require crate AGENTS.md wherever Rust opts into unsafe.
 agents-md:
@@ -71,6 +71,14 @@ agents-md:
     done
     if [[ "$fail" -ne 0 ]]; then exit 1; fi
     echo "agents-md ok"
+
+# KEL-145: one canonical atomic problem-solving protocol plus narrow references.
+atomic-protocol:
+    mkdir -p target/atomic-protocol
+    rustc --edition=2024 -D warnings --test tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol-test
+    target/atomic-protocol/atomic-protocol-test
+    rustc --edition=2024 -D warnings tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol
+    target/atomic-protocol/atomic-protocol check .
 
 # Generate the checked-in agent-readable docs index and full corpus.
 llms:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3080,11 +3080,10 @@ retry, because a retry reports a flaky test green and hides its first failure
 (KEL-112). Workspace clippy is already pedantic; do not re-enable it per crate
 (learnings 2026-07-08).
 
-**Chose — local mirror of CI (`justfile`).** `just ci` runs, in order:
-`agents-md` → `mermaid-test` → `mermaid-check` → `mermaid-render-check` → `llms-test` →
-`llms-check` → `hygiene` (KEL-39) → `fmt-check` → `clippy` → `test` → `doc` → `deny`.
-Gitleaks is **not** in `just ci`; the justfile
-says it stays GitHub-only (checksum-pinned OSS CLI in `.github/workflows/ci.yml`).
+**Chose — local mirror of CI (`justfile`).** The `ci` recipe in the justfile is the
+single source of truth for the exact local gate inventory and order; prose MUST NOT copy
+that executable list. `just ci` runs the current inventory. Gitleaks stays GitHub-only
+(checksum-pinned OSS CLI in `.github/workflows/ci.yml`).
 
 **Chose — no Husky / no committed git-hook manager.** Tracked config has no
 husky, lefthook, pre-commit, prek, or cargo-husky. Do not add one to “match

--- a/tools/atomic_protocol.rs
+++ b/tools/atomic_protocol.rs
@@ -13,8 +13,23 @@ const ROOT: &str = "AGENTS.md";
 const WORKFLOW: &str = "docs/agents/workflow.md";
 const TESTING: &str = ".agents/testing.md";
 const INDEX: &str = ".agents/index.md";
+const JUSTFILE: &str = "justfile";
+const DEVELOPMENT_GUIDE: &str = "docs/onboarding/05-development-guide.md";
 const ROOT_HEADING: &str = "## Atomic problem-solving protocol (MUST)";
 const RETIRED_HEADING: &str = "Failure decomposition protocol (MUST)";
+const WORKFLOW_HEADING: &str = "## The loop (one issue, one agent, one concern)";
+const TESTING_HEADING: &str = "## Failure-first proof";
+const INDEX_HEADING: &str = "## Task routing";
+const DEVELOPMENT_GUIDE_CI_ROW: &str = "| `just ci` | Full local gate; the `justfile` `ci` recipe is the sole source of its inventory and order. |";
+const ENFORCEMENT_LINE_PREFIX: &str =
+    "Enforcement: `just atomic-protocol` validates the canonical stages";
+const ATOMIC_RECIPE_COMMANDS: &[&str] = &[
+    "mkdir -p target/atomic-protocol",
+    "rustc --edition=2024 -D warnings --test tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol-test",
+    "target/atomic-protocol/atomic-protocol-test",
+    "rustc --edition=2024 -D warnings tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol",
+    "target/atomic-protocol/atomic-protocol check .",
+];
 
 const STAGES: &[&str] = &[
     "1. **Decompose before deciding (MUST).**",
@@ -24,15 +39,31 @@ const STAGES: &[&str] = &[
     "5. **Synthesize only after proof (MUST).**",
 ];
 
-const ROOT_SEMANTICS: &[&str] = &[
-    "Before selecting a design, answer or fix",
-    "Each atom MUST name its owner, boundary and inputs/outputs, failure mode, and observable contract",
-    "Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.",
-    "direct evidence or a falsifiable test or negative control",
-    "until every decision-bearing atom is passed, explicitly unknown, or named as a blocker",
-    "If the synthesis contradicts a passed atom, agents MUST stop and correct the model",
+const INTRO_SEMANTICS: &[&str] = &["Before selecting a design, answer or fix"];
+
+const STAGE_SEMANTICS: &[&[&str]] = &[
+    &["Split the problem into decision-bearing atoms"],
+    &[
+        "Each atom MUST name its owner, boundary and inputs/outputs, failure mode, and observable contract",
+    ],
+    &[
+        "Changing or falsifying one atom MUST NOT silently alter another",
+        "Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.",
+    ],
+    &[
+        "Each atom MUST have direct evidence or a falsifiable test or negative control",
+        "Prose, comments, mocks, or another atom's pass are not proof of that atom.",
+    ],
+    &[
+        "until every decision-bearing atom is passed, explicitly unknown, or named as a blocker",
+        "If the synthesis contradicts a passed atom, agents MUST stop and correct the model",
+    ],
+];
+
+const FOOTER_SEMANTICS: &[&str] = &[
     "Performance decompositions MUST separate census, work, queue/copy, clock, statistic and artifact.",
     "Security decompositions MUST separate identity, authentication, authorization, OS containment, lifecycle/revocation and evidence provenance.",
+    "Enforcement: `just atomic-protocol` validates the canonical stages",
 ];
 
 const WORKFLOW_REQUIREMENTS: &[&str] = &[
@@ -79,34 +110,110 @@ fn without_html_comments(text: &str) -> String {
     visible
 }
 
+fn without_struck_text(line: &str) -> String {
+    let mut visible = String::with_capacity(line.len());
+    let mut remainder = line;
+    while let Some(start) = remainder.find("~~") {
+        visible.push_str(&remainder[..start]);
+        let struck = &remainder[start + 2..];
+        let Some(end) = struck.find("~~") else {
+            return visible;
+        };
+        remainder = &struck[end + 2..];
+    }
+    visible.push_str(remainder);
+    visible
+}
+
+fn without_inline_code(line: &str) -> String {
+    let mut visible = String::with_capacity(line.len());
+    let mut remainder = line;
+    while let Some(start) = remainder.find('`') {
+        visible.push_str(&remainder[..start]);
+        let opening = &remainder[start..];
+        let width = opening.bytes().take_while(|byte| *byte == b'`').count();
+        let marker = "`".repeat(width);
+        let code = &opening[width..];
+        let Some(end) = code.find(&marker) else {
+            return visible;
+        };
+        remainder = &code[end + width..];
+    }
+    visible.push_str(remainder);
+    visible
+}
+
+fn fence_marker(line: &str) -> Option<(u8, usize, bool)> {
+    let indent = line.bytes().take_while(|byte| *byte == b' ').count();
+    if indent > 3 || line.starts_with('\t') {
+        return None;
+    }
+    let trimmed = &line[indent..];
+    let marker = *trimmed.as_bytes().first()?;
+    if marker != b'`' && marker != b'~' {
+        return None;
+    }
+    let width = trimmed.bytes().take_while(|byte| *byte == marker).count();
+    (width >= 3).then(|| (marker, width, trimmed[width..].trim().is_empty()))
+}
+
 fn visible_markdown(text: &str) -> String {
     let without_comments = without_html_comments(text);
     let mut visible = String::with_capacity(without_comments.len());
-    let mut fence: Option<&str> = None;
+    let mut fence: Option<(u8, usize)> = None;
+    let mut block_quote = false;
 
     for line in without_comments.lines() {
         let trimmed = line.trim_start();
-        let marker = if trimmed.starts_with("```") {
-            Some("```")
-        } else if trimmed.starts_with("~~~") {
-            Some("~~~")
-        } else {
-            None
-        };
-        if let Some(active) = fence {
-            if marker == Some(active) {
+        let marker = fence_marker(line);
+        if let Some((active_marker, active_width)) = fence {
+            if marker.is_some_and(|(candidate, width, closing)| {
+                candidate == active_marker && width >= active_width && closing
+            }) {
                 fence = None;
             }
             continue;
         }
-        if let Some(opening) = marker {
-            fence = Some(opening);
+        if line.starts_with('\t') || line.len() - trimmed.len() >= 4 {
             continue;
         }
-        visible.push_str(line);
+        if let Some((opening, width, _)) = marker {
+            fence = Some((opening, width));
+            continue;
+        }
+        if trimmed.is_empty() {
+            block_quote = false;
+            visible.push('\n');
+            continue;
+        }
+        if trimmed.starts_with('>') {
+            block_quote = true;
+            continue;
+        }
+        if block_quote {
+            continue;
+        }
+        if trimmed.starts_with('[') && trimmed.split_once("]:").is_some() {
+            continue;
+        }
+        visible.push_str(&without_struck_text(line));
         visible.push('\n');
     }
     visible
+}
+
+fn binding_prose(text: &str) -> String {
+    visible_markdown(text)
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.contains('|') && (!trimmed.starts_with('#') || trimmed.starts_with("## "))
+        })
+        .fold(String::new(), |mut prose, line| {
+            prose.push_str(&without_inline_code(line));
+            prose.push('\n');
+            prose
+        })
 }
 
 fn normalize(text: &str) -> String {
@@ -116,7 +223,18 @@ fn normalize(text: &str) -> String {
         .join(" ")
 }
 
-fn section<'a>(text: &'a str, heading: &str) -> Result<&'a str, String> {
+fn normalize_binding(text: &str) -> String {
+    binding_prose(text)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalized_occurrences(haystack: &str, needle: &str) -> usize {
+    normalize(haystack).matches(&normalize(needle)).count()
+}
+
+fn section<'a>(text: &'a str, heading: &str, path: &str) -> Result<&'a str, String> {
     let heading_offsets = text
         .split_inclusive('\n')
         .scan(0, |offset, line| {
@@ -128,7 +246,7 @@ fn section<'a>(text: &'a str, heading: &str) -> Result<&'a str, String> {
         .collect::<Vec<_>>();
     if heading_offsets.len() != 1 {
         return Err(format!(
-            "ATOMIC-PROTOCOL: `{ROOT}` must contain exactly one `{heading}` section. Restore the canonical owner instead of copying or deleting it."
+            "ATOMIC-PROTOCOL: `{path}` must contain exactly one `{heading}` section. Restore the canonical owner instead of copying or deleting it."
         ));
     }
     let start = heading_offsets[0];
@@ -140,7 +258,7 @@ fn section<'a>(text: &'a str, heading: &str) -> Result<&'a str, String> {
 }
 
 fn require_normalized(haystack: &str, needle: &str, path: &str) -> Result<(), String> {
-    if normalize(haystack).contains(&normalize(needle)) {
+    if normalize_binding(haystack).contains(&normalize_binding(needle)) {
         return Ok(());
     }
     Err(format!(
@@ -166,58 +284,211 @@ fn require_ordered(haystack: &str, needles: &[&str], path: &str) -> Result<(), S
     Ok(())
 }
 
+fn exact_line_offsets(text: &str, marker: &str) -> Vec<usize> {
+    text.split_inclusive('\n')
+        .scan(0, |offset, line| {
+            let current = *offset;
+            *offset += line.len();
+            Some((current, line.trim_end_matches(['\r', '\n'])))
+        })
+        .filter_map(|(offset, line)| (line == marker).then_some(offset))
+        .collect()
+}
+
+fn line_prefix_offsets(text: &str, marker: &str) -> Vec<usize> {
+    text.split_inclusive('\n')
+        .scan(0, |offset, line| {
+            let current = *offset;
+            *offset += line.len();
+            Some((current, line.trim_end_matches(['\r', '\n'])))
+        })
+        .filter_map(|(offset, line)| line.starts_with(marker).then_some(offset))
+        .collect()
+}
+
+fn require_unique_normalized(haystack: &str, needle: &str, path: &str) -> Result<(), String> {
+    let count = normalize_binding(haystack)
+        .matches(&normalize_binding(needle))
+        .count();
+    if count == 1 {
+        return Ok(());
+    }
+    Err(format!(
+        "ATOMIC-PROTOCOL: `{path}` must contain binding wording `{needle}` exactly once; found {count}. Remove decoy, historical, or duplicate policy text."
+    ))
+}
+
 fn check_root(text: &str) -> Result<(), String> {
-    let visible = visible_markdown(text);
+    let rendered = visible_markdown(text);
+    let visible = binding_prose(text);
     if visible.contains(RETIRED_HEADING) {
         return Err(format!(
             "ATOMIC-PROTOCOL: `{ROOT}` still contains retired duplicate `{RETIRED_HEADING}`. Reconcile failures into `{ROOT_HEADING}`."
         ));
     }
-    let protocol = section(&visible, ROOT_HEADING)?;
+    let protocol = section(&visible, ROOT_HEADING, ROOT)?;
+    let rendered_protocol = section(&rendered, ROOT_HEADING, ROOT)?;
+    if line_prefix_offsets(rendered_protocol, ENFORCEMENT_LINE_PREFIX).len() != 1
+        || line_prefix_offsets(&rendered, ENFORCEMENT_LINE_PREFIX).len() != 1
+    {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{ROOT}` must contain one `{ENFORCEMENT_LINE_PREFIX}` line in `{ROOT_HEADING}`."
+        ));
+    }
     require_ordered(protocol, STAGES, ROOT)?;
-    for requirement in ROOT_SEMANTICS {
+
+    let mut offsets = Vec::with_capacity(STAGES.len());
+    for stage in STAGES {
+        let stage_offsets = line_prefix_offsets(protocol, stage);
+        if stage_offsets.len() != 1 || normalized_occurrences(&visible, stage) != 1 {
+            return Err(format!(
+                "ATOMIC-PROTOCOL: `{ROOT}` must contain mandatory stage `{stage}` exactly once as its own line in `{ROOT_HEADING}`."
+            ));
+        }
+        offsets.push(stage_offsets[0]);
+    }
+
+    let intro = &protocol[..offsets[0]];
+    for requirement in INTRO_SEMANTICS {
+        require_normalized(intro, requirement, ROOT)?;
+        require_unique_normalized(&visible, requirement, ROOT)?;
+    }
+    for (index, requirements) in STAGE_SEMANTICS.iter().enumerate() {
+        let end = offsets.get(index + 1).copied().unwrap_or(protocol.len());
+        let body = &protocol[offsets[index]..end];
+        for requirement in *requirements {
+            require_normalized(body, requirement, ROOT)?;
+            require_unique_normalized(&visible, requirement, ROOT)?;
+        }
+    }
+    for requirement in FOOTER_SEMANTICS {
         require_normalized(protocol, requirement, ROOT)?;
+        require_unique_normalized(&visible, requirement, ROOT)?;
+    }
+
+    let outside = visible.replacen(protocol, "", 1).to_ascii_lowercase();
+    let duplicate_owner = outside.split("\n## ").any(|candidate_section| {
+        let signature_count = ["logical component", "independ", "correct", "synthes"]
+            .iter()
+            .filter(|signature| candidate_section.contains(*signature))
+            .count();
+        candidate_section.contains("atomic") && signature_count >= 3
+    });
+    if duplicate_owner {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{ROOT}` contains a second protocol owner outside `{ROOT_HEADING}`. Reconcile its stages into the canonical section."
+        ));
     }
     Ok(())
 }
 
+fn line_block<'a>(
+    text: &'a str,
+    start_marker: &str,
+    end_marker: Option<&str>,
+    path: &str,
+) -> Result<&'a str, String> {
+    let starts = line_prefix_offsets(text, start_marker);
+    if starts.len() != 1 {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{path}` must contain `{start_marker}` exactly once in its owning section."
+        ));
+    }
+    let start = starts[0];
+    let end = if let Some(marker) = end_marker {
+        let ends = line_prefix_offsets(text, marker);
+        if ends.len() != 1 || ends[0] <= start {
+            return Err(format!(
+                "ATOMIC-PROTOCOL: `{path}` must contain `{marker}` once after `{start_marker}`."
+            ));
+        }
+        ends[0]
+    } else {
+        text.len()
+    };
+    Ok(&text[start..end])
+}
+
 fn require_index_route(text: &str) -> Result<(), String> {
     let visible = visible_markdown(text);
-    let routed = visible.lines().any(|line| {
-        let cells = line
-            .strip_prefix('|')
-            .and_then(|line| line.strip_suffix('|'))
-            .map(|line| line.split('|').map(str::trim).collect::<Vec<_>>());
-        cells.is_some_and(|cells| {
-            cells.len() == 2
-                && cells[0] == INDEX_REQUIREMENTS[0]
-                && cells[1].contains(INDEX_REQUIREMENTS[1])
-        })
+    let routing = section(&visible, INDEX_HEADING, INDEX)?;
+    let lines = routing
+        .lines()
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    let header = lines
+        .iter()
+        .position(|line| line.trim() == "| Task or path | Read |");
+    let route_is_in_table = header.is_some_and(|header| {
+        lines
+            .get(header + 1)
+            .is_some_and(|line| line.trim() == "|---|---|")
+            && lines[header + 2..]
+                .iter()
+                .take_while(|line| line.trim().starts_with('|'))
+                .any(|line| {
+                    line.trim()
+                        .strip_prefix('|')
+                        .and_then(|line| line.strip_suffix('|'))
+                        .map(|line| line.split('|').map(str::trim).collect::<Vec<_>>())
+                        .is_some_and(|cells| {
+                            cells.len() == 2
+                                && cells[0] == INDEX_REQUIREMENTS[0]
+                                && cells[1].contains(INDEX_REQUIREMENTS[1])
+                        })
+                })
     });
-    if routed {
+    if route_is_in_table && normalized_occurrences(&visible, INDEX_REQUIREMENTS[0]) == 1 {
         return Ok(());
     }
     Err(format!(
-        "ATOMIC-PROTOCOL: `{INDEX}` must route `{}` to `{}` in one task-routing table row. Plain prose is not a route.",
+        "ATOMIC-PROTOCOL: `{INDEX}` must route `{}` to `{}` inside the canonical table in `{INDEX_HEADING}`. Plain prose or an isolated decoy table is not a route.",
         INDEX_REQUIREMENTS[0], INDEX_REQUIREMENTS[1]
     ))
 }
 
 fn check_references(root: &Path) -> Result<(), String> {
     let workflow = read(root, WORKFLOW)?;
-    for requirement in WORKFLOW_REQUIREMENTS {
-        require_normalized(&workflow, requirement, WORKFLOW)?;
+    let workflow_visible = binding_prose(&workflow);
+    let workflow_loop = section(&workflow_visible, WORKFLOW_HEADING, WORKFLOW)?;
+    let pickup = line_block(
+        workflow_loop,
+        "1. **Pick up and refresh.**",
+        Some("2. **Spec gate.**"),
+        WORKFLOW,
+    )?;
+    let implementation = line_block(
+        workflow_loop,
+        "4. **Implement and coordinate.**",
+        Some("5. **Verify**"),
+        WORKFLOW,
+    )?;
+    for requirement in &WORKFLOW_REQUIREMENTS[..3] {
+        require_normalized(pickup, requirement, WORKFLOW)?;
+        require_unique_normalized(&workflow_visible, requirement, WORKFLOW)?;
+    }
+    for requirement in &WORKFLOW_REQUIREMENTS[3..] {
+        require_normalized(implementation, requirement, WORKFLOW)?;
+        require_unique_normalized(&workflow_visible, requirement, WORKFLOW)?;
     }
 
     let testing = read(root, TESTING)?;
+    let testing_visible = binding_prose(&testing);
+    let failure_first = section(&testing_visible, TESTING_HEADING, TESTING)?;
     for requirement in TESTING_REQUIREMENTS {
-        require_normalized(&testing, requirement, TESTING)?;
+        require_normalized(failure_first, requirement, TESTING)?;
+        require_unique_normalized(&testing_visible, requirement, TESTING)?;
     }
 
     let index = read(root, INDEX)?;
     require_index_route(&index)?;
 
-    for (path, text) in [(WORKFLOW, workflow), (TESTING, testing), (INDEX, index)] {
+    for (path, text) in [
+        (WORKFLOW, binding_prose(&workflow)),
+        (TESTING, binding_prose(&testing)),
+        (INDEX, binding_prose(&index)),
+    ] {
         for stage in STAGES {
             if normalize(&text).contains(&normalize(stage)) {
                 return Err(format!(
@@ -229,10 +500,67 @@ fn check_references(root: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn check_justfile_and_development_guide(root: &Path) -> Result<(), String> {
+    let justfile = read(root, JUSTFILE)?;
+    let Some(ci_line) = justfile.lines().find(|line| line.starts_with("ci:")) else {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{JUSTFILE}` has no `ci:` recipe. Restore the sole local-gate inventory."
+        ));
+    };
+    if ci_line
+        .split_whitespace()
+        .filter(|word| *word == "atomic-protocol")
+        .count()
+        != 1
+    {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{JUSTFILE}` `ci:` must include `atomic-protocol` exactly once."
+        ));
+    }
+    if exact_line_offsets(&justfile, "atomic-protocol:").len() != 1 {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{JUSTFILE}` must define the `atomic-protocol:` recipe exactly once."
+        ));
+    }
+    let mut in_recipe = false;
+    let mut recipe_commands = Vec::new();
+    for line in justfile.lines() {
+        if line == "atomic-protocol:" {
+            in_recipe = true;
+            continue;
+        }
+        if !in_recipe {
+            continue;
+        }
+        if !line.trim().is_empty() && !line.starts_with(' ') && !line.starts_with('\t') {
+            break;
+        }
+        let command = line.trim();
+        if !command.is_empty() && !command.starts_with('#') {
+            recipe_commands.push(command);
+        }
+    }
+    if recipe_commands != ATOMIC_RECIPE_COMMANDS {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{JUSTFILE}` `atomic-protocol:` must compile and run the checker tests and real-check commands exactly; got `{}`.",
+            recipe_commands.join(" | ")
+        ));
+    }
+
+    let guide = visible_markdown(&read(root, DEVELOPMENT_GUIDE)?);
+    if exact_line_offsets(&guide, DEVELOPMENT_GUIDE_CI_ROW).len() != 1 {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{DEVELOPMENT_GUIDE}` must point `just ci` at the `justfile` as the sole inventory instead of copying a stale gate list."
+        ));
+    }
+    Ok(())
+}
+
 fn check(root: &Path) -> Result<(), String> {
     let root_text = read(root, ROOT)?;
     check_root(&root_text)?;
-    check_references(root)
+    check_references(root)?;
+    check_justfile_and_development_guide(root)
 }
 
 fn run_cli() -> Result<(), String> {
@@ -300,7 +628,7 @@ mod tests {
 
     fn valid_root() -> String {
         format!(
-            "# Rules\n\n{ROOT_HEADING}\n\nBefore selecting a design, answer or fix.\n\n{}\n{} Each atom MUST name its owner, boundary and inputs/outputs, failure mode, and observable contract.\n{} Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.\n{} Each atom needs direct evidence or a falsifiable test or negative control.\n{} Do not synthesize until every decision-bearing atom is passed, explicitly unknown, or named as a blocker. If the synthesis contradicts a passed atom, agents MUST stop and correct the model.\n\nPerformance decompositions MUST separate census, work, queue/copy, clock, statistic and artifact. Security decompositions MUST separate identity, authentication, authorization, OS containment, lifecycle/revocation and evidence provenance.\n\n## Next\n",
+            "# Rules\n\n{ROOT_HEADING}\n\nBefore selecting a design, answer or fix.\n\n{} Split the problem into decision-bearing atoms.\n{} Each atom MUST name its owner, boundary and inputs/outputs, failure mode, and observable contract.\n{} Changing or falsifying one atom MUST NOT silently alter another. Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.\n{} Each atom MUST have direct evidence or a falsifiable test or negative control. Prose, comments, mocks, or another atom's pass are not proof of that atom.\n{} Do not synthesize until every decision-bearing atom is passed, explicitly unknown, or named as a blocker. If the synthesis contradicts a passed atom, agents MUST stop and correct the model.\n\nPerformance decompositions MUST separate census, work, queue/copy, clock, statistic and artifact. Security decompositions MUST separate identity, authentication, authorization, OS containment, lifecycle/revocation and evidence provenance.\n\nEnforcement: `just atomic-protocol` validates the canonical stages.\n\n## Next\n",
             STAGES[0], STAGES[1], STAGES[2], STAGES[3], STAGES[4]
         )
     }
@@ -310,15 +638,26 @@ mod tests {
         temp.write(ROOT, &valid_root());
         temp.write(
             WORKFLOW,
-            "root `AGENTS.md` § Atomic problem-solving protocol\nThe same first comment MUST record the decision-bearing atoms: owner, boundary and inputs/outputs, failure mode, observable contract, independence from the other atoms, and first falsifier. A material-decision comment MUST also record every atom changed or added by the decision, its independence edges and first falsifier.\n",
+            "# Workflow\n\n## The loop (one issue, one agent, one concern)\n\n1. **Pick up and refresh.** Fetch the Linear issue (team KELD, current milestone first),\nroot `AGENTS.md` § Atomic problem-solving protocol. The same first comment MUST record the decision-bearing atoms: owner, boundary and inputs/outputs, failure mode, observable contract, independence from the other atoms, and first falsifier.\n2. **Spec gate.** Larger than a bug fix and no spec? Write one from\n3. **Isolate.** Work separately.\n4. **Implement and coordinate.** Tests with the change (conformance entries *first* for\nA material-decision comment MUST also record every atom changed or added by the decision, its independence edges and first falsifier.\n5. **Verify** (the gate from root `AGENTS.md`): fmt + clippy `-D warnings` + full test\n\n## Next\n",
         );
         temp.write(
             TESTING,
-            "Root `AGENTS.md` § Atomic problem-solving protocol owns the decomposition. The author MUST bind it to one named atom's observable contract and state why its oracle is independent of the implementation and the other atoms. Every negative control MUST name the one fault or mutation that falsifies that atom.\n",
+            "# Testing\n\n## Failure-first proof\n\nRoot `AGENTS.md` § Atomic problem-solving protocol owns the decomposition. The author MUST bind it to one named atom's observable contract and state why its oracle is independent of the implementation and the other atoms. Every negative control MUST name the one fault or mutation that falsifies that atom.\n\n## Next\n",
         );
         temp.write(
             INDEX,
-            "| Task or path | Read |\n|---|---|\n| Any non-trivial design, diagnosis, review, or implementation | Root `AGENTS.md` § Atomic problem-solving protocol. |\n",
+            "# Index\n\n## Task routing\n\n| Task or path | Read |\n|---|---|\n| Any non-trivial design, diagnosis, review, or implementation | Root `AGENTS.md` § Atomic problem-solving protocol. |\n\n## Next\n",
+        );
+        temp.write(
+            JUSTFILE,
+            &format!(
+                "ci: atomic-protocol fmt-check\n\natomic-protocol:\n    {}\n",
+                ATOMIC_RECIPE_COMMANDS.join("\n    ")
+            ),
+        );
+        temp.write(
+            DEVELOPMENT_GUIDE,
+            &format!("# Development\n\n{DEVELOPMENT_GUIDE_CI_ROW}\n"),
         );
         temp
     }
@@ -370,7 +709,16 @@ mod tests {
 
     #[test]
     fn every_root_semantic_fails_when_removed() {
-        for requirement in ROOT_SEMANTICS {
+        let requirements = INTRO_SEMANTICS
+            .iter()
+            .copied()
+            .chain(
+                STAGE_SEMANTICS
+                    .iter()
+                    .flat_map(|items| items.iter().copied()),
+            )
+            .chain(FOOTER_SEMANTICS.iter().copied());
+        for requirement in requirements {
             let temp = fixture();
             replace_requirement(&temp, ROOT, requirement);
             let error = check(&temp.path).expect_err("removed root semantic must fail");
@@ -382,13 +730,167 @@ mod tests {
     fn hidden_stage_text_cannot_satisfy_the_contract() {
         for hidden in [
             format!("<!-- {} -->", STAGES[0]),
-            format!("```text\n{}\n```", STAGES[0]),
+            format!("```text\n{}\n```\n", STAGES[0]),
         ] {
             let temp = fixture();
             temp.write(ROOT, &valid_root().replacen(STAGES[0], &hidden, 1));
             let error = check(&temp.path).expect_err("hidden stage must not count as policy");
             assert!(error.contains(STAGES[0]), "{error}");
         }
+    }
+
+    #[test]
+    fn decoy_markdown_cannot_satisfy_binding_sections() {
+        let requirement = STAGE_SEMANTICS[1][0];
+        for decoy in [
+            format!("| Historical | {requirement} |"),
+            format!("Historical | {requirement}\n--- | ---"),
+            format!("[//]: # ({requirement})"),
+            format!("[atomic]: # ({requirement})"),
+            format!("~~{requirement}~~"),
+            format!("> {requirement}"),
+            format!("> Historical quote\n{requirement}"),
+            format!("### Historical: {requirement}"),
+            format!("`{requirement}`"),
+        ] {
+            let temp = fixture();
+            let weakened = valid_root()
+                .replacen(requirement, "Each atom MAY name only a component.", 1)
+                .replacen("\n## Next", &format!("\n{decoy}\n\n## Next"), 1);
+            temp.write(ROOT, &weakened);
+            check(&temp.path).expect_err("decoy text must not restore a weakened stage body");
+        }
+
+        let temp = fixture();
+        let in_stage_table = valid_root().replacen(
+            requirement,
+            &format!("Each atom MAY name only a component.\n| Historical | {requirement} |"),
+            1,
+        );
+        temp.write(ROOT, &in_stage_table);
+        assert!(
+            !binding_prose(&in_stage_table).contains(requirement),
+            "table decoy must be absent from binding prose"
+        );
+        check(&temp.path).expect_err("a table inside the stage body is still a decoy");
+
+        let temp = fixture();
+        let in_stage_code = valid_root().replacen(
+            requirement,
+            &format!("Each atom MAY name only a component. `{requirement}`"),
+            1,
+        );
+        temp.write(ROOT, &in_stage_code);
+        check(&temp.path).expect_err("inline code inside the stage body is still a decoy");
+
+        let temp = fixture();
+        let wide_fence = valid_root().replacen(
+            requirement,
+            &format!(
+                "Each atom MAY name only a component.\n````text\n```\n{requirement}\n````\n    ```"
+            ),
+            1,
+        );
+        temp.write(ROOT, &wide_fence);
+        check(&temp.path).expect_err("a shorter inner fence must not expose hidden policy");
+
+        let temp = fixture();
+        let workflow = fs::read_to_string(temp.path.join(WORKFLOW)).expect("read workflow");
+        let moved = workflow
+            .replacen(WORKFLOW_REQUIREMENTS[1], "weakened historical pointer", 1)
+            .replace(
+                "## Next",
+                &format!(
+                    "## Historical wording\n\n{}\n\n## Next",
+                    WORKFLOW_REQUIREMENTS[1]
+                ),
+            );
+        temp.write(WORKFLOW, &moved);
+        check(&temp.path).expect_err("historical section must not own workflow policy");
+
+        let temp = fixture();
+        let index = fs::read_to_string(temp.path.join(INDEX)).expect("read index");
+        let route_row = format!("| {} | {}. |", INDEX_REQUIREMENTS[0], INDEX_REQUIREMENTS[1]);
+        let moved = index
+            .replacen(&route_row, "| Unrelated | No route. |", 1)
+            .replace("## Next", &format!("## Next\n\n{route_row}"));
+        temp.write(INDEX, &moved);
+        check(&temp.path).expect_err("isolated table row must not become task routing");
+    }
+
+    #[test]
+    fn duplicate_stage_and_renamed_protocol_owner_fail() {
+        let temp = fixture();
+        temp.write(
+            ROOT,
+            &format!("{}\n{} duplicate\n", valid_root(), STAGES[0]),
+        );
+        check(&temp.path).expect_err("duplicate mandatory stage must fail");
+
+        let temp = fixture();
+        temp.write(
+            ROOT,
+            &format!(
+                "{}\n## Alternate atomic rules\n\nDecompose the units and state each logical component.\n\nValidate independence.\n\nVerify correctness.\n\nThen synthesize the final answer.\n",
+                valid_root()
+            ),
+        );
+        let error = check(&temp.path).expect_err("renamed duplicate owner must fail");
+        assert!(error.contains("second protocol owner"), "{error}");
+    }
+
+    #[test]
+    fn justfile_and_development_guide_cannot_drift() {
+        let temp = fixture();
+        temp.write(JUSTFILE, "ci: fmt-check\n\natomic-protocol:\n    true\n");
+        check(&temp.path).expect_err("local ci must retain atomic protocol gate");
+
+        let temp = fixture();
+        temp.write(
+            JUSTFILE,
+            "ci: atomic-protocol fmt-check\n\nfake-atomic-protocol:\n    true\n",
+        );
+        check(&temp.path).expect_err("renamed recipe header must fail");
+
+        let temp = fixture();
+        temp.write(
+            JUSTFILE,
+            "ci: atomic-protocol fmt-check\n\natomic-protocol:\n    true\n",
+        );
+        check(&temp.path).expect_err("no-op recipe body must fail");
+
+        let temp = fixture();
+        temp.write(
+            DEVELOPMENT_GUIDE,
+            "| `just ci` | copied list: fmt-check clippy test |\n",
+        );
+        check(&temp.path).expect_err("development guide must not copy gate inventory");
+    }
+
+    #[test]
+    fn harmless_workflow_reflow_and_route_reordering_pass() {
+        let temp = fixture();
+        let workflow = fs::read_to_string(temp.path.join(WORKFLOW)).expect("read workflow");
+        temp.write(
+            WORKFLOW,
+            &workflow.replacen(
+                "1. **Pick up and refresh.** Fetch the Linear issue",
+                "1. **Pick up and refresh.**\n   Fetch the Linear issue",
+                1,
+            ),
+        );
+        check(&temp.path).expect("list-item prose reflow must keep ownership");
+
+        let index = fs::read_to_string(temp.path.join(INDEX)).expect("read index");
+        temp.write(
+            INDEX,
+            &index.replacen(
+                "| Any non-trivial design",
+                "| A harmless earlier route | Read something else. |\n| Any non-trivial design",
+                1,
+            ),
+        );
+        check(&temp.path).expect("route order inside the canonical table is not policy");
     }
 
     #[test]
@@ -419,7 +921,7 @@ mod tests {
             "Any non-trivial design, diagnosis, review, or implementation reads Root `AGENTS.md` § Atomic problem-solving protocol.\n",
         );
         let error = check(&temp.path).expect_err("plain prose is not task routing");
-        assert!(error.contains("table row"), "{error}");
+        assert!(error.contains(INDEX), "{error}");
     }
 
     #[test]
@@ -441,9 +943,11 @@ mod tests {
         assert!(error.contains(WORKFLOW), "{error}");
 
         let temp = fixture();
-        let copied = format!(
-            "root `AGENTS.md` § Atomic problem-solving protocol\nThe same first comment MUST record the decision-bearing atoms: owner, boundary and inputs/outputs, failure mode, observable contract, independence from the other atoms, and first falsifier. A material-decision comment MUST also record every atom changed or added by the decision, its independence edges and first falsifier.\n{}\n",
-            STAGES[0]
+        let workflow = fs::read_to_string(temp.path.join(WORKFLOW)).expect("read workflow");
+        let copied = workflow.replacen(
+            "2. **Spec gate.**",
+            &format!("{}\n2. **Spec gate.**", STAGES[0]),
+            1,
         );
         temp.write(WORKFLOW, &copied);
         let error = check(&temp.path).expect_err("copied canonical stages must fail");

--- a/tools/atomic_protocol.rs
+++ b/tools/atomic_protocol.rs
@@ -26,7 +26,7 @@ const STAGES: &[&str] = &[
 
 const ROOT_SEMANTICS: &[&str] = &[
     "Before selecting a design, answer or fix",
-    "owner, boundary and inputs/outputs, failure mode, and observable contract",
+    "Each atom MUST name its owner, boundary and inputs/outputs, failure mode, and observable contract",
     "Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.",
     "direct evidence or a falsifiable test or negative control",
     "until every decision-bearing atom is passed, explicitly unknown, or named as a blocker",
@@ -117,14 +117,21 @@ fn normalize(text: &str) -> String {
 }
 
 fn section<'a>(text: &'a str, heading: &str) -> Result<&'a str, String> {
-    if text.match_indices(heading).count() != 1 {
+    let heading_offsets = text
+        .split_inclusive('\n')
+        .scan(0, |offset, line| {
+            let current = *offset;
+            *offset += line.len();
+            Some((current, line.trim_end_matches(['\r', '\n'])))
+        })
+        .filter_map(|(offset, line)| (line == heading).then_some(offset))
+        .collect::<Vec<_>>();
+    if heading_offsets.len() != 1 {
         return Err(format!(
             "ATOMIC-PROTOCOL: `{ROOT}` must contain exactly one `{heading}` section. Restore the canonical owner instead of copying or deleting it."
         ));
     }
-    let start = text.find(heading).ok_or_else(|| {
-        format!("ATOMIC-PROTOCOL: `{ROOT}` is missing canonical section `{heading}`.")
-    })?;
+    let start = heading_offsets[0];
     let after_heading = start + heading.len();
     let end = text[after_heading..]
         .find("\n## ")
@@ -142,32 +149,58 @@ fn require_normalized(haystack: &str, needle: &str, path: &str) -> Result<(), St
 }
 
 fn require_ordered(haystack: &str, needles: &[&str], path: &str) -> Result<(), String> {
-    let normalized = normalize(haystack);
-    let mut cursor = 0;
+    let visible = visible_markdown(haystack);
+    let lines = visible.lines().collect::<Vec<_>>();
+    let mut cursor = 0_usize;
     for needle in needles {
-        let expected = normalize(needle);
-        let Some(offset) = normalized[cursor..].find(&expected) else {
+        let Some(offset) = lines[cursor..]
+            .iter()
+            .position(|line| line.starts_with(needle))
+        else {
             return Err(format!(
                 "ATOMIC-PROTOCOL: `{path}` is missing or reorders mandatory stage `{needle}`. Restore all stages in canonical order."
             ));
         };
-        cursor += offset + expected.len();
+        cursor += offset + 1;
     }
     Ok(())
 }
 
 fn check_root(text: &str) -> Result<(), String> {
-    if text.contains(RETIRED_HEADING) {
+    let visible = visible_markdown(text);
+    if visible.contains(RETIRED_HEADING) {
         return Err(format!(
             "ATOMIC-PROTOCOL: `{ROOT}` still contains retired duplicate `{RETIRED_HEADING}`. Reconcile failures into `{ROOT_HEADING}`."
         ));
     }
-    let protocol = section(text, ROOT_HEADING)?;
+    let protocol = section(&visible, ROOT_HEADING)?;
     require_ordered(protocol, STAGES, ROOT)?;
     for requirement in ROOT_SEMANTICS {
         require_normalized(protocol, requirement, ROOT)?;
     }
     Ok(())
+}
+
+fn require_index_route(text: &str) -> Result<(), String> {
+    let visible = visible_markdown(text);
+    let routed = visible.lines().any(|line| {
+        let cells = line
+            .strip_prefix('|')
+            .and_then(|line| line.strip_suffix('|'))
+            .map(|line| line.split('|').map(str::trim).collect::<Vec<_>>());
+        cells.is_some_and(|cells| {
+            cells.len() == 2
+                && cells[0] == INDEX_REQUIREMENTS[0]
+                && cells[1].contains(INDEX_REQUIREMENTS[1])
+        })
+    });
+    if routed {
+        return Ok(());
+    }
+    Err(format!(
+        "ATOMIC-PROTOCOL: `{INDEX}` must route `{}` to `{}` in one task-routing table row. Plain prose is not a route.",
+        INDEX_REQUIREMENTS[0], INDEX_REQUIREMENTS[1]
+    ))
 }
 
 fn check_references(root: &Path) -> Result<(), String> {
@@ -182,9 +215,7 @@ fn check_references(root: &Path) -> Result<(), String> {
     }
 
     let index = read(root, INDEX)?;
-    for requirement in INDEX_REQUIREMENTS {
-        require_normalized(&index, requirement, INDEX)?;
-    }
+    require_index_route(&index)?;
 
     for (path, text) in [(WORKFLOW, workflow), (TESTING, testing), (INDEX, index)] {
         for stage in STAGES {
@@ -269,7 +300,7 @@ mod tests {
 
     fn valid_root() -> String {
         format!(
-            "# Rules\n\n{ROOT_HEADING}\n\nBefore selecting a design, answer or fix.\n\n{}\n{} Each atom names its owner, boundary and inputs/outputs, failure mode, and observable contract.\n{} Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.\n{} Each atom needs direct evidence or a falsifiable test or negative control.\n{} Do not synthesize until every decision-bearing atom is passed, explicitly unknown, or named as a blocker. If the synthesis contradicts a passed atom, agents MUST stop and correct the model.\n\nPerformance decompositions MUST separate census, work, queue/copy, clock, statistic and artifact. Security decompositions MUST separate identity, authentication, authorization, OS containment, lifecycle/revocation and evidence provenance.\n\n## Next\n",
+            "# Rules\n\n{ROOT_HEADING}\n\nBefore selecting a design, answer or fix.\n\n{}\n{} Each atom MUST name its owner, boundary and inputs/outputs, failure mode, and observable contract.\n{} Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.\n{} Each atom needs direct evidence or a falsifiable test or negative control.\n{} Do not synthesize until every decision-bearing atom is passed, explicitly unknown, or named as a blocker. If the synthesis contradicts a passed atom, agents MUST stop and correct the model.\n\nPerformance decompositions MUST separate census, work, queue/copy, clock, statistic and artifact. Security decompositions MUST separate identity, authentication, authorization, OS containment, lifecycle/revocation and evidence provenance.\n\n## Next\n",
             STAGES[0], STAGES[1], STAGES[2], STAGES[3], STAGES[4]
         )
     }
@@ -287,7 +318,7 @@ mod tests {
         );
         temp.write(
             INDEX,
-            "Any non-trivial design, diagnosis, review, or implementation reads Root `AGENTS.md` § Atomic problem-solving protocol.\n",
+            "| Task or path | Read |\n|---|---|\n| Any non-trivial design, diagnosis, review, or implementation | Root `AGENTS.md` § Atomic problem-solving protocol. |\n",
         );
         temp
     }
@@ -358,6 +389,37 @@ mod tests {
             let error = check(&temp.path).expect_err("hidden stage must not count as policy");
             assert!(error.contains(STAGES[0]), "{error}");
         }
+    }
+
+    #[test]
+    fn canonical_structure_and_normative_strength_are_mandatory() {
+        let temp = fixture();
+        temp.write(
+            ROOT,
+            &valid_root().replacen(ROOT_HEADING, "Atomic problem-solving protocol (MUST)", 1),
+        );
+        let error = check(&temp.path).expect_err("ordinary prose heading must fail");
+        assert!(error.contains("exactly one"), "{error}");
+
+        let temp = fixture();
+        temp.write(
+            ROOT,
+            &valid_root().replacen(
+                "Each atom MUST name its owner",
+                "Each atom MAY name its owner",
+                1,
+            ),
+        );
+        let error = check(&temp.path).expect_err("MAY must not satisfy MUST");
+        assert!(error.contains("Each atom MUST name"), "{error}");
+
+        let temp = fixture();
+        temp.write(
+            INDEX,
+            "Any non-trivial design, diagnosis, review, or implementation reads Root `AGENTS.md` § Atomic problem-solving protocol.\n",
+        );
+        let error = check(&temp.path).expect_err("plain prose is not task routing");
+        assert!(error.contains("table row"), "{error}");
     }
 
     #[test]

--- a/tools/atomic_protocol.rs
+++ b/tools/atomic_protocol.rs
@@ -1,0 +1,308 @@
+//! KEL-145 documentary contract check for Keld's atomic problem-solving protocol.
+//!
+//! Root `AGENTS.md` owns the policy. This checker only pins its mandatory stage markers
+//! and the narrower operational references. It is deliberately std-only and outside the
+//! Cargo workspace. Compile with:
+//! `rustc --edition=2024 -D warnings tools/atomic_protocol.rs`
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ROOT: &str = "AGENTS.md";
+const WORKFLOW: &str = "docs/agents/workflow.md";
+const TESTING: &str = ".agents/testing.md";
+const INDEX: &str = ".agents/index.md";
+const ROOT_HEADING: &str = "## Atomic problem-solving protocol (MUST)";
+const RETIRED_HEADING: &str = "Failure decomposition protocol (MUST)";
+
+const STAGES: &[&str] = &[
+    "1. **Decompose before deciding (MUST).**",
+    "2. **State the logical component (MUST).**",
+    "3. **Validate independence (MUST).**",
+    "4. **Verify correctness (MUST).**",
+    "5. **Synthesize only after proof (MUST).**",
+];
+
+const ROOT_SEMANTICS: &[&str] = &[
+    "Before selecting a design, answer or fix",
+    "owner, boundary and inputs/outputs, failure mode, and observable contract",
+    "Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.",
+    "direct evidence or a falsifiable test or negative control",
+    "until every decision-bearing atom is passed, explicitly unknown, or named as a blocker",
+    "If the synthesis contradicts a passed atom, agents MUST stop and correct the model",
+    "Performance decompositions MUST separate census, work, queue/copy, clock, statistic and artifact.",
+    "Security decompositions MUST separate identity, authentication, authorization, OS containment, lifecycle/revocation and evidence provenance.",
+];
+
+fn read(root: &Path, relative: &str) -> Result<String, String> {
+    let path = root.join(relative);
+    fs::read_to_string(&path).map_err(|error| {
+        format!(
+            "ATOMIC-PROTOCOL: cannot read `{}`: {error}. Restore the KEL-145 contract file.",
+            path.display()
+        )
+    })
+}
+
+fn normalize(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn section<'a>(text: &'a str, heading: &str) -> Result<&'a str, String> {
+    if text.match_indices(heading).count() != 1 {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{ROOT}` must contain exactly one `{heading}` section. Restore the canonical owner instead of copying or deleting it."
+        ));
+    }
+    let start = text.find(heading).ok_or_else(|| {
+        format!("ATOMIC-PROTOCOL: `{ROOT}` is missing canonical section `{heading}`.")
+    })?;
+    let after_heading = start + heading.len();
+    let end = text[after_heading..]
+        .find("\n## ")
+        .map_or(text.len(), |offset| after_heading + offset);
+    Ok(&text[start..end])
+}
+
+fn require_normalized(haystack: &str, needle: &str, path: &str) -> Result<(), String> {
+    if normalize(haystack).contains(&normalize(needle)) {
+        return Ok(());
+    }
+    Err(format!(
+        "ATOMIC-PROTOCOL: `{path}` is missing or weakens `{needle}`. Restore the binding KEL-145 wording."
+    ))
+}
+
+fn require_ordered(haystack: &str, needles: &[&str], path: &str) -> Result<(), String> {
+    let normalized = normalize(haystack);
+    let mut cursor = 0;
+    for needle in needles {
+        let expected = normalize(needle);
+        let Some(offset) = normalized[cursor..].find(&expected) else {
+            return Err(format!(
+                "ATOMIC-PROTOCOL: `{path}` is missing or reorders mandatory stage `{needle}`. Restore all stages in canonical order."
+            ));
+        };
+        cursor += offset + expected.len();
+    }
+    Ok(())
+}
+
+fn check_root(text: &str) -> Result<(), String> {
+    if text.contains(RETIRED_HEADING) {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{ROOT}` still contains retired duplicate `{RETIRED_HEADING}`. Reconcile failures into `{ROOT_HEADING}`."
+        ));
+    }
+    let protocol = section(text, ROOT_HEADING)?;
+    require_ordered(protocol, STAGES, ROOT)?;
+    for requirement in ROOT_SEMANTICS {
+        require_normalized(protocol, requirement, ROOT)?;
+    }
+    Ok(())
+}
+
+fn check_references(root: &Path) -> Result<(), String> {
+    let workflow = read(root, WORKFLOW)?;
+    for requirement in [
+        "root `AGENTS.md` § Atomic problem-solving protocol",
+        "same first comment MUST record the decision-bearing atoms",
+        "owner, boundary and inputs/outputs, failure mode, observable contract, independence from the other atoms, and first falsifier",
+        "A material-decision comment MUST also record every atom changed or added by the decision, its independence edges and first falsifier",
+    ] {
+        require_normalized(&workflow, requirement, WORKFLOW)?;
+    }
+
+    let testing = read(root, TESTING)?;
+    for requirement in [
+        "Root `AGENTS.md` § Atomic problem-solving protocol owns the decomposition.",
+        "bind it to one named atom's observable contract",
+        "state why its oracle is independent of the implementation and the other atoms",
+        "Every negative control MUST name the one fault or mutation that falsifies that atom",
+    ] {
+        require_normalized(&testing, requirement, TESTING)?;
+    }
+
+    let index = read(root, INDEX)?;
+    require_normalized(
+        &index,
+        "Any non-trivial design, diagnosis, review, or implementation",
+        INDEX,
+    )?;
+    require_normalized(
+        &index,
+        "Root `AGENTS.md` § Atomic problem-solving protocol",
+        INDEX,
+    )?;
+
+    for (path, text) in [(WORKFLOW, workflow), (TESTING, testing), (INDEX, index)] {
+        for stage in STAGES {
+            if normalize(&text).contains(&normalize(stage)) {
+                return Err(format!(
+                    "ATOMIC-PROTOCOL: `{path}` copies canonical stage `{stage}`. Reference `{ROOT_HEADING}` and keep only path-specific operations."
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check(root: &Path) -> Result<(), String> {
+    let root_text = read(root, ROOT)?;
+    check_root(&root_text)?;
+    check_references(root)
+}
+
+fn run_cli() -> Result<(), String> {
+    let mut args = env::args().skip(1);
+    let command = args.next().ok_or_else(|| {
+        "ATOMIC-PROTOCOL: missing command. Run `atomic-protocol check [workspace]`.".to_owned()
+    })?;
+    let root = args
+        .next()
+        .map_or_else(|| PathBuf::from("."), PathBuf::from);
+    if args.next().is_some() {
+        return Err(
+            "ATOMIC-PROTOCOL: too many arguments. Run `atomic-protocol check [workspace]`."
+                .to_owned(),
+        );
+    }
+    if command != "check" {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: unknown command `{command}`. Use `check`."
+        ));
+    }
+    check(&root)
+}
+
+fn main() {
+    if let Err(error) = run_cli() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            let id = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+            let path =
+                env::temp_dir().join(format!("keld-atomic-protocol-{}-{id}", std::process::id()));
+            fs::create_dir_all(&path).expect("create isolated fixture root");
+            Self { path }
+        }
+
+        fn write(&self, relative: &str, contents: &str) {
+            let path = self.path.join(relative);
+            fs::create_dir_all(path.parent().expect("fixture path has parent"))
+                .expect("create fixture parent");
+            fs::write(path, contents).expect("write fixture");
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn valid_root() -> String {
+        format!(
+            "# Rules\n\n{ROOT_HEADING}\n\nBefore selecting a design, answer or fix.\n\n{}\n{} Each atom names its owner, boundary and inputs/outputs, failure mode, and observable contract.\n{} Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.\n{} Each atom needs direct evidence or a falsifiable test or negative control.\n{} Do not synthesize until every decision-bearing atom is passed, explicitly unknown, or named as a blocker. If the synthesis contradicts a passed atom, agents MUST stop and correct the model.\n\nPerformance decompositions MUST separate census, work, queue/copy, clock, statistic and artifact. Security decompositions MUST separate identity, authentication, authorization, OS containment, lifecycle/revocation and evidence provenance.\n\n## Next\n",
+            STAGES[0], STAGES[1], STAGES[2], STAGES[3], STAGES[4]
+        )
+    }
+
+    fn fixture() -> TempDir {
+        let temp = TempDir::new();
+        temp.write(ROOT, &valid_root());
+        temp.write(
+            WORKFLOW,
+            "root `AGENTS.md` § Atomic problem-solving protocol\nThe same first comment MUST record the decision-bearing atoms: owner, boundary and inputs/outputs, failure mode, observable contract, independence from the other atoms, and first falsifier. A material-decision comment MUST also record every atom changed or added by the decision, its independence edges and first falsifier.\n",
+        );
+        temp.write(
+            TESTING,
+            "Root `AGENTS.md` § Atomic problem-solving protocol owns the decomposition. The author MUST bind it to one named atom's observable contract and state why its oracle is independent of the implementation and the other atoms. Every negative control MUST name the one fault or mutation that falsifies that atom.\n",
+        );
+        temp.write(
+            INDEX,
+            "Any non-trivial design, diagnosis, review, or implementation reads Root `AGENTS.md` § Atomic problem-solving protocol.\n",
+        );
+        temp
+    }
+
+    #[test]
+    fn complete_contract_passes() {
+        let temp = fixture();
+        check(&temp.path).expect("complete atomic protocol fixture must pass");
+    }
+
+    #[test]
+    fn every_mandatory_stage_fails_when_removed_or_weakened() {
+        for stage in STAGES {
+            let temp = fixture();
+            temp.write(ROOT, &valid_root().replacen(stage, "", 1));
+            let error = check(&temp.path).expect_err("removed stage must fail");
+            assert!(error.contains(stage), "{error}");
+
+            let temp = fixture();
+            let weakened = stage.replace("(MUST)", "(SHOULD)");
+            temp.write(ROOT, &valid_root().replacen(stage, &weakened, 1));
+            let error = check(&temp.path).expect_err("weakened stage must fail");
+            assert!(error.contains(stage), "{error}");
+        }
+    }
+
+    #[test]
+    fn synthesis_contradiction_rule_is_mandatory() {
+        let temp = fixture();
+        temp.write(
+            ROOT,
+            &valid_root().replace(
+                "If the synthesis contradicts a passed atom, agents MUST stop and correct the model.",
+                "",
+            ),
+        );
+        let error = check(&temp.path).expect_err("missing contradiction stop must fail");
+        assert!(error.contains("contradicts"), "{error}");
+    }
+
+    #[test]
+    fn old_failure_protocol_cannot_remain_as_a_second_owner() {
+        let temp = fixture();
+        temp.write(
+            ROOT,
+            &format!("{}\n**{RETIRED_HEADING}:** duplicate", valid_root()),
+        );
+        let error = check(&temp.path).expect_err("duplicate owner must fail");
+        assert!(error.contains("retired duplicate"), "{error}");
+    }
+
+    #[test]
+    fn operational_references_are_required_but_must_not_copy_the_stages() {
+        let temp = fixture();
+        temp.write(WORKFLOW, "material decision without atoms\n");
+        let error = check(&temp.path).expect_err("missing workflow binding must fail");
+        assert!(error.contains(WORKFLOW), "{error}");
+
+        let temp = fixture();
+        let copied = format!(
+            "root `AGENTS.md` § Atomic problem-solving protocol\nThe same first comment MUST record the decision-bearing atoms: owner, boundary and inputs/outputs, failure mode, observable contract, independence from the other atoms, and first falsifier. A material-decision comment MUST also record every atom changed or added by the decision, its independence edges and first falsifier.\n{}\n",
+            STAGES[0]
+        );
+        temp.write(WORKFLOW, &copied);
+        let error = check(&temp.path).expect_err("copied canonical stages must fail");
+        assert!(error.contains("copies canonical stage"), "{error}");
+    }
+}

--- a/tools/atomic_protocol.rs
+++ b/tools/atomic_protocol.rs
@@ -35,6 +35,25 @@ const ROOT_SEMANTICS: &[&str] = &[
     "Security decompositions MUST separate identity, authentication, authorization, OS containment, lifecycle/revocation and evidence provenance.",
 ];
 
+const WORKFLOW_REQUIREMENTS: &[&str] = &[
+    "root `AGENTS.md` § Atomic problem-solving protocol",
+    "same first comment MUST record the decision-bearing atoms",
+    "owner, boundary and inputs/outputs, failure mode, observable contract, independence from the other atoms, and first falsifier",
+    "A material-decision comment MUST also record every atom changed or added by the decision, its independence edges and first falsifier",
+];
+
+const TESTING_REQUIREMENTS: &[&str] = &[
+    "Root `AGENTS.md` § Atomic problem-solving protocol owns the decomposition.",
+    "bind it to one named atom's observable contract",
+    "state why its oracle is independent of the implementation and the other atoms",
+    "Every negative control MUST name the one fault or mutation that falsifies that atom",
+];
+
+const INDEX_REQUIREMENTS: &[&str] = &[
+    "Any non-trivial design, diagnosis, review, or implementation",
+    "Root `AGENTS.md` § Atomic problem-solving protocol",
+];
+
 fn read(root: &Path, relative: &str) -> Result<String, String> {
     let path = root.join(relative);
     fs::read_to_string(&path).map_err(|error| {
@@ -45,8 +64,56 @@ fn read(root: &Path, relative: &str) -> Result<String, String> {
     })
 }
 
+fn without_html_comments(text: &str) -> String {
+    let mut visible = String::with_capacity(text.len());
+    let mut remainder = text;
+    while let Some(start) = remainder.find("<!--") {
+        visible.push_str(&remainder[..start]);
+        let comment = &remainder[start + "<!--".len()..];
+        let Some(end) = comment.find("-->") else {
+            return visible;
+        };
+        remainder = &comment[end + "-->".len()..];
+    }
+    visible.push_str(remainder);
+    visible
+}
+
+fn visible_markdown(text: &str) -> String {
+    let without_comments = without_html_comments(text);
+    let mut visible = String::with_capacity(without_comments.len());
+    let mut fence: Option<&str> = None;
+
+    for line in without_comments.lines() {
+        let trimmed = line.trim_start();
+        let marker = if trimmed.starts_with("```") {
+            Some("```")
+        } else if trimmed.starts_with("~~~") {
+            Some("~~~")
+        } else {
+            None
+        };
+        if let Some(active) = fence {
+            if marker == Some(active) {
+                fence = None;
+            }
+            continue;
+        }
+        if let Some(opening) = marker {
+            fence = Some(opening);
+            continue;
+        }
+        visible.push_str(line);
+        visible.push('\n');
+    }
+    visible
+}
+
 fn normalize(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
+    visible_markdown(text)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn section<'a>(text: &'a str, heading: &str) -> Result<&'a str, String> {
@@ -105,36 +172,19 @@ fn check_root(text: &str) -> Result<(), String> {
 
 fn check_references(root: &Path) -> Result<(), String> {
     let workflow = read(root, WORKFLOW)?;
-    for requirement in [
-        "root `AGENTS.md` § Atomic problem-solving protocol",
-        "same first comment MUST record the decision-bearing atoms",
-        "owner, boundary and inputs/outputs, failure mode, observable contract, independence from the other atoms, and first falsifier",
-        "A material-decision comment MUST also record every atom changed or added by the decision, its independence edges and first falsifier",
-    ] {
+    for requirement in WORKFLOW_REQUIREMENTS {
         require_normalized(&workflow, requirement, WORKFLOW)?;
     }
 
     let testing = read(root, TESTING)?;
-    for requirement in [
-        "Root `AGENTS.md` § Atomic problem-solving protocol owns the decomposition.",
-        "bind it to one named atom's observable contract",
-        "state why its oracle is independent of the implementation and the other atoms",
-        "Every negative control MUST name the one fault or mutation that falsifies that atom",
-    ] {
+    for requirement in TESTING_REQUIREMENTS {
         require_normalized(&testing, requirement, TESTING)?;
     }
 
     let index = read(root, INDEX)?;
-    require_normalized(
-        &index,
-        "Any non-trivial design, diagnosis, review, or implementation",
-        INDEX,
-    )?;
-    require_normalized(
-        &index,
-        "Root `AGENTS.md` § Atomic problem-solving protocol",
-        INDEX,
-    )?;
+    for requirement in INDEX_REQUIREMENTS {
+        require_normalized(&index, requirement, INDEX)?;
+    }
 
     for (path, text) in [(WORKFLOW, workflow), (TESTING, testing), (INDEX, index)] {
         for stage in STAGES {
@@ -242,6 +292,15 @@ mod tests {
         temp
     }
 
+    fn replace_requirement(temp: &TempDir, path: &str, requirement: &str) {
+        let contents = fs::read_to_string(temp.path.join(path)).expect("read fixture document");
+        assert!(
+            contents.contains(requirement),
+            "fixture must contain `{requirement}`"
+        );
+        temp.write(path, &contents.replacen(requirement, "", 1));
+    }
+
     #[test]
     fn complete_contract_passes() {
         let temp = fixture();
@@ -279,6 +338,29 @@ mod tests {
     }
 
     #[test]
+    fn every_root_semantic_fails_when_removed() {
+        for requirement in ROOT_SEMANTICS {
+            let temp = fixture();
+            replace_requirement(&temp, ROOT, requirement);
+            let error = check(&temp.path).expect_err("removed root semantic must fail");
+            assert!(error.contains(requirement), "{error}");
+        }
+    }
+
+    #[test]
+    fn hidden_stage_text_cannot_satisfy_the_contract() {
+        for hidden in [
+            format!("<!-- {} -->", STAGES[0]),
+            format!("```text\n{}\n```", STAGES[0]),
+        ] {
+            let temp = fixture();
+            temp.write(ROOT, &valid_root().replacen(STAGES[0], &hidden, 1));
+            let error = check(&temp.path).expect_err("hidden stage must not count as policy");
+            assert!(error.contains(STAGES[0]), "{error}");
+        }
+    }
+
+    #[test]
     fn old_failure_protocol_cannot_remain_as_a_second_owner() {
         let temp = fixture();
         temp.write(
@@ -304,5 +386,22 @@ mod tests {
         temp.write(WORKFLOW, &copied);
         let error = check(&temp.path).expect_err("copied canonical stages must fail");
         assert!(error.contains("copies canonical stage"), "{error}");
+    }
+
+    #[test]
+    fn every_operational_requirement_is_independently_enforced() {
+        for (path, requirements) in [
+            (WORKFLOW, WORKFLOW_REQUIREMENTS),
+            (TESTING, TESTING_REQUIREMENTS),
+            (INDEX, INDEX_REQUIREMENTS),
+        ] {
+            for requirement in requirements {
+                let temp = fixture();
+                replace_requirement(&temp, path, requirement);
+                let error = check(&temp.path).expect_err("removed reference must fail");
+                assert!(error.contains(path), "{error}");
+                assert!(error.contains(requirement), "{error}");
+            }
+        }
     }
 }

--- a/tools/ci_changes.sh
+++ b/tools/ci_changes.sh
@@ -487,7 +487,7 @@ classify_path() {
         # These inputs own the repository-hygiene contract, but do not affect a
         # product build or graphical window.
         .github/CODEOWNERS | .github/PULL_REQUEST_TEMPLATE.md | .github/ISSUE_TEMPLATE/* | \
-        .gitignore | justfile | tools/ci_hygiene.rs)
+        .gitignore | justfile | tools/ci_hygiene.rs | tools/atomic_protocol.rs)
             hygiene="$TRUE"
             ;;
 

--- a/tools/ci_changes_test.sh
+++ b/tools/ci_changes_test.sh
@@ -115,6 +115,10 @@ expect_empty_packages "docs-only change selects no package" "$docs_classificatio
 hygiene_classification="$(result_for_paths .github/CODEOWNERS)"
 expect_flags "hygiene input runs only hygiene contract" "$hygiene_only" "$hygiene_classification"
 
+atomic_checker_classification="$(result_for_paths tools/atomic_protocol.rs)"
+expect_flags "atomic protocol checker runs only its hygiene contract" "$hygiene_only" "$atomic_checker_classification"
+expect_empty_packages "atomic protocol checker selects no package" "$atomic_checker_classification"
+
 host_classification="$(result_for_paths crates/keld-ipc/src/lib.rs)"
 expect_flags "host dependency closure routes IPC change to GUI smoke and GTK for its selected test closure" "$host_dependency" "$host_classification"
 expect_package_token "IPC change includes host consumer" keld-host "$host_classification"

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -15,6 +15,7 @@ const ISSUE_DIR: &str = ".github/ISSUE_TEMPLATE";
 const WORKFLOW: &str = ".github/workflows/ci.yml";
 const KELDBOT_WORKFLOW: &str = ".github/workflows/keldbot.yml";
 const CI_REQUIRED_EVALUATOR: &str = "tools/ci_required.sh";
+const ATOMIC_PROTOCOL_CHECKER: &str = "tools/atomic_protocol.rs";
 const GITIGNORE: &str = ".gitignore";
 const NEXTEST_CONFIG: &str = ".config/nextest.toml";
 const MERMAID_CHECKER: &str = "tools/mermaid_docs.rs";
@@ -65,6 +66,14 @@ const WORKFLOW_RUN_NEEDLES: &[&str] = &[
     "--test tools/mermaid_docs.rs",
     "mermaid-docs check .",
     "tools/mermaid_render_check.sh",
+];
+
+const ATOMIC_PROTOCOL_COMMANDS: &[&str] = &[
+    "mkdir -p target/atomic-protocol",
+    "rustc --edition=2024 -D warnings --test tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol-test",
+    "target/atomic-protocol/atomic-protocol-test",
+    "rustc --edition=2024 -D warnings tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol",
+    "target/atomic-protocol/atomic-protocol check .",
 ];
 
 fn read(root: &Path, relative: &str) -> Result<String, String> {
@@ -128,6 +137,41 @@ fn yaml_content(line: &str) -> Option<(usize, &str)> {
         .map_or(trimmed, |(before, _)| before)
         .trim_end();
     Some((indent, content))
+}
+
+fn yaml_mapping_key(content: &str) -> Option<(String, &str)> {
+    let content = content.strip_prefix("- ").unwrap_or(content);
+    let (key, value) = content.split_once(':')?;
+    Some((
+        key.trim().trim_matches(['\'', '"']).to_owned(),
+        value.trim(),
+    ))
+}
+
+fn forbidden_workflow_control_key(text: &str) -> Option<String> {
+    let mut run_block_indent = None;
+    for line in text.lines() {
+        let Some((indent, content)) = yaml_content(line) else {
+            continue;
+        };
+        if let Some(run_indent) = run_block_indent {
+            if indent > run_indent {
+                continue;
+            }
+            run_block_indent = None;
+        }
+        let Some((key, value)) = yaml_mapping_key(content) else {
+            continue;
+        };
+        if key == "run" && (value.starts_with('|') || value.starts_with('>')) {
+            run_block_indent = Some(indent);
+            continue;
+        }
+        if key == "continue-on-error" || key == "defaults" {
+            return Some(key);
+        }
+    }
+    None
 }
 
 fn workflow_has_checkout_persist_credentials_false(text: &str) -> bool {
@@ -307,6 +351,31 @@ fn workflow_job_block<'a>(text: &'a str, job_name: &str) -> Option<String> {
             continue;
         }
         if matches!(parsed, Some((indent, _)) if indent <= 2) {
+            break;
+        }
+        block.push_str(line);
+        block.push('\n');
+    }
+
+    found.then_some(block)
+}
+
+fn workflow_direct_named_step_block(text: &str, step_name: &str) -> Option<String> {
+    let expected_name = format!("- name: {step_name}");
+    let mut found = false;
+    let mut block = String::new();
+
+    for line in text.lines() {
+        let parsed = yaml_content(line);
+        if !found {
+            if matches!(parsed, Some((6, ref content)) if content == &expected_name) {
+                found = true;
+                block.push_str(line);
+                block.push('\n');
+            }
+            continue;
+        }
+        if matches!(parsed, Some((indent, _)) if indent <= 6) {
             break;
         }
         block.push_str(line);
@@ -673,8 +742,8 @@ fn check_required_job(text: &str) -> Result<(), String> {
             "CI-HYGIENE: `{WORKFLOW}` `required` must not set `continue-on-error`; the merge decision must preserve a failing exit status."
         ));
     }
-    let evaluator_keys = workflow_named_step_direct_keys(&block, "Verify required CI results")
-        .unwrap_or_default();
+    let evaluator_keys =
+        workflow_named_step_direct_keys(&block, "Verify required CI results").unwrap_or_default();
     if evaluator_keys != ["env", "run"] {
         return Err(format!(
             "CI-HYGIENE: `{WORKFLOW}` `required` evaluator step may contain only direct `env` and `run` keys; got `{}`. Conditions, custom shells, and continue-on-error can erase its failing status.",
@@ -693,9 +762,7 @@ fn check_required_job(text: &str) -> Result<(), String> {
         "hygiene",
     ];
     let actual_needs = workflow_job_sequence_values(&block, "needs").ok_or_else(|| {
-        format!(
-            "CI-HYGIENE: `{WORKFLOW}` `required` must declare a structured `needs` sequence."
-        )
+        format!("CI-HYGIENE: `{WORKFLOW}` `required` must declare a structured `needs` sequence.")
     })?;
     if actual_needs != expected_needs {
         return Err(format!(
@@ -709,10 +776,7 @@ fn check_required_job(text: &str) -> Result<(), String> {
         ("KELD_RESULT_FMT", "${{ needs.fmt.result }}"),
         ("KELD_RESULT_CHECK", "${{ needs.check.result }}"),
         ("KELD_RESULT_BUN", "${{ needs['bun-test'].result }}"),
-        (
-            "KELD_RESULT_GUI",
-            "${{ needs['linux-gui-smoke'].result }}",
-        ),
+        ("KELD_RESULT_GUI", "${{ needs['linux-gui-smoke'].result }}"),
         ("KELD_RESULT_MSRV", "${{ needs.msrv.result }}"),
         ("KELD_RESULT_DENY", "${{ needs.deny.result }}"),
         ("KELD_RESULT_SECRETS", "${{ needs.secrets.result }}"),
@@ -722,10 +786,7 @@ fn check_required_job(text: &str) -> Result<(), String> {
         ("KELD_ROUTE_GUI", "${{ needs.changes.outputs.gui }}"),
         ("KELD_ROUTE_MSRV", "${{ needs.changes.outputs.msrv }}"),
         ("KELD_ROUTE_DENY", "${{ needs.changes.outputs.deny }}"),
-        (
-            "KELD_ROUTE_HYGIENE",
-            "${{ needs.changes.outputs.hygiene }}",
-        ),
+        ("KELD_ROUTE_HYGIENE", "${{ needs.changes.outputs.hygiene }}"),
         ("KELD_ROUTE_DOCS", "${{ needs.changes.outputs.docs }}"),
     ] {
         if workflow_named_step_env_value(&block, "Verify required CI results", key).as_deref()
@@ -749,11 +810,8 @@ fn check_required_job(text: &str) -> Result<(), String> {
         "tools/ci_required.sh test".to_owned(),
         expected_check_command.to_owned(),
     ];
-    let actual_commands = workflow_named_step_shell_commands(
-        &block,
-        "Verify required CI results",
-    )
-    .unwrap_or_default();
+    let actual_commands = workflow_named_step_shell_commands(&block, "Verify required CI results")
+        .unwrap_or_default();
     if actual_commands != expected_commands {
         return Err(format!(
             "CI-HYGIENE: `{WORKFLOW}` `required` evaluator run block must contain only its self-test and the exact ordered 16-argument check, without control flow, reassignment, wrappers, or exit-status suppression."
@@ -762,6 +820,62 @@ fn check_required_job(text: &str) -> Result<(), String> {
     if !workflow_has_checkout_persist_credentials_false(&block) {
         return Err(format!(
             "CI-HYGIENE: `{WORKFLOW}` `required` checkout must set `persist-credentials: false`; the merge-decision job needs repository bytes, not push authority."
+        ));
+    }
+    Ok(())
+}
+
+fn check_atomic_protocol_step(text: &str) -> Result<(), String> {
+    const STEP: &str = "Atomic problem-solving protocol contract";
+    let Some(hygiene) = workflow_job_block(text, "hygiene") else {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` has no `hygiene` job for the atomic protocol contract."
+        ));
+    };
+    let expected_if =
+        "needs.changes.outputs.hygiene == 'true' || needs.changes.outputs.docs == 'true'";
+    if workflow_job_level_if(&hygiene).as_deref() != Some(expected_if) {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `hygiene` must run for both hygiene and docs router outputs so the atomic protocol gate cannot disappear on a docs-only edit."
+        ));
+    }
+    if workflow_job_level_property(&hygiene, "continue-on-error").is_some() {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `hygiene` must not set `continue-on-error`; `CI required` needs the atomic check's failing status."
+        ));
+    }
+    let expected_name = format!("- name: {STEP}");
+    let name_count = hygiene
+        .lines()
+        .filter_map(yaml_content)
+        .filter(|(indent, content)| *indent == 6 && *content == expected_name)
+        .count();
+    if name_count != 1 {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `hygiene` must contain exactly one `{STEP}` step; found {name_count}."
+        ));
+    }
+    let atomic_step = workflow_direct_named_step_block(&hygiene, STEP).ok_or_else(|| {
+        format!("CI-HYGIENE: `{WORKFLOW}` `{STEP}` must be a direct child of `hygiene.steps`.")
+    })?;
+    let expected_keys = ["run".to_owned()];
+    if workflow_named_step_direct_keys(&atomic_step, STEP).as_deref()
+        != Some(expected_keys.as_slice())
+    {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `{STEP}` may contain only its `run` key. A condition, custom shell, or continue-on-error can erase enforcement."
+        ));
+    }
+    let commands = workflow_named_step_shell_commands(&atomic_step, STEP).ok_or_else(|| {
+        format!("CI-HYGIENE: `{WORKFLOW}` `{STEP}` has no executable multiline `run` block.")
+    })?;
+    if commands
+        .iter()
+        .map(String::as_str)
+        .ne(ATOMIC_PROTOCOL_COMMANDS.iter().copied())
+    {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `{STEP}` must compile and run the checker tests and real checkout exactly, without wrappers or exit suppression."
         ));
     }
     Ok(())
@@ -1171,6 +1285,12 @@ fn check_issue_templates(root: &Path) -> Result<(), String> {
 fn check_workflow(root: &Path) -> Result<(), String> {
     let text = read(root, WORKFLOW)?;
     let _required_evaluator = read(root, CI_REQUIRED_EVALUATOR)?;
+    let _atomic_protocol_checker = read(root, ATOMIC_PROTOCOL_CHECKER)?;
+    if let Some(key) = forbidden_workflow_control_key(&text) {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` must not set `{key}` at workflow, job, or step scope. Required jobs use the default failure-preserving shell and must expose every failing exit status."
+        ));
+    }
     for needle in WORKFLOW_TEXT_NEEDLES {
         if !uncommented_line_contains(&text, needle) {
             return Err(format!(
@@ -1193,6 +1313,7 @@ fn check_workflow(root: &Path) -> Result<(), String> {
     check_msrv_avoids_apt(&text)?;
     check_bun_test_job(&text)?;
     check_required_job(&text)?;
+    check_atomic_protocol_step(&text)?;
     for needle in WORKFLOW_RUN_NEEDLES {
         if !workflow_has_executable_run_needle(&text, needle) {
             return Err(format!(
@@ -1384,8 +1505,16 @@ mod tests {
             "      - run: echo 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb | sha256sum -c -",
             "      - run: gitleaks detect --source . --exit-code 1",
             "  hygiene:",
+            "    if: needs.changes.outputs.hygiene == 'true' || needs.changes.outputs.docs == 'true'",
             "    steps:",
             "      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
+            "      - name: Atomic problem-solving protocol contract",
+            "        run: |",
+            "          mkdir -p target/atomic-protocol",
+            "          rustc --edition=2024 -D warnings --test tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol-test",
+            "          target/atomic-protocol/atomic-protocol-test",
+            "          rustc --edition=2024 -D warnings tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol",
+            "          target/atomic-protocol/atomic-protocol check .",
             "      - run: rustc --edition=2024 --test tools/ci_hygiene.rs",
             "      - run: rustc --edition=2024 tools/llms_docs.rs",
             "      - run: llms-docs check .",
@@ -1499,6 +1628,7 @@ mod tests {
         temp.write(WORKFLOW, &valid_workflow());
         temp.write(KELDBOT_WORKFLOW, &valid_keldbot_workflow());
         temp.write(CI_REQUIRED_EVALUATOR, "#!/usr/bin/env bash\nexit 0\n");
+        temp.write(ATOMIC_PROTOCOL_CHECKER, "fn main() {}\n");
         temp.write(MERMAID_CHECKER, "fn main() {}\n");
         temp.write(NEXTEST_CONFIG, "[profile.ci]\n");
         temp.write(
@@ -1534,6 +1664,121 @@ mod tests {
         );
         let error = check(temp.path()).expect_err("non-always required result must fail");
         assert!(error.contains("always"), "{error}");
+    }
+
+    #[test]
+    fn atomic_protocol_step_is_mandatory_and_failure_preserving() {
+        let temp = complete_fixture();
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "      - name: Atomic problem-solving protocol contract\n",
+                "",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("missing atomic step must fail");
+        assert!(error.contains("Atomic problem-solving"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "          target/atomic-protocol/atomic-protocol check .",
+                "          echo target/atomic-protocol/atomic-protocol check .",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("echoed atomic check must fail");
+        assert!(error.contains("without wrappers"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "      - name: Atomic problem-solving protocol contract\n        run:",
+                "      - name: Atomic problem-solving protocol contract\n        if: ${{ false }}\n        run:",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("skipped atomic step must fail");
+        assert!(error.contains("may contain only"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "    if: needs.changes.outputs.hygiene == 'true' || needs.changes.outputs.docs == 'true'",
+                "    if: needs.changes.outputs.hygiene == 'true'",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("docs-only atomic skip must fail");
+        assert!(error.contains("both hygiene and docs"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "  hygiene:\n    if: needs.changes.outputs.hygiene == 'true' || needs.changes.outputs.docs == 'true'",
+                "  hygiene:\n    if: needs.changes.outputs.hygiene == 'true' || needs.changes.outputs.docs == 'true'\n    continue-on-error: true",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("hygiene failure suppression must fail");
+        assert!(error.contains("continue-on-error"), "{error}");
+
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(
+                "  hygiene:\n    if:",
+                "  hygiene:\n    \"continue-on-error\": true\n    if:",
+                1,
+            ),
+        );
+        let error = check(temp.path()).expect_err("quoted failure suppression must fail");
+        assert!(error.contains("continue-on-error"), "{error}");
+
+        for (needle, replacement, label) in [
+            (
+                "  hygiene:\n    if:",
+                "  hygiene:\n    defaults:\n      run:\n        shell: bash {0} || true\n    if:",
+                "job inherited shell",
+            ),
+            (
+                "jobs:\n",
+                "defaults:\n  run:\n    shell: bash {0} || true\njobs:\n",
+                "workflow inherited shell",
+            ),
+        ] {
+            temp.write(WORKFLOW, &valid_workflow().replacen(needle, replacement, 1));
+            let error = check(temp.path()).expect_err(label);
+            assert!(error.contains("defaults"), "{error}");
+        }
+
+        let real_step = concat!(
+            "      - name: Atomic problem-solving protocol contract\n",
+            "        run: |\n",
+            "          mkdir -p target/atomic-protocol\n",
+            "          rustc --edition=2024 -D warnings --test tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol-test\n",
+            "          target/atomic-protocol/atomic-protocol-test\n",
+            "          rustc --edition=2024 -D warnings tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol\n",
+            "          target/atomic-protocol/atomic-protocol check .\n",
+        );
+        let decoy_step = concat!(
+            "      - name: Disabled decoy\n",
+            "        if: ${{ false }}\n",
+            "        run: |\n",
+            "          - name: Atomic problem-solving protocol contract\n",
+            "            run: |\n",
+            "              mkdir -p target/atomic-protocol\n",
+            "              rustc --edition=2024 -D warnings --test tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol-test\n",
+            "              target/atomic-protocol/atomic-protocol-test\n",
+            "              rustc --edition=2024 -D warnings tools/atomic_protocol.rs -o target/atomic-protocol/atomic-protocol\n",
+            "              target/atomic-protocol/atomic-protocol check .\n",
+        );
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replacen(real_step, decoy_step, 1),
+        );
+        let error = check(temp.path()).expect_err("nested decoy step must fail");
+        assert!(error.contains("exactly one"), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Make root `AGENTS.md` the single owner of the mandatory pre-decision atomic problem-solving protocol.
- Bind Linear claim/decision records and test evidence to named atoms without copying the canonical rule.
- Add a decoy-resistant std-only documentary checker and make `just ci` plus live GitHub hygiene/docs CI execute it.
- Keep justfile as the sole local-gate inventory and reject disabled, moved, hidden, weakened, duplicate, renamed, or no-op enforcement shapes.

## Spec refs

No boundary change. KEL-145 owns this repository-process contract; no architecture or product claim changes.

## Review gates

none

Root `AGENTS.md`, CI workflow, and shared agent-process files require human review under KEL-145.

## Tests

- `just atomic-protocol` — 13/13 tests and the real checkout passed.
- Negative controls reject MUST→MAY hidden by tables, historical sections, reference comments, blockquotes, strikethrough, inline/mixed-width fenced code, duplicate/renamed owners, fake routing rows, and renamed/no-op recipes.
- Exact GitHub step mutation (`MUST → MAY`) — the five-command CI chain exited 1 on the real checkout; after restoration it passed.
- CI hygiene negative controls reject moved/echoed/skipped/nested atomic steps, custom/inherited shells, quoted controls, defaults, and continue-on-error; 62/62 hygiene tests passed.
- Router suite — docs select docs, checker selects hygiene, workflow edits exercise all lanes.
- `cargo fmt --all --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo nextest run --workspace --profile ci` — 576 passed, 0 skipped.
- `bun test` in `packages/@keld/electron` — 32 passed, 0 failed.
- agents-md, llms tests/check, Mermaid tests/check, rustdoc, cargo-deny — passed; cargo-deny informational warnings remain.
- CodeRabbit CLI current-head reviews — 0 findings on protocol and CI deltas.
- Adversarial isolated current-head reviews — clean after every discovered falsifier was fixed and rerun.

## Platforms

CI-only process/documentary change verified on macOS 26.5 arm64. The workflow edit schedules Ubuntu, macOS, and Windows lanes; no real OS/device acceptance applies.

## Perf impact

No product-runtime impact. Docs/hygiene diffs compile and run two small std-only Rust checker binaries inside the existing hygiene job.

## Linear

KEL-145. KEL-128 / PR #117 is merged; branch is rebased onto `origin/main` and live `CI required` now consumes the hygiene result.
