### PR TITLE
feat(runtime): enforce Windows LPAC and host-death reaping

### DIFF
--- a/.agents/instruction-budget.tsv
+++ b/.agents/instruction-budget.tsv
@@ -4,6 +4,7 @@ CLAUDE.md	always	64	claude-root-alias	claude-session
 crates/keld-compat/AGENTS.md	always	1536	compat-invariants	path:crates/keld-compat
 crates/keld-guard/AGENTS.md	always	2560	guard-invariants	path:crates/keld-guard
 crates/keld-ipc/AGENTS.md	always	2560	ipc-invariants	path:crates/keld-ipc
+crates/keld-runtime/AGENTS.md	always	1536	runtime-invariants	path:crates/keld-runtime
 crates/keld-wv/AGENTS.md	always	4096	webview-invariants	path:crates/keld-wv
 .agents/index.md	routed	4096	task-router	root:instruction-loading
 .agents/ci.md	routed	4096	ci-keldbot-policy	route:ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ status is `docs/architecture/01-overview.md` §1.
 | keld-ipc | kipc framing/codecs; TARGET channel registry + shm; nested `AGENTS.md` |
 | keld-guard | Capabilities, manifest, scopes; nested `AGENTS.md` |
 | keld-native | Guard-checked brokers; `fs` live, rest SKELETON |
-| keld-runtime | Supervised Bun child-role runtime |
+| keld-runtime | Supervised Bun child-role runtime; nested `AGENTS.md` |
 | keld-update | SKELETON; TARGET signed manifests + delta update |
 | keld-pack | SKELETON; TARGET installers/signing/cross-compile |
 | keld-compat | Electron conformance/lifecycle oracle; TARGET host emulation; nested `AGENTS.md` |
@@ -133,7 +133,7 @@ status is `docs/architecture/01-overview.md` §1.
 | packages/ | `@keld/electron` live; other `@keld/*` upcoming |
 
 Crate `AGENTS.md` exists only for real extra invariants (`wv`, `ipc`, `guard`,
-`compat`). MUST NOT add hollow agent files.
+`compat`, `runtime`). MUST NOT add hollow agent files.
 
 ## Verification floor
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ nix = { version = "=0.31.3", default-features = false, features = ["fs", "signal
 #   does not implement the frozen manual LPAC contract. License MIT OR
 #   Apache-2.0; MSRV 1.71 <= workspace 1.97. Unsafe is isolated to reviewed
 #   Windows platform modules with exact handle/pointer lifetime proofs.
-windows-sys = { version = "=0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Isolation", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
+windows-sys = { version = "=0.61.2", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Security_Authorization", "Win32_Security_Isolation", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_LibraryLoader", "Win32_System_Registry", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 # --- Dependency review (KEL-77 T2 / AGENTS.md gate) ---
 # Name: sha2 0.10 (RustCrypto)
 # Purpose: SHA-256 for KEL-77 test artifacts and KEL-96's cold `keld-cli`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,20 @@ getrandom = "0.4"
 # signaling and `fs` supplies safe descriptor-kind/CLOEXEC validation for the
 # private liveness bootstrap. License: MIT (deny.toml allow-list).
 nix = { version = "=0.31.3", default-features = false, features = ["fs", "signal"] }
+# --- Dependency review (KEL-78/T3 / AGENTS.md gate) ---
+# Name: windows-sys =0.61.2 (microsoft/windows-rs)
+# Purpose: official target-only Win32 bindings for the unnamed host Job,
+#   zero-capability LPAC STARTUPINFOEX attributes, AppContainer profile SID,
+#   and explicit inherited-handle list required by the approved Windows T3
+#   process boundary. Already present in Cargo.lock through tempfile.
+# Alternatives rejected: std exposes none of these process security APIs;
+#   keld-wv's crate-local `windows` projection is the wrong owner and adds
+#   broader runtime surface; winapi duplicates an older binding; the 2025
+#   Experimental_CreateProcessInSandbox API is explicitly experimental and
+#   does not implement the frozen manual LPAC contract. License MIT OR
+#   Apache-2.0; MSRV 1.71 <= workspace 1.97. Unsafe is isolated to reviewed
+#   Windows platform modules with exact handle/pointer lifetime proofs.
+windows-sys = { version = "=0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Isolation", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 # --- Dependency review (KEL-77 T2 / AGENTS.md gate) ---
 # Name: sha2 0.10 (RustCrypto)
 # Purpose: SHA-256 for KEL-77 test artifacts and KEL-96's cold `keld-cli`

--- a/crates/keld-runtime/AGENTS.md
+++ b/crates/keld-runtime/AGENTS.md
@@ -1,0 +1,26 @@
+# keld-runtime invariants
+
+Extends root `AGENTS.md`; this file owns only runtime process-boundary rules.
+
+## Windows containment ABI
+
+- Production `unsafe` is limited to `windows_job.rs` and `windows_lpac.rs`.
+  Each operation MUST use the narrow `windows-sys` projection, deny
+  `unsafe_op_in_unsafe_fn`, and carry a local `// SAFETY:` handle, pointer,
+  allocation, or lifetime proof. Another runtime module requires human review
+  plus an update to this owner; tests MAY use unsafe only for independent OS
+  observation and fixture cleanup.
+- The host Job is supervisor cleanup, never authority containment. It MUST be
+  unnamed, non-inheritable, configured without breakaway, installed before any
+  child, and proved by host-only termination of a real descendant tree.
+- LPAC is the Windows authority boundary governed by
+  `docs/specs/kel78-strict-profile-sandbox.md`. A strict spawn MUST use zero
+  capabilities, the All Application Packages opt-out, reviewed path ACLs, an
+  explicit environment, and private inheritable duplicates listed in
+  `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`. Caller-owned handle flags MUST NOT be
+  toggled. The child remains suspended until token and raw handle-table
+  admission evidence passes.
+- Windows containment changes MUST run on real Windows with hostile direct-API
+  probes and a temporary negative control for the changed atom. Job cleanup,
+  LPAC denial, guarded host protocol, and resource limits remain separate
+  verdict layers; one MUST NOT substitute for another.

--- a/crates/keld-runtime/Cargo.toml
+++ b/crates/keld-runtime/Cargo.toml
@@ -14,6 +14,9 @@ keld-ipc = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 nix = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }
+
 # KEL-77 differential harness only (test-only; no shipped API).
 # - serde_json: parse fixture observation lines and emit evidence JSON.
 # - keld-compat: reuse `keld_compat::evidence::parse_evidence` (KEL-74). Do not

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -33,6 +33,8 @@ mod role;
 mod virtual_port;
 #[cfg(windows)]
 pub mod windows_job;
+#[cfg(windows)]
+pub mod windows_lpac;
 
 /// How often the supervisor thread polls a running child for exit, and the
 /// granularity at which `shutdown()` is observed.

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -31,6 +31,8 @@ pub mod registry;
 mod role;
 #[cfg(unix)]
 mod virtual_port;
+#[cfg(windows)]
+pub mod windows_job;
 
 /// How often the supervisor thread polls a running child for exit, and the
 /// granularity at which `shutdown()` is observed.

--- a/crates/keld-runtime/src/windows_job.rs
+++ b/crates/keld-runtime/src/windows_job.rs
@@ -1,0 +1,203 @@
+//! Windows host-death descendant ownership for KEL-78/T3.
+//!
+//! This is supervisor cleanup, not LPAC containment. The host installs one
+//! unnamed, non-inheritable Job before any Bun role exists. The host is a Job
+//! member, so later children inherit membership without a spawn/assignment
+//! race. The sole Job handle intentionally lives until process termination;
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` then terminates the enrolled tree even
+//! when host destructors cannot run.
+
+#![allow(unsafe_code)] // isolated Win32 Job ABI; every call has a local handle/pointer proof
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::io;
+use std::os::windows::io::{FromRawHandle as _, OwnedHandle};
+
+use windows_sys::Win32::Foundation::{
+    GetHandleInformation, HANDLE_FLAG_INHERIT, SetHandleInformation,
+};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, IsProcessInJob, JOB_OBJECT_LIMIT_BREAKAWAY_OK,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+    QueryInformationJobObject, SetInformationJobObject,
+};
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+/// Verified facts about the installed host-death Job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowsHostJobObservation {
+    /// The exact configured limit flags.
+    pub limit_flags: u32,
+    /// Whether the host was already inside an outer Job before nesting Keld's
+    /// own unnamed Job.
+    pub nested_under_existing_job: bool,
+    /// Assignment of the current host process to the Keld Job succeeded.
+    pub current_process_assigned: bool,
+    /// The sole Job handle was verified non-inheritable before assignment.
+    pub handle_inheritable: bool,
+}
+
+/// Failure to install the Windows host-death Job before child creation.
+#[derive(Debug)]
+pub struct WindowsHostJobError {
+    phase: &'static str,
+    source: io::Error,
+}
+
+impl WindowsHostJobError {
+    fn new(phase: &'static str) -> Self {
+        Self {
+            phase,
+            source: io::Error::last_os_error(),
+        }
+    }
+}
+
+impl std::fmt::Display for WindowsHostJobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "KELD-RUNTIME-014: Windows host-death Job installation failed during {}: {}. \
+             Stop before spawning Bun; verify nested Job support and retry.",
+            self.phase, self.source
+        )
+    }
+}
+
+impl std::error::Error for WindowsHostJobError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+/// Installs the one process-lifetime Windows Job that reaps Bun descendants
+/// when the host dies abnormally.
+///
+/// Call exactly once, before the first supervised child or listener is
+/// created. The unnamed Job grants no open-by-name path. Its handle is
+/// explicitly non-inheritable and intentionally retained by the OS until host
+/// termination; returning it would let a caller leak lifecycle ownership.
+///
+/// # Errors
+///
+/// Fails closed when Job creation/configuration, nested assignment, or exact
+/// flag/handle verification fails. No child may be spawned after an error.
+pub fn install_host_death_job() -> Result<WindowsHostJobObservation, WindowsHostJobError> {
+    let mut outer_job = 0;
+    // SAFETY: GetCurrentProcess returns a non-owning pseudo-handle valid for
+    // this process lifetime; `outer_job` is live writable BOOL storage. A null
+    // Job handle asks whether the process belongs to any Job.
+    if unsafe {
+        IsProcessInJob(
+            GetCurrentProcess(),
+            std::ptr::null_mut(),
+            &raw mut outer_job,
+        )
+    } == 0
+    {
+        return Err(WindowsHostJobError::new("outer Job observation"));
+    }
+
+    // SAFETY: both optional inputs are null, requesting an unnamed Job with
+    // default non-inheritable security attributes. The returned owning handle
+    // is checked before conversion.
+    let raw_job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+    if raw_job.is_null() {
+        return Err(WindowsHostJobError::new("CreateJobObjectW"));
+    }
+    // SAFETY: `raw_job` is a fresh non-null owning handle returned above and
+    // is converted exactly once.
+    let job = unsafe { OwnedHandle::from_raw_handle(raw_job.cast()) };
+
+    // Defense in depth: default SECURITY_ATTRIBUTES already makes the handle
+    // non-inheritable. Clear the bit explicitly before any child exists.
+    // SAFETY: the Job handle is live and owned by `job`; this call changes one
+    // flag and retains no pointer.
+    if unsafe { SetHandleInformation(raw_job, HANDLE_FLAG_INHERIT, 0) } == 0 {
+        return Err(WindowsHostJobError::new("Job handle inheritance clear"));
+    }
+
+    let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    let limits_size =
+        u32::try_from(std::mem::size_of_val(&limits)).map_err(|_| WindowsHostJobError {
+            phase: "Job limit structure size",
+            source: io::Error::other("JOBOBJECT_EXTENDED_LIMIT_INFORMATION exceeds u32"),
+        })?;
+    // SAFETY: `limits` is a live initialized structure of `limits_size` bytes;
+    // SetInformationJobObject copies it synchronously and retains no pointer.
+    if unsafe {
+        SetInformationJobObject(
+            raw_job,
+            JobObjectExtendedLimitInformation,
+            (&raw const limits).cast(),
+            limits_size,
+        )
+    } == 0
+    {
+        return Err(WindowsHostJobError::new("Job limit configuration"));
+    }
+
+    let mut observed_limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+    // SAFETY: `observed_limits` is live writable storage of exactly
+    // `limits_size`; the optional returned-length pointer is not needed.
+    if unsafe {
+        QueryInformationJobObject(
+            raw_job,
+            JobObjectExtendedLimitInformation,
+            (&raw mut observed_limits).cast(),
+            limits_size,
+            std::ptr::null_mut(),
+        )
+    } == 0
+    {
+        return Err(WindowsHostJobError::new("Job limit readback"));
+    }
+    let observed_flags = observed_limits.BasicLimitInformation.LimitFlags;
+    let forbidden = JOB_OBJECT_LIMIT_BREAKAWAY_OK | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK;
+    if observed_flags != JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE || observed_flags & forbidden != 0 {
+        return Err(WindowsHostJobError {
+            phase: "Job limit readback",
+            source: io::Error::other(format!(
+                "expected only KILL_ON_JOB_CLOSE, observed 0x{observed_flags:08x}"
+            )),
+        });
+    }
+
+    let mut handle_flags = 0_u32;
+    // SAFETY: `raw_job` remains live and `handle_flags` is writable storage.
+    if unsafe { GetHandleInformation(raw_job, &raw mut handle_flags) } == 0 {
+        return Err(WindowsHostJobError::new("Job handle inheritance readback"));
+    }
+    if handle_flags & HANDLE_FLAG_INHERIT != 0 {
+        return Err(WindowsHostJobError {
+            phase: "Job handle inheritance readback",
+            source: io::Error::other("Job handle remains inheritable"),
+        });
+    }
+
+    // Assignment is deliberately last: every prior failure can close an empty
+    // Job harmlessly. The current process may already belong to a CI/launcher
+    // Job; Windows 8+ nested Job semantics make this Keld Job the immediate
+    // child owner when the outer Job permits nesting.
+    // SAFETY: both handles are live for the call; GetCurrentProcess is a
+    // non-owning pseudo-handle and `raw_job` is owned by `job`.
+    if unsafe { AssignProcessToJobObject(raw_job, GetCurrentProcess()) } == 0 {
+        return Err(WindowsHostJobError::new("current-process Job assignment"));
+    }
+
+    let observation = WindowsHostJobObservation {
+        limit_flags: observed_flags,
+        nested_under_existing_job: outer_job != 0,
+        current_process_assigned: true,
+        handle_inheritable: false,
+    };
+
+    // This is an intentional process-lifetime handle, not a recoverable leak:
+    // closing it while the host is alive would synchronously terminate the
+    // host and every enrolled child. The kernel closes it on every abnormal or
+    // orderly process-termination path, which is the mechanism being proved.
+    std::mem::forget(job);
+    Ok(observation)
+}

--- a/crates/keld-runtime/src/windows_lpac.rs
+++ b/crates/keld-runtime/src/windows_lpac.rs
@@ -19,8 +19,9 @@ use windows_sys::Win32::Foundation::{
     WAIT_TIMEOUT,
 };
 use windows_sys::Win32::Security::Authorization::{
-    EXPLICIT_ACCESS_W, GetNamedSecurityInfoW, NO_MULTIPLE_TRUSTEE, SE_FILE_OBJECT, SET_ACCESS,
-    SetEntriesInAclW, SetNamedSecurityInfoW, TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
+    ConvertSidToStringSidW, EXPLICIT_ACCESS_W, GetNamedSecurityInfoW, NO_MULTIPLE_TRUSTEE,
+    SE_FILE_OBJECT, SET_ACCESS, SetEntriesInAclW, SetNamedSecurityInfoW, TRUSTEE_IS_SID,
+    TRUSTEE_IS_USER, TRUSTEE_W,
 };
 use windows_sys::Win32::Security::Isolation::{
     CreateAppContainerProfile, DeleteAppContainerProfile,
@@ -163,6 +164,47 @@ impl WindowsLpacProfile {
             ));
         }
         Ok(Self { name, sid })
+    }
+
+    /// Returns the canonical package SID string for evidence identity.
+    ///
+    /// # Errors
+    ///
+    /// Fails if Windows cannot serialize the profile SID or returns malformed
+    /// non-terminated output.
+    pub fn sid_string(&self) -> Result<String, WindowsLpacError> {
+        let mut raw = std::ptr::null_mut();
+        // SAFETY: `sid` is live and valid; `raw` receives one LocalAlloc string.
+        if unsafe { ConvertSidToStringSidW(self.sid, &raw mut raw) } == 0 {
+            return Err(WindowsLpacError::last_os("AppContainer SID serialization"));
+        }
+        if raw.is_null() {
+            return Err(WindowsLpacError::contract(
+                "AppContainer SID serialization",
+                "success returned a null string",
+            ));
+        }
+        let allocation = LocalAllocation(raw.cast());
+        let mut length = 0_usize;
+        while length < 256 {
+            // SAFETY: ConvertSidToStringSidW guarantees NUL-terminated output;
+            // the conservative SID-string bound prevents an unbounded scan.
+            if unsafe { *raw.add(length) } == 0 {
+                // SAFETY: `raw` is live UTF-16 storage of `length` units.
+                let units = unsafe { std::slice::from_raw_parts(raw, length) };
+                let value = String::from_utf16(units).map_err(|error| WindowsLpacError {
+                    phase: "AppContainer SID serialization",
+                    detail: error.to_string(),
+                })?;
+                drop(allocation);
+                return Ok(value);
+            }
+            length += 1;
+        }
+        Err(WindowsLpacError::contract(
+            "AppContainer SID serialization",
+            "SID string exceeded 255 UTF-16 units without a terminator",
+        ))
     }
 
     /// Adds the package SID to an existing filesystem DACL without replacing

--- a/crates/keld-runtime/src/windows_lpac.rs
+++ b/crates/keld-runtime/src/windows_lpac.rs
@@ -15,7 +15,7 @@ use std::os::windows::io::{AsRawHandle as _, BorrowedHandle, FromRawHandle as _,
 use std::path::Path;
 
 use windows_sys::Win32::Foundation::{
-    CloseHandle, GetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT, LocalFree, WAIT_OBJECT_0,
+    CloseHandle, DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE, LocalFree, WAIT_OBJECT_0,
     WAIT_TIMEOUT,
 };
 use windows_sys::Win32::Security::Authorization::{
@@ -35,11 +35,12 @@ use windows_sys::Win32::Storage::FileSystem::{
 };
 use windows_sys::Win32::System::Threading::{
     CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateProcessW, DeleteProcThreadAttributeList,
-    EXTENDED_STARTUPINFO_PRESENT, GetExitCodeProcess, InitializeProcThreadAttributeList,
-    OpenProcessToken, PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY,
-    PROC_THREAD_ATTRIBUTE_HANDLE_LIST, PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
-    PROCESS_INFORMATION, ResumeThread, STARTF_USESTDHANDLES, STARTUPINFOEXW, TerminateProcess,
-    UpdateProcThreadAttribute, WaitForSingleObject,
+    EXTENDED_STARTUPINFO_PRESENT, GetCurrentProcess, GetExitCodeProcess,
+    InitializeProcThreadAttributeList, OpenProcessToken,
+    PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+    PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES, PROCESS_INFORMATION, ResumeThread,
+    STARTF_USESTDHANDLES, STARTUPINFOEXW, TerminateProcess, UpdateProcThreadAttribute,
+    WaitForSingleObject,
 };
 use windows_sys::Win32::System::WindowsProgramming::PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT;
 
@@ -297,9 +298,10 @@ impl WindowsLpacProfile {
                 .map(|handle| handle.as_raw_handle().cast()),
         );
         deduplicate_handles(&mut raw_handles)?;
-        let _inheritance = HandleInheritance::enable(&raw_handles)?;
+        let inherited = InheritedHandleCopies::duplicate(&raw_handles)?;
+        let inherited_handles = inherited.raw_handles();
 
-        let attribute_count = if raw_handles.is_empty() { 2 } else { 3 };
+        let attribute_count = if inherited_handles.is_empty() { 2 } else { 3 };
         let mut attributes = AttributeList::new(attribute_count)?;
         let capabilities = SECURITY_CAPABILITIES {
             AppContainerSid: self.sid,
@@ -320,11 +322,11 @@ impl WindowsLpacProfile {
             std::mem::size_of_val(&all_packages_policy),
             "All Application Packages opt-out",
         )?;
-        if !raw_handles.is_empty() {
+        if !inherited_handles.is_empty() {
             attributes.update(
                 PROC_THREAD_ATTRIBUTE_HANDLE_LIST as usize,
-                raw_handles.as_ptr().cast(),
-                std::mem::size_of_val(raw_handles.as_slice()),
+                inherited_handles.as_ptr().cast(),
+                std::mem::size_of_val(inherited_handles.as_slice()),
                 "explicit inherited-handle list",
             )?;
         }
@@ -337,9 +339,12 @@ impl WindowsLpacProfile {
         startup.lpAttributeList = attributes.pointer;
         if let Some(stdio) = standard_handles {
             startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
-            startup.StartupInfo.hStdInput = stdio.stdin.as_raw_handle().cast();
-            startup.StartupInfo.hStdOutput = stdio.stdout.as_raw_handle().cast();
-            startup.StartupInfo.hStdError = stdio.stderr.as_raw_handle().cast();
+            startup.StartupInfo.hStdInput =
+                inherited.copy_of(stdio.stdin.as_raw_handle().cast())?;
+            startup.StartupInfo.hStdOutput =
+                inherited.copy_of(stdio.stdout.as_raw_handle().cast())?;
+            startup.StartupInfo.hStdError =
+                inherited.copy_of(stdio.stderr.as_raw_handle().cast())?;
         }
 
         create_suspended_process(
@@ -348,7 +353,7 @@ impl WindowsLpacProfile {
             &environment,
             current_dir.as_deref(),
             &startup,
-            !raw_handles.is_empty(),
+            !inherited_handles.is_empty(),
         )
     }
 }
@@ -633,13 +638,14 @@ impl Drop for AttributeList {
     }
 }
 
-struct HandleInheritance {
-    original: Vec<(HANDLE, u32)>,
+struct InheritedHandleCopies {
+    originals: Vec<HANDLE>,
+    copies: Vec<OwnedHandle>,
 }
 
-impl HandleInheritance {
-    fn enable(handles: &[HANDLE]) -> Result<Self, WindowsLpacError> {
-        let mut original = Vec::with_capacity(handles.len());
+impl InheritedHandleCopies {
+    fn duplicate(handles: &[HANDLE]) -> Result<Self, WindowsLpacError> {
+        let mut copies = Vec::with_capacity(handles.len());
         for &handle in handles {
             if handle.is_null() || handle == (-1_isize as HANDLE) {
                 return Err(WindowsLpacError::contract(
@@ -647,43 +653,60 @@ impl HandleInheritance {
                     "null or invalid handle in allowlist",
                 ));
             }
-            let mut flags = 0_u32;
-            // SAFETY: caller supplied a live borrowed handle; flags is writable.
-            if unsafe { GetHandleInformation(handle, &raw mut flags) } == 0 {
-                return Err(WindowsLpacError::last_os("inherited-handle validation"));
-            }
-            original.push((handle, flags));
-            // SAFETY: live handle; only the inherit bit is changed.
+            let mut duplicate = std::ptr::null_mut();
+            // SAFETY: the source handle and current-process pseudo-handles are
+            // live. `duplicate` receives one owning, inheritable copy with the
+            // same access. No caller-owned handle flag is changed.
             if unsafe {
-                windows_sys::Win32::Foundation::SetHandleInformation(
+                DuplicateHandle(
+                    GetCurrentProcess(),
                     handle,
-                    HANDLE_FLAG_INHERIT,
-                    HANDLE_FLAG_INHERIT,
+                    GetCurrentProcess(),
+                    &raw mut duplicate,
+                    0,
+                    1,
+                    DUPLICATE_SAME_ACCESS,
                 )
             } == 0
             {
-                let guard = Self { original };
-                drop(guard);
-                return Err(WindowsLpacError::last_os("inherited-handle preparation"));
+                return Err(WindowsLpacError::last_os(
+                    "inherited-handle private duplication",
+                ));
             }
+            if duplicate.is_null() {
+                return Err(WindowsLpacError::contract(
+                    "inherited-handle private duplication",
+                    "success returned a null duplicate",
+                ));
+            }
+            // SAFETY: duplicate is one fresh non-null owning handle.
+            copies.push(unsafe { OwnedHandle::from_raw_handle(duplicate.cast()) });
         }
-        Ok(Self { original })
+        Ok(Self {
+            originals: handles.to_vec(),
+            copies,
+        })
     }
-}
 
-impl Drop for HandleInheritance {
-    fn drop(&mut self) {
-        for &(handle, flags) in self.original.iter().rev() {
-            // SAFETY: the caller's borrowed handle outlives this guard; restore
-            // only the inherit bit to its original value.
-            let _ = unsafe {
-                windows_sys::Win32::Foundation::SetHandleInformation(
-                    handle,
-                    HANDLE_FLAG_INHERIT,
-                    flags & HANDLE_FLAG_INHERIT,
+    fn raw_handles(&self) -> Vec<HANDLE> {
+        self.copies
+            .iter()
+            .map(|handle| handle.as_raw_handle().cast())
+            .collect()
+    }
+
+    fn copy_of(&self, original: HANDLE) -> Result<HANDLE, WindowsLpacError> {
+        let index = self
+            .originals
+            .iter()
+            .position(|candidate| *candidate == original)
+            .ok_or_else(|| {
+                WindowsLpacError::contract(
+                    "standard-handle private duplication",
+                    "standard handle missing from admitted list",
                 )
-            };
-        }
+            })?;
+        Ok(self.copies[index].as_raw_handle().cast())
     }
 }
 
@@ -867,4 +890,39 @@ fn wide_nul(value: &OsStr, phase: &'static str) -> Result<Vec<u16>, WindowsLpacE
     }
     encoded.push(0);
     Ok(encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::os::windows::io::AsRawHandle as _;
+
+    use windows_sys::Win32::Foundation::{GetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT};
+
+    use super::InheritedHandleCopies;
+
+    #[test]
+    fn admitted_handle_uses_private_inheritable_copy_without_mutating_caller() {
+        let original = File::open("NUL").expect("open test handle");
+        let original_raw = original.as_raw_handle().cast();
+        assert!(!is_inheritable(original_raw));
+
+        let copies = InheritedHandleCopies::duplicate(&[original_raw])
+            .expect("duplicate admitted handle privately");
+        assert!(!is_inheritable(original_raw));
+        assert!(is_inheritable(copies.raw_handles()[0]));
+        assert_eq!(copies.copies.len(), 1);
+    }
+
+    fn is_inheritable(handle: HANDLE) -> bool {
+        let mut flags = 0_u32;
+        // SAFETY: the test supplies a live borrowed handle and writable flags.
+        assert_ne!(
+            unsafe { GetHandleInformation(handle, &raw mut flags) },
+            0,
+            "query handle flags: {}",
+            std::io::Error::last_os_error()
+        );
+        flags & HANDLE_FLAG_INHERIT != 0
+    }
 }

--- a/crates/keld-runtime/src/windows_lpac.rs
+++ b/crates/keld-runtime/src/windows_lpac.rs
@@ -1,0 +1,870 @@
+//! Zero-capability Less Privileged `AppContainer` process admission for Windows.
+//!
+//! The profile SID, ACL grants, creation attributes, admitted environment and
+//! inherited handles are constructed explicitly. A child starts suspended so
+//! its token and raw handle table can be audited before untrusted code runs.
+
+#![allow(unsafe_code)] // isolated Win32 security/process ABI; every call has a local proof
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::collections::BTreeSet;
+use std::ffi::{OsStr, OsString, c_void};
+use std::io;
+use std::os::windows::ffi::OsStrExt as _;
+use std::os::windows::io::{AsRawHandle as _, BorrowedHandle, FromRawHandle as _, OwnedHandle};
+use std::path::Path;
+
+use windows_sys::Win32::Foundation::{
+    CloseHandle, GetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT, LocalFree, WAIT_OBJECT_0,
+    WAIT_TIMEOUT,
+};
+use windows_sys::Win32::Security::Authorization::{
+    EXPLICIT_ACCESS_W, GetNamedSecurityInfoW, NO_MULTIPLE_TRUSTEE, SE_FILE_OBJECT, SET_ACCESS,
+    SetEntriesInAclW, SetNamedSecurityInfoW, TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
+};
+use windows_sys::Win32::Security::Isolation::{
+    CreateAppContainerProfile, DeleteAppContainerProfile,
+};
+use windows_sys::Win32::Security::{
+    DACL_SECURITY_INFORMATION, FreeSid, GetTokenInformation, PSID, SECURITY_CAPABILITIES,
+    SUB_CONTAINERS_AND_OBJECTS_INHERIT, TOKEN_GROUPS, TOKEN_QUERY, TokenCapabilities,
+    TokenIsAppContainer,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_TRAVERSE,
+};
+use windows_sys::Win32::System::Threading::{
+    CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateProcessW, DeleteProcThreadAttributeList,
+    EXTENDED_STARTUPINFO_PRESENT, GetExitCodeProcess, InitializeProcThreadAttributeList,
+    OpenProcessToken, PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY,
+    PROC_THREAD_ATTRIBUTE_HANDLE_LIST, PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
+    PROCESS_INFORMATION, ResumeThread, STARTF_USESTDHANDLES, STARTUPINFOEXW, TerminateProcess,
+    UpdateProcThreadAttribute, WaitForSingleObject,
+};
+use windows_sys::Win32::System::WindowsProgramming::PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT;
+
+const ERROR_SUCCESS: u32 = 0;
+const STILL_ACTIVE: u32 = 259;
+
+/// Access granted to the LPAC package SID for one reviewed filesystem path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowsLpacPathAccess {
+    /// Traverse this directory itself without listing or inherited access.
+    Traverse,
+    /// Read and execute one runtime or fixture artifact.
+    ReadExecute,
+    /// Read, write, and traverse a role-private directory and its descendants.
+    RolePrivate,
+}
+
+/// Kernel token facts observed from a created LPAC process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowsLpacTokenObservation {
+    /// The token has `AppContainer` identity.
+    pub is_app_container: bool,
+    /// The required All Application Packages opt-out was supplied to the
+    /// process-creation attribute list. Its access effect is a separate
+    /// hostile oracle because some Windows builds reject the token info class.
+    pub all_application_packages_opt_out_configured: bool,
+    /// Number of capability SIDs in the actual child token.
+    pub capability_count: u32,
+}
+
+/// Typed failure while constructing or using the Windows strict boundary.
+#[derive(Debug)]
+pub struct WindowsLpacError {
+    phase: &'static str,
+    detail: String,
+}
+
+impl WindowsLpacError {
+    fn last_os(phase: &'static str) -> Self {
+        Self {
+            phase,
+            detail: io::Error::last_os_error().to_string(),
+        }
+    }
+
+    fn status(phase: &'static str, status: i32) -> Self {
+        Self {
+            phase,
+            detail: format!("HRESULT/NT status 0x{:08x}", status.cast_unsigned()),
+        }
+    }
+
+    fn win32(phase: &'static str, status: u32) -> Self {
+        Self {
+            phase,
+            detail: io::Error::from_raw_os_error(status.cast_signed()).to_string(),
+        }
+    }
+
+    fn contract(phase: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            phase,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for WindowsLpacError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "KELD-RUNTIME-015: Windows LPAC admission failed during {}: {}. \
+             Do not start an unconfined replacement; repair the profile, ACL, or handle list.",
+            self.phase, self.detail
+        )
+    }
+}
+
+impl std::error::Error for WindowsLpacError {}
+
+/// One zero-capability `AppContainer` profile and its owning SID allocation.
+#[derive(Debug)]
+pub struct WindowsLpacProfile {
+    name: Vec<u16>,
+    sid: PSID,
+}
+
+impl WindowsLpacProfile {
+    /// Creates a new, uniquely named profile with no capability SIDs.
+    ///
+    /// # Errors
+    ///
+    /// Fails rather than opening an existing profile, because an existing
+    /// identity would make ACL/profile-generation provenance ambiguous.
+    pub fn create(name: &OsStr) -> Result<Self, WindowsLpacError> {
+        let name = wide_nul(name, "AppContainer profile name")?;
+        let mut sid = std::ptr::null_mut();
+        // SAFETY: all three strings are live NUL-terminated UTF-16 buffers;
+        // capability pointer/count are both empty; `sid` is writable storage.
+        let status = unsafe {
+            CreateAppContainerProfile(
+                name.as_ptr(),
+                name.as_ptr(),
+                name.as_ptr(),
+                std::ptr::null(),
+                0,
+                &raw mut sid,
+            )
+        };
+        if status < 0 {
+            return Err(WindowsLpacError::status(
+                "CreateAppContainerProfile",
+                status,
+            ));
+        }
+        if sid.is_null() {
+            return Err(WindowsLpacError::contract(
+                "CreateAppContainerProfile",
+                "success returned a null package SID",
+            ));
+        }
+        Ok(Self { name, sid })
+    }
+
+    /// Adds the package SID to an existing filesystem DACL without replacing
+    /// its other access entries.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the path does not exist or its DACL cannot be read, merged,
+    /// and written exactly.
+    pub fn grant_path(
+        &self,
+        path: &Path,
+        access: WindowsLpacPathAccess,
+    ) -> Result<(), WindowsLpacError> {
+        let path_wide = wide_nul(path.as_os_str(), "ACL path")?;
+        let metadata = std::fs::metadata(path).map_err(|error| WindowsLpacError {
+            phase: "ACL path metadata",
+            detail: error.to_string(),
+        })?;
+
+        let mut old_acl = std::ptr::null_mut();
+        let mut security_descriptor = std::ptr::null_mut();
+        // SAFETY: `path_wide` is NUL terminated; the requested output slots
+        // are live. The returned descriptor owns the borrowed old ACL.
+        let status = unsafe {
+            GetNamedSecurityInfoW(
+                path_wide.as_ptr(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &raw mut old_acl,
+                std::ptr::null_mut(),
+                &raw mut security_descriptor,
+            )
+        };
+        if status != ERROR_SUCCESS {
+            return Err(WindowsLpacError::win32("filesystem DACL read", status));
+        }
+        let descriptor = LocalAllocation(security_descriptor);
+
+        let permissions = match access {
+            WindowsLpacPathAccess::Traverse => FILE_TRAVERSE,
+            WindowsLpacPathAccess::ReadExecute => FILE_GENERIC_READ | FILE_GENERIC_EXECUTE,
+            WindowsLpacPathAccess::RolePrivate => {
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE | FILE_GENERIC_EXECUTE
+            }
+        };
+        let inheritance = if metadata.is_dir() && access != WindowsLpacPathAccess::Traverse {
+            SUB_CONTAINERS_AND_OBJECTS_INHERIT
+        } else {
+            0
+        };
+        let entry = EXPLICIT_ACCESS_W {
+            grfAccessPermissions: permissions,
+            grfAccessMode: SET_ACCESS,
+            grfInheritance: inheritance,
+            Trustee: TRUSTEE_W {
+                pMultipleTrustee: std::ptr::null_mut(),
+                MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+                TrusteeForm: TRUSTEE_IS_SID,
+                TrusteeType: TRUSTEE_IS_USER,
+                ptstrName: self.sid.cast(),
+            },
+        };
+        let mut new_acl = std::ptr::null_mut();
+        // SAFETY: `entry` and old ACL remain live for the synchronous merge;
+        // `new_acl` receives one LocalAlloc allocation on success.
+        let status = unsafe { SetEntriesInAclW(1, &raw const entry, old_acl, &raw mut new_acl) };
+        if status != ERROR_SUCCESS {
+            return Err(WindowsLpacError::win32("filesystem DACL merge", status));
+        }
+        let new_acl = LocalAllocation(new_acl.cast());
+        // SAFETY: the path is live and `new_acl` contains the merged DACL;
+        // SetNamedSecurityInfoW copies it before returning.
+        let status = unsafe {
+            SetNamedSecurityInfoW(
+                path_wide.as_ptr().cast_mut(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                new_acl.0.cast(),
+                std::ptr::null(),
+            )
+        };
+        drop(descriptor);
+        if status != ERROR_SUCCESS {
+            return Err(WindowsLpacError::win32("filesystem DACL write", status));
+        }
+        Ok(())
+    }
+
+    /// Creates a suspended LPAC child with an explicit environment and exact
+    /// inherited-handle list.
+    ///
+    /// `standard_handles`, when present, are added to the allowlist and wired
+    /// as stdin/stdout/stderr. `extra_handles` is reserved for authenticated
+    /// app-link transport. No other handle is admitted.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on malformed input, attribute construction, inheritance
+    /// preparation, or process creation. The child never runs on success until
+    /// [`WindowsLpacChild::resume`] is called.
+    pub fn spawn_suspended(
+        &self,
+        program: &Path,
+        args: &[OsString],
+        environment: &[(OsString, OsString)],
+        current_dir: Option<&Path>,
+        standard_handles: Option<WindowsLpacStdio<'_>>,
+        extra_handles: &[BorrowedHandle<'_>],
+    ) -> Result<WindowsLpacChild, WindowsLpacError> {
+        let application = wide_nul(program.as_os_str(), "application path")?;
+        let mut command_line = encode_command_line(program.as_os_str(), args)?;
+        let environment = encode_environment(environment)?;
+        let current_dir = current_dir
+            .map(|path| wide_nul(path.as_os_str(), "current directory"))
+            .transpose()?;
+
+        let mut raw_handles = Vec::with_capacity(extra_handles.len() + 3);
+        if let Some(stdio) = standard_handles {
+            raw_handles.extend([
+                stdio.stdin.as_raw_handle().cast(),
+                stdio.stdout.as_raw_handle().cast(),
+                stdio.stderr.as_raw_handle().cast(),
+            ]);
+        }
+        raw_handles.extend(
+            extra_handles
+                .iter()
+                .map(|handle| handle.as_raw_handle().cast()),
+        );
+        deduplicate_handles(&mut raw_handles)?;
+        let _inheritance = HandleInheritance::enable(&raw_handles)?;
+
+        let attribute_count = if raw_handles.is_empty() { 2 } else { 3 };
+        let mut attributes = AttributeList::new(attribute_count)?;
+        let capabilities = SECURITY_CAPABILITIES {
+            AppContainerSid: self.sid,
+            Capabilities: std::ptr::null_mut(),
+            CapabilityCount: 0,
+            Reserved: 0,
+        };
+        attributes.update(
+            PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES as usize,
+            (&raw const capabilities).cast(),
+            std::mem::size_of_val(&capabilities),
+            "zero-capability SECURITY_CAPABILITIES",
+        )?;
+        let all_packages_policy = PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT;
+        attributes.update(
+            PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY as usize,
+            (&raw const all_packages_policy).cast(),
+            std::mem::size_of_val(&all_packages_policy),
+            "All Application Packages opt-out",
+        )?;
+        if !raw_handles.is_empty() {
+            attributes.update(
+                PROC_THREAD_ATTRIBUTE_HANDLE_LIST as usize,
+                raw_handles.as_ptr().cast(),
+                std::mem::size_of_val(raw_handles.as_slice()),
+                "explicit inherited-handle list",
+            )?;
+        }
+
+        let mut startup = STARTUPINFOEXW::default();
+        startup.StartupInfo.cb =
+            u32::try_from(std::mem::size_of::<STARTUPINFOEXW>()).map_err(|_| {
+                WindowsLpacError::contract("STARTUPINFOEXW size", "structure exceeds u32")
+            })?;
+        startup.lpAttributeList = attributes.pointer;
+        if let Some(stdio) = standard_handles {
+            startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+            startup.StartupInfo.hStdInput = stdio.stdin.as_raw_handle().cast();
+            startup.StartupInfo.hStdOutput = stdio.stdout.as_raw_handle().cast();
+            startup.StartupInfo.hStdError = stdio.stderr.as_raw_handle().cast();
+        }
+
+        create_suspended_process(
+            &application,
+            &mut command_line,
+            &environment,
+            current_dir.as_deref(),
+            &startup,
+            !raw_handles.is_empty(),
+        )
+    }
+}
+
+impl Drop for WindowsLpacProfile {
+    fn drop(&mut self) {
+        // SAFETY: the name remains NUL terminated and identifies only this
+        // profile. Deletion revokes the persistent profile registration; live
+        // process tokens remain kernel-owned.
+        let _ = unsafe { DeleteAppContainerProfile(self.name.as_ptr()) };
+        // SAFETY: `sid` is the one allocation returned by profile creation and
+        // is released exactly once here.
+        let _ = unsafe { FreeSid(self.sid) };
+    }
+}
+
+fn create_suspended_process(
+    application: &[u16],
+    command_line: &mut [u16],
+    environment: &[u16],
+    current_dir: Option<&[u16]>,
+    startup: &STARTUPINFOEXW,
+    inherit_handles: bool,
+) -> Result<WindowsLpacChild, WindowsLpacError> {
+    let mut process = PROCESS_INFORMATION::default();
+    let creation_flags =
+        CREATE_SUSPENDED | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT;
+    // SAFETY: every pointer refers to live storage through this synchronous
+    // call; command line is mutable as required; attributes retain their
+    // backing values; process/thread outputs are writable. TRUE inheritance
+    // is used only together with the explicit handle-list attribute.
+    let created = unsafe {
+        CreateProcessW(
+            application.as_ptr(),
+            command_line.as_mut_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            i32::from(inherit_handles),
+            creation_flags,
+            environment.as_ptr().cast(),
+            current_dir.map_or(std::ptr::null(), <[u16]>::as_ptr),
+            (&raw const startup.StartupInfo).cast(),
+            &raw mut process,
+        )
+    };
+    if created == 0 {
+        return Err(WindowsLpacError::last_os("CreateProcessW LPAC launch"));
+    }
+    if process.hProcess.is_null() || process.hThread.is_null() {
+        // SAFETY: any non-null output belongs to this failed construction.
+        unsafe {
+            if !process.hProcess.is_null() {
+                let _ = CloseHandle(process.hProcess);
+            }
+            if !process.hThread.is_null() {
+                let _ = CloseHandle(process.hThread);
+            }
+        }
+        return Err(WindowsLpacError::contract(
+            "CreateProcessW LPAC launch",
+            "success returned a null process or thread handle",
+        ));
+    }
+
+    Ok(WindowsLpacChild {
+        // SAFETY: both handles are fresh, non-null owning handles returned by
+        // CreateProcessW and each is converted exactly once.
+        process: unsafe { OwnedHandle::from_raw_handle(process.hProcess.cast()) },
+        thread: Some(unsafe { OwnedHandle::from_raw_handle(process.hThread.cast()) }),
+        pid: process.dwProcessId,
+        terminated: false,
+    })
+}
+
+/// The exact standard handles admitted to one LPAC child.
+#[derive(Debug, Clone, Copy)]
+pub struct WindowsLpacStdio<'a> {
+    /// Child standard input.
+    pub stdin: BorrowedHandle<'a>,
+    /// Child standard output.
+    pub stdout: BorrowedHandle<'a>,
+    /// Child standard error.
+    pub stderr: BorrowedHandle<'a>,
+}
+
+/// Owning handle pair for a suspended or running LPAC child.
+#[derive(Debug)]
+pub struct WindowsLpacChild {
+    process: OwnedHandle,
+    thread: Option<OwnedHandle>,
+    pid: u32,
+    terminated: bool,
+}
+
+impl WindowsLpacChild {
+    /// Returns the OS process identifier used only for evidence correlation.
+    #[must_use]
+    pub fn id(&self) -> u32 {
+        self.pid
+    }
+
+    /// Borrows the process handle for token and cross-process handle-table
+    /// observation before resume.
+    #[must_use]
+    pub fn process_handle(&self) -> BorrowedHandle<'_> {
+        // SAFETY: the returned borrow cannot outlive `self.process`.
+        unsafe { BorrowedHandle::borrow_raw(self.process.as_raw_handle()) }
+    }
+
+    /// Reads the kernel token's `AppContainer`, LPAC, and capability facts.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the token cannot be opened or any fact cannot be queried.
+    pub fn observe_token(&self) -> Result<WindowsLpacTokenObservation, WindowsLpacError> {
+        let mut raw_token = std::ptr::null_mut();
+        // SAFETY: process handle is live; output receives one token handle.
+        if unsafe {
+            OpenProcessToken(
+                self.process.as_raw_handle().cast(),
+                TOKEN_QUERY,
+                &raw mut raw_token,
+            )
+        } == 0
+        {
+            return Err(WindowsLpacError::last_os("LPAC child token open"));
+        }
+        if raw_token.is_null() {
+            return Err(WindowsLpacError::contract(
+                "LPAC child token open",
+                "success returned a null token handle",
+            ));
+        }
+        // SAFETY: fresh non-null owning token handle converted once.
+        let token = unsafe { OwnedHandle::from_raw_handle(raw_token.cast()) };
+        let is_app_container = query_token_u32(&token, TokenIsAppContainer, "TokenIsAppContainer")?;
+        let capabilities = query_token_buffer(&token, TokenCapabilities, "TokenCapabilities")?;
+        // SAFETY: query_token_buffer returns aligned storage filled for the
+        // requested TOKEN_GROUPS class and keeps it live for this read.
+        let capability_count =
+            unsafe { (*(capabilities.as_ptr().cast::<TOKEN_GROUPS>())).GroupCount };
+        Ok(WindowsLpacTokenObservation {
+            is_app_container: is_app_container != 0,
+            all_application_packages_opt_out_configured: true,
+            capability_count,
+        })
+    }
+
+    /// Resumes the initially suspended primary thread exactly once.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the child was already resumed or the kernel rejects resume.
+    pub fn resume(&mut self) -> Result<(), WindowsLpacError> {
+        let thread = self.thread.as_ref().ok_or_else(|| {
+            WindowsLpacError::contract("LPAC child resume", "primary thread already resumed")
+        })?;
+        // SAFETY: the primary-thread handle is live and still owned here.
+        if unsafe { ResumeThread(thread.as_raw_handle().cast()) } == u32::MAX {
+            return Err(WindowsLpacError::last_os("LPAC child resume"));
+        }
+        self.thread = None;
+        Ok(())
+    }
+
+    /// Waits for termination and returns the exact Windows exit code.
+    ///
+    /// # Errors
+    ///
+    /// Fails on timeout or process-status query failure.
+    pub fn wait(&mut self, timeout_ms: u32) -> Result<u32, WindowsLpacError> {
+        // SAFETY: process handle remains live for the wait.
+        match unsafe { WaitForSingleObject(self.process.as_raw_handle().cast(), timeout_ms) } {
+            WAIT_OBJECT_0 => {}
+            WAIT_TIMEOUT => {
+                return Err(WindowsLpacError::contract(
+                    "LPAC child wait",
+                    format!("process {} exceeded {timeout_ms} ms", self.pid),
+                ));
+            }
+            _ => return Err(WindowsLpacError::last_os("LPAC child wait")),
+        }
+        let mut exit_code = STILL_ACTIVE;
+        // SAFETY: live process handle and writable exit-code storage.
+        if unsafe { GetExitCodeProcess(self.process.as_raw_handle().cast(), &raw mut exit_code) }
+            == 0
+        {
+            return Err(WindowsLpacError::last_os("LPAC child exit code"));
+        }
+        self.terminated = true;
+        Ok(exit_code)
+    }
+
+    /// Terminates only this test/supervisor-owned child.
+    ///
+    /// # Errors
+    ///
+    /// Fails if Windows rejects termination.
+    pub fn terminate(&mut self, exit_code: u32) -> Result<(), WindowsLpacError> {
+        // SAFETY: live owning process handle; the caller owns this child.
+        if unsafe { TerminateProcess(self.process.as_raw_handle().cast(), exit_code) } == 0 {
+            return Err(WindowsLpacError::last_os("LPAC child terminate"));
+        }
+        self.terminated = true;
+        Ok(())
+    }
+}
+
+impl Drop for WindowsLpacChild {
+    fn drop(&mut self) {
+        if self.terminated {
+            return;
+        }
+        // SAFETY: this owner never detaches. Termination prevents a suspended
+        // or failed-evidence child from escaping when callers unwind.
+        let _ = unsafe { TerminateProcess(self.process.as_raw_handle().cast(), 1) };
+    }
+}
+
+struct AttributeList {
+    _storage: Vec<usize>,
+    pointer: *mut c_void,
+}
+
+impl AttributeList {
+    fn new(count: u32) -> Result<Self, WindowsLpacError> {
+        let mut bytes = 0_usize;
+        // SAFETY: null is the documented sizing call; `bytes` is writable.
+        let _ = unsafe {
+            InitializeProcThreadAttributeList(std::ptr::null_mut(), count, 0, &raw mut bytes)
+        };
+        if bytes == 0 {
+            return Err(WindowsLpacError::last_os("process attribute-list sizing"));
+        }
+        let words = bytes.div_ceil(std::mem::size_of::<usize>());
+        let mut storage = vec![0_usize; words];
+        let pointer = storage.as_mut_ptr().cast();
+        // SAFETY: storage is aligned and at least the sized byte count; it
+        // remains owned by this structure until DeleteProcThreadAttributeList.
+        if unsafe { InitializeProcThreadAttributeList(pointer, count, 0, &raw mut bytes) } == 0 {
+            return Err(WindowsLpacError::last_os(
+                "process attribute-list initialization",
+            ));
+        }
+        Ok(Self {
+            _storage: storage,
+            pointer,
+        })
+    }
+
+    fn update(
+        &mut self,
+        attribute: usize,
+        value: *const c_void,
+        bytes: usize,
+        phase: &'static str,
+    ) -> Result<(), WindowsLpacError> {
+        // SAFETY: list is initialized and live; each value is retained by the
+        // caller through CreateProcessW; optional output pointers are null.
+        if unsafe {
+            UpdateProcThreadAttribute(
+                self.pointer,
+                0,
+                attribute,
+                value,
+                bytes,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+            )
+        } == 0
+        {
+            return Err(WindowsLpacError::last_os(phase));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for AttributeList {
+    fn drop(&mut self) {
+        // SAFETY: pointer was initialized once and storage remains live.
+        unsafe { DeleteProcThreadAttributeList(self.pointer) };
+    }
+}
+
+struct HandleInheritance {
+    original: Vec<(HANDLE, u32)>,
+}
+
+impl HandleInheritance {
+    fn enable(handles: &[HANDLE]) -> Result<Self, WindowsLpacError> {
+        let mut original = Vec::with_capacity(handles.len());
+        for &handle in handles {
+            if handle.is_null() || handle == (-1_isize as HANDLE) {
+                return Err(WindowsLpacError::contract(
+                    "inherited-handle validation",
+                    "null or invalid handle in allowlist",
+                ));
+            }
+            let mut flags = 0_u32;
+            // SAFETY: caller supplied a live borrowed handle; flags is writable.
+            if unsafe { GetHandleInformation(handle, &raw mut flags) } == 0 {
+                return Err(WindowsLpacError::last_os("inherited-handle validation"));
+            }
+            original.push((handle, flags));
+            // SAFETY: live handle; only the inherit bit is changed.
+            if unsafe {
+                windows_sys::Win32::Foundation::SetHandleInformation(
+                    handle,
+                    HANDLE_FLAG_INHERIT,
+                    HANDLE_FLAG_INHERIT,
+                )
+            } == 0
+            {
+                let guard = Self { original };
+                drop(guard);
+                return Err(WindowsLpacError::last_os("inherited-handle preparation"));
+            }
+        }
+        Ok(Self { original })
+    }
+}
+
+impl Drop for HandleInheritance {
+    fn drop(&mut self) {
+        for &(handle, flags) in self.original.iter().rev() {
+            // SAFETY: the caller's borrowed handle outlives this guard; restore
+            // only the inherit bit to its original value.
+            let _ = unsafe {
+                windows_sys::Win32::Foundation::SetHandleInformation(
+                    handle,
+                    HANDLE_FLAG_INHERIT,
+                    flags & HANDLE_FLAG_INHERIT,
+                )
+            };
+        }
+    }
+}
+
+struct LocalAllocation(*mut c_void);
+
+impl Drop for LocalAllocation {
+    fn drop(&mut self) {
+        if self.0.is_null() {
+            return;
+        }
+        // SAFETY: pointer is one LocalAlloc-family allocation returned by the
+        // security API and is released once here.
+        let _ = unsafe { LocalFree(self.0) };
+    }
+}
+
+fn query_token_u32(
+    token: &OwnedHandle,
+    class: i32,
+    phase: &'static str,
+) -> Result<u32, WindowsLpacError> {
+    let mut value = 0_u32;
+    let mut returned = 0_u32;
+    // SAFETY: token is live; value and returned length are writable.
+    if unsafe {
+        GetTokenInformation(
+            token.as_raw_handle().cast(),
+            class,
+            (&raw mut value).cast(),
+            u32::try_from(std::mem::size_of_val(&value)).unwrap_or(u32::MAX),
+            &raw mut returned,
+        )
+    } == 0
+    {
+        return Err(WindowsLpacError::last_os(phase));
+    }
+    Ok(value)
+}
+
+fn query_token_buffer(
+    token: &OwnedHandle,
+    class: i32,
+    phase: &'static str,
+) -> Result<Vec<usize>, WindowsLpacError> {
+    let mut bytes = 0_u32;
+    // SAFETY: null sizing call with writable returned length.
+    let _ = unsafe {
+        GetTokenInformation(
+            token.as_raw_handle().cast(),
+            class,
+            std::ptr::null_mut(),
+            0,
+            &raw mut bytes,
+        )
+    };
+    if bytes == 0 {
+        return Err(WindowsLpacError::last_os(phase));
+    }
+    let byte_count = usize::try_from(bytes)
+        .map_err(|_| WindowsLpacError::contract(phase, "token information length exceeds usize"))?;
+    let mut storage = vec![0_usize; byte_count.div_ceil(std::mem::size_of::<usize>())];
+    // SAFETY: aligned storage has at least `bytes` writable bytes.
+    if unsafe {
+        GetTokenInformation(
+            token.as_raw_handle().cast(),
+            class,
+            storage.as_mut_ptr().cast(),
+            bytes,
+            &raw mut bytes,
+        )
+    } == 0
+    {
+        return Err(WindowsLpacError::last_os(phase));
+    }
+    Ok(storage)
+}
+
+fn deduplicate_handles(handles: &mut Vec<HANDLE>) -> Result<(), WindowsLpacError> {
+    let mut seen = BTreeSet::new();
+    handles.retain(|handle| seen.insert(*handle as usize));
+    if handles.len() > u32::MAX as usize {
+        return Err(WindowsLpacError::contract(
+            "inherited-handle list",
+            "handle count exceeds u32",
+        ));
+    }
+    Ok(())
+}
+
+fn encode_command_line(program: &OsStr, args: &[OsString]) -> Result<Vec<u16>, WindowsLpacError> {
+    let mut encoded = Vec::new();
+    append_quoted_arg(&mut encoded, program)?;
+    for arg in args {
+        encoded.push(u16::from(b' '));
+        append_quoted_arg(&mut encoded, arg)?;
+    }
+    encoded.push(0);
+    Ok(encoded)
+}
+
+fn append_quoted_arg(output: &mut Vec<u16>, arg: &OsStr) -> Result<(), WindowsLpacError> {
+    let units: Vec<u16> = arg.encode_wide().collect();
+    if units.contains(&0) {
+        return Err(WindowsLpacError::contract(
+            "command-line encoding",
+            "argument contains NUL",
+        ));
+    }
+    let needs_quotes =
+        units.is_empty() || units.iter().any(|unit| matches!(*unit, 0x20 | 0x09 | 0x22));
+    if !needs_quotes {
+        output.extend(units);
+        return Ok(());
+    }
+
+    output.push(u16::from(b'"'));
+    let mut slashes = 0_usize;
+    for unit in units {
+        if unit == u16::from(b'\\') {
+            slashes += 1;
+            continue;
+        }
+        if unit == u16::from(b'"') {
+            output.extend(std::iter::repeat_n(u16::from(b'\\'), slashes * 2 + 1));
+        } else {
+            output.extend(std::iter::repeat_n(u16::from(b'\\'), slashes));
+        }
+        slashes = 0;
+        output.push(unit);
+    }
+    output.extend(std::iter::repeat_n(u16::from(b'\\'), slashes * 2));
+    output.push(u16::from(b'"'));
+    Ok(())
+}
+
+fn encode_environment(environment: &[(OsString, OsString)]) -> Result<Vec<u16>, WindowsLpacError> {
+    let mut ordered = Vec::with_capacity(environment.len());
+    let mut keys = BTreeSet::new();
+    for (key, value) in environment {
+        let key_units: Vec<u16> = key.encode_wide().collect();
+        let value_units: Vec<u16> = value.encode_wide().collect();
+        if key_units.is_empty()
+            || key_units.contains(&0)
+            || key_units.contains(&u16::from(b'='))
+            || value_units.contains(&0)
+        {
+            return Err(WindowsLpacError::contract(
+                "environment encoding",
+                "key is empty/contains '=' or key/value contains NUL",
+            ));
+        }
+        let folded = key.to_string_lossy().to_uppercase();
+        if !keys.insert(folded.clone()) {
+            return Err(WindowsLpacError::contract(
+                "environment encoding",
+                format!("duplicate case-insensitive key {folded}"),
+            ));
+        }
+        ordered.push((folded, key_units, value_units));
+    }
+    ordered.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let mut encoded = Vec::new();
+    for (_, key, value) in ordered {
+        encoded.extend(key);
+        encoded.push(u16::from(b'='));
+        encoded.extend(value);
+        encoded.push(0);
+    }
+    encoded.push(0);
+    if environment.is_empty() {
+        encoded.push(0);
+    }
+    Ok(encoded)
+}
+
+fn wide_nul(value: &OsStr, phase: &'static str) -> Result<Vec<u16>, WindowsLpacError> {
+    let mut encoded: Vec<u16> = value.encode_wide().collect();
+    if encoded.contains(&0) {
+        return Err(WindowsLpacError::contract(phase, "value contains NUL"));
+    }
+    encoded.push(0);
+    Ok(encoded)
+}

--- a/crates/keld-runtime/tests/windows_host_death_job.rs
+++ b/crates/keld-runtime/tests/windows_host_death_job.rs
@@ -1,0 +1,219 @@
+//! Real Windows process-tree proof for the KEL-78/T3 host-death Job.
+
+#![cfg(windows)]
+#![allow(unsafe_code)] // isolated test-only process-handle observation with local ABI proofs
+#![allow(clippy::expect_used, clippy::panic)] // process fixture invariants must abort loudly
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::env;
+use std::io::{self, BufRead as _, BufReader, Write as _};
+use std::os::windows::io::{FromRawHandle as _, OwnedHandle};
+use std::process::{Child, Command, Stdio};
+
+use keld_runtime::windows_job::install_host_death_job;
+use windows_sys::Win32::Foundation::WAIT_OBJECT_0;
+use windows_sys::Win32::System::Threading::{
+    OpenProcess, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, TerminateProcess, WaitForSingleObject,
+};
+
+const HELPER_ENV: &str = "KELD_WINDOWS_JOB_HELPER";
+const HELPER_TEST: &str = "windows_job_process_helper";
+const PROCESS_WAIT_MS: u32 = 10_000;
+
+#[test]
+fn abnormal_host_death_reaps_direct_child_and_descendant_then_relaunches() {
+    let mut host = spawn_helper("host");
+    let stdout = host.stdout.take().expect("host stdout pipe");
+    let mut lines = BufReader::new(stdout).lines();
+
+    let observation = next_prefixed_line(&mut lines, "JOB ");
+    assert!(
+        observation.contains("limits=0x00002000"),
+        "Job must report only KILL_ON_JOB_CLOSE: {observation}"
+    );
+    assert!(
+        observation.contains("assigned=true") && observation.contains("inheritable=false"),
+        "Job assignment and non-inheritance must be observed: {observation}"
+    );
+
+    let direct_pid = parse_pid(&next_prefixed_line(&mut lines, "DIRECT "), "DIRECT");
+    let descendant_pid = parse_pid(&next_prefixed_line(&mut lines, "DESCENDANT "), "DESCENDANT");
+    let direct = open_process_for_wait(direct_pid);
+    let descendant = open_process_for_wait(descendant_pid);
+
+    // Child::kill terminates this one host process. It does not request tree
+    // termination, so the two retained process handles independently observe
+    // whether the Job kernel contract reaped both enrolled descendants.
+    host.kill()
+        .expect("terminate only the host fixture process");
+    let _ = host.wait().expect("wait for terminated host fixture");
+    assert_process_exited(&direct, "direct child");
+    assert_process_exited(&descendant, "descendant");
+
+    let relaunch = spawn_helper("relaunch")
+        .wait_with_output()
+        .expect("run post-cleanup launch");
+    assert!(
+        relaunch.status.success(),
+        "post-cleanup launch failed: status={} stderr={}",
+        relaunch.status,
+        String::from_utf8_lossy(&relaunch.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&relaunch.stdout).contains("RELAUNCH_OK"),
+        "post-cleanup launch did not report success: {}",
+        String::from_utf8_lossy(&relaunch.stdout)
+    );
+}
+
+#[test]
+#[ignore = "private subprocess entry point"]
+fn windows_job_process_helper() {
+    match env::var(HELPER_ENV).as_deref() {
+        Ok("host") => run_host_helper(),
+        Ok("direct") => run_direct_helper(),
+        Ok("descendant") => run_descendant_helper(),
+        Ok("relaunch") => run_relaunch_helper(),
+        other => panic!("unexpected {HELPER_ENV} value: {other:?}"),
+    }
+}
+
+fn run_host_helper() {
+    let observation = install_host_death_job().expect("install host-death Job");
+    println!(
+        "JOB limits=0x{:08x} nested={} assigned={} inheritable={}",
+        observation.limit_flags,
+        observation.nested_under_existing_job,
+        observation.current_process_assigned,
+        observation.handle_inheritable
+    );
+    io::stdout().flush().expect("flush Job observation");
+
+    let mut direct = spawn_helper("direct");
+    let direct_stdout = direct.stdout.take().expect("direct stdout pipe");
+    for line in BufReader::new(direct_stdout).lines() {
+        println!("{}", line.expect("read direct process observation"));
+        io::stdout().flush().expect("flush process observation");
+    }
+    let status = direct.wait().expect("wait for direct child");
+    assert!(status.success(), "direct child failed: {status}");
+}
+
+fn run_direct_helper() {
+    println!("DIRECT {}", std::process::id());
+    io::stdout().flush().expect("flush direct PID");
+
+    let mut descendant = spawn_helper("descendant");
+    let descendant_stdout = descendant.stdout.take().expect("descendant stdout pipe");
+    let mut lines = BufReader::new(descendant_stdout).lines();
+    println!("{}", next_prefixed_line(&mut lines, "DESCENDANT "));
+    io::stdout().flush().expect("flush descendant PID");
+    let status = descendant.wait().expect("wait for descendant");
+    assert!(status.success(), "descendant failed: {status}");
+}
+
+fn run_descendant_helper() {
+    println!("DESCENDANT {}", std::process::id());
+    io::stdout().flush().expect("flush descendant PID");
+    std::thread::park();
+}
+
+fn run_relaunch_helper() {
+    let observation = install_host_death_job().expect("install Job after prior host death");
+    assert!(observation.current_process_assigned);
+
+    let status = Command::new("cmd.exe")
+        .args(["/d", "/c", "exit 0"])
+        .status()
+        .expect("spawn child after prior Job cleanup");
+    assert!(status.success(), "post-cleanup child failed: {status}");
+    println!("RELAUNCH_OK");
+}
+
+fn spawn_helper(role: &str) -> Child {
+    let mut command = Command::new(env::current_exe().expect("current test executable"));
+    command
+        .args(["--exact", HELPER_TEST, "--ignored", "--nocapture"])
+        .env(HELPER_ENV, role)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command.spawn().unwrap_or_else(|error| {
+        panic!("spawn {role} process fixture: {error}");
+    })
+}
+
+fn next_prefixed_line(
+    lines: &mut impl Iterator<Item = io::Result<String>>,
+    prefix: &str,
+) -> String {
+    lines
+        .find_map(|line| match line {
+            Ok(line) if line.starts_with(prefix) => Some(Ok(line)),
+            Ok(_) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .unwrap_or_else(|| panic!("line starting with {prefix:?} missing"))
+        .unwrap_or_else(|error| panic!("read line starting with {prefix:?}: {error}"))
+}
+
+fn parse_pid(line: &str, label: &str) -> u32 {
+    let prefix = format!("{label} ");
+    line.strip_prefix(&prefix)
+        .unwrap_or_else(|| panic!("expected {label} PID line, got {line:?}"))
+        .parse()
+        .unwrap_or_else(|error| panic!("parse {label} PID from {line:?}: {error}"))
+}
+
+struct ObservedProcess {
+    handle: OwnedHandle,
+    pid: u32,
+}
+
+impl Drop for ObservedProcess {
+    fn drop(&mut self) {
+        use std::os::windows::io::AsRawHandle as _;
+
+        let raw = self.handle.as_raw_handle().cast();
+        // SAFETY: `raw` is live for both calls. A zero-time wait only checks
+        // state. If a failed assertion or negative control left the fixture
+        // alive, PROCESS_TERMINATE was requested specifically for cleanup.
+        if unsafe { WaitForSingleObject(raw, 0) } != WAIT_OBJECT_0 {
+            // SAFETY: same live process handle, with PROCESS_TERMINATE access;
+            // this test-owned fixture has no state outside the test.
+            let _ = unsafe { TerminateProcess(raw, 1) };
+        }
+    }
+}
+
+fn open_process_for_wait(pid: u32) -> ObservedProcess {
+    // SAFETY: OpenProcess receives a numeric PID observed from the live test
+    // child and requests observation plus test-fixture cleanup rights. A
+    // non-null result is one fresh owning handle, converted exactly once.
+    let raw = unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_TERMINATE, 0, pid) };
+    assert!(
+        !raw.is_null(),
+        "open process {pid}: {}",
+        io::Error::last_os_error()
+    );
+    ObservedProcess {
+        // SAFETY: `raw` is the fresh non-null owning handle returned above.
+        handle: unsafe { OwnedHandle::from_raw_handle(raw.cast()) },
+        pid,
+    }
+}
+
+fn assert_process_exited(process: &ObservedProcess, description: &str) {
+    use std::os::windows::io::AsRawHandle as _;
+
+    // SAFETY: the borrowed raw process handle remains live for this call. A
+    // signaled process handle is the kernel's termination oracle; the timeout
+    // only bounds a broken fixture and is not synchronization by sleeping.
+    let result =
+        unsafe { WaitForSingleObject(process.handle.as_raw_handle().cast(), PROCESS_WAIT_MS) };
+    assert_eq!(
+        result, WAIT_OBJECT_0,
+        "{description} PID {} survived host death",
+        process.pid
+    );
+}

--- a/crates/keld-runtime/tests/windows_lpac_boundary.rs
+++ b/crates/keld-runtime/tests/windows_lpac_boundary.rs
@@ -1,0 +1,738 @@
+//! Real Windows LPAC, ACL, hostile-probe, and raw handle-census proof.
+
+#![cfg(windows)]
+#![allow(unsafe_code)] // isolated test-only NT/Win32 observation with local ABI proofs
+#![allow(clippy::expect_used, clippy::panic)] // process fixture invariants must abort loudly
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::env;
+use std::ffi::{OsStr, OsString, c_void};
+use std::fs::{File, OpenOptions};
+use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+use std::os::windows::ffi::OsStrExt as _;
+use std::os::windows::io::{AsHandle as _, AsRawHandle as _, FromRawHandle as _, OwnedHandle};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use keld_runtime::windows_lpac::{WindowsLpacPathAccess, WindowsLpacProfile, WindowsLpacStdio};
+use tempfile::tempdir;
+use windows_sys::Win32::Foundation::{
+    CloseHandle, CompareObjectHandles, DUPLICATE_SAME_ACCESS, DuplicateHandle,
+    GetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT, LocalFree, SetHandleInformation,
+};
+use windows_sys::Win32::Networking::WinSock::{
+    AF_INET, INVALID_SOCKET, IPPROTO_TCP, SOCK_STREAM, SOCKADDR, SOCKADDR_IN, SOCKET_ERROR,
+    WSACleanup, WSADATA, WSAStartup, bind, closesocket, socket,
+};
+use windows_sys::Win32::Security::Authorization::{
+    EXPLICIT_ACCESS_W, GetNamedSecurityInfoW, NO_MULTIPLE_TRUSTEE, SE_FILE_OBJECT, SET_ACCESS,
+    SetEntriesInAclW, SetNamedSecurityInfoW, TRUSTEE_IS_SID, TRUSTEE_IS_WELL_KNOWN_GROUP,
+    TRUSTEE_W,
+};
+use windows_sys::Win32::Security::{
+    CreateWellKnownSid, DACL_SECURITY_INFORMATION, GetTokenInformation, TOKEN_GROUPS, TOKEN_QUERY,
+    TokenCapabilities, TokenIsAppContainer, WinBuiltinAnyPackageSid,
+};
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_READ;
+use windows_sys::Win32::System::LibraryLoader::LoadLibraryW;
+use windows_sys::Win32::System::Registry::{
+    HKEY_CURRENT_USER, KEY_READ, RegCloseKey, RegOpenKeyExW,
+};
+use windows_sys::Win32::System::Threading::{
+    GetCurrentProcess, GetProcessHandleCount, OpenProcess, OpenProcessToken,
+    PROCESS_QUERY_LIMITED_INFORMATION,
+};
+
+const HELPER_ENV: &str = "KELD_WINDOWS_LPAC_HELPER";
+const HELPER_TEST: &str = "windows_lpac_process_helper";
+const SYSTEM_EXTENDED_HANDLE_INFORMATION: u32 = 64;
+const STATUS_INFO_LENGTH_MISMATCH: i32 = -1_073_741_820;
+
+unsafe extern "system" {
+    fn NtQuerySystemInformation(
+        system_information_class: u32,
+        system_information: *mut c_void,
+        system_information_length: u32,
+        return_length: *mut u32,
+    ) -> i32;
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct SystemHandleEntry {
+    object: *mut c_void,
+    unique_process_id: usize,
+    handle_value: usize,
+    granted_access: u32,
+    creator_backtrace_index: u16,
+    object_type_index: u16,
+    handle_attributes: u32,
+    reserved: u32,
+}
+
+#[test]
+#[allow(clippy::too_many_lines)] // one crash-safe end-to-end boundary fixture and oracle
+fn zero_capability_lpac_denies_host_authority_and_inherits_only_allowlisted_handles() {
+    let temporary = tempdir().expect("create isolated LPAC fixture root");
+    let root = temporary.path();
+    let runtime_dir = root.join("runtime");
+    let role_dir = root.join("role-private");
+    let forbidden_dir = root.join("host-only");
+    std::fs::create_dir_all(&runtime_dir).expect("create runtime directory");
+    std::fs::create_dir_all(&role_dir).expect("create role-private directory");
+    std::fs::create_dir_all(&forbidden_dir).expect("create host-only directory");
+
+    let fixture = runtime_dir.join("lpac-probe.exe");
+    std::fs::copy(
+        env::current_exe().expect("current test executable"),
+        &fixture,
+    )
+    .expect("copy signed-equivalent test artifact");
+    let forbidden_file = forbidden_dir.join("secret.txt");
+    std::fs::write(&forbidden_file, b"host secret").expect("write forbidden fixture");
+    let blocked_dll = forbidden_dir.join("blocked.dll");
+    let system_root = env::var_os("SystemRoot").unwrap_or_else(|| OsString::from(r"C:\Windows"));
+    std::fs::copy(
+        Path::new(&system_root).join(r"System32\version.dll"),
+        &blocked_dll,
+    )
+    .expect("copy real DLL outside LPAC ACL");
+    let all_packages_file = forbidden_dir.join("ordinary-appcontainer-visible.txt");
+    std::fs::write(&all_packages_file, b"ordinary AppContainer grant")
+        .expect("write All Application Packages fixture");
+    grant_all_application_packages_read(&all_packages_file);
+    let update_stage = forbidden_dir.join("update-stage");
+    std::fs::create_dir(&update_stage).expect("create host-owned update stage");
+    let update_payload = update_stage.join("payload.bin");
+    std::fs::write(&update_payload, b"signed update payload").expect("write staged payload");
+
+    let profile_name = unique_profile_name();
+    let profile =
+        WindowsLpacProfile::create(&profile_name).expect("create zero-capability profile");
+    profile
+        .grant_path(root, WindowsLpacPathAccess::Traverse)
+        .expect("grant root traversal only");
+    profile
+        .grant_path(&runtime_dir, WindowsLpacPathAccess::ReadExecute)
+        .expect("grant runtime read/execute");
+    profile
+        .grant_path(&role_dir, WindowsLpacPathAccess::RolePrivate)
+        .expect("grant role-private read/write");
+
+    let output_path = role_dir.join("probe-output.txt");
+    let mut output = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .read(true)
+        .write(true)
+        .open(&output_path)
+        .expect("open LPAC log sink");
+    let input = File::open("NUL").expect("open null stdin");
+    let marker_path = forbidden_dir.join("inheritable-host-marker.txt");
+    let marker = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .read(true)
+        .write(true)
+        .open(&marker_path)
+        .expect("open host-only inheritable marker");
+    set_inheritable(marker.as_raw_handle().cast(), true);
+
+    let allowed_file = role_dir.join("allowed.txt");
+    let arguments = vec![
+        OsString::from("--exact"),
+        OsString::from(HELPER_TEST),
+        OsString::from("--ignored"),
+        OsString::from("--nocapture"),
+    ];
+    let mut environment = vec![
+        (OsString::from(HELPER_ENV), OsString::from("probe")),
+        (
+            OsString::from("KELD_LPAC_ALLOWED"),
+            allowed_file.into_os_string(),
+        ),
+        (
+            OsString::from("KELD_LPAC_DENIED"),
+            forbidden_file.into_os_string(),
+        ),
+        (
+            OsString::from("KELD_LPAC_BLOCKED_DLL"),
+            blocked_dll.into_os_string(),
+        ),
+        (
+            OsString::from("KELD_LPAC_ALL_PACKAGES_FILE"),
+            all_packages_file.into_os_string(),
+        ),
+        (
+            OsString::from("KELD_LPAC_UPDATE_STAGE"),
+            update_payload.into_os_string(),
+        ),
+        (
+            OsString::from("KELD_LPAC_MARKER"),
+            OsString::from(format!("{:x}", marker.as_raw_handle() as usize)),
+        ),
+        (
+            OsString::from("KELD_LPAC_CONTROLLER_PID"),
+            OsString::from(std::process::id().to_string()),
+        ),
+        (OsString::from("SystemRoot"), system_root),
+        (OsString::from("TEMP"), role_dir.clone().into_os_string()),
+        (OsString::from("TMP"), role_dir.clone().into_os_string()),
+    ];
+    for key in ["LOCALAPPDATA", "USERPROFILE", "WINDIR"] {
+        if let Some(value) = env::var_os(key) {
+            environment.push((OsString::from(key), value));
+        }
+    }
+    let stdio = WindowsLpacStdio {
+        stdin: input.as_handle(),
+        stdout: output.as_handle(),
+        stderr: output.as_handle(),
+    };
+    let mut child = profile
+        .spawn_suspended(
+            &fixture,
+            &arguments,
+            &environment,
+            Some(&role_dir),
+            Some(stdio),
+            &[],
+        )
+        .expect("create suspended LPAC fixture");
+
+    let token = child.observe_token().expect("observe LPAC child token");
+    assert_eq!(
+        token,
+        keld_runtime::windows_lpac::WindowsLpacTokenObservation {
+            is_app_container: true,
+            all_application_packages_opt_out_configured: true,
+            capability_count: 0,
+        }
+    );
+
+    let census = raw_process_handle_census(child.id());
+    let kernel_count = process_handle_count(child.process_handle().as_raw_handle().cast());
+    assert_eq!(
+        census.len(),
+        usize::try_from(kernel_count).expect("handle count fits usize"),
+        "raw SystemExtendedHandleInformation census must match GetProcessHandleCount"
+    );
+    assert!(
+        child_contains_object(&child, &census, input.as_raw_handle().cast()),
+        "allowlisted stdin object missing from child handle table"
+    );
+    assert!(
+        child_contains_object(&child, &census, output.as_raw_handle().cast()),
+        "allowlisted log object missing from child handle table"
+    );
+    assert!(
+        !child_contains_object(&child, &census, marker.as_raw_handle().cast()),
+        "non-allowlisted inheritable host file crossed the child boundary"
+    );
+    assert_no_other_inheritable_parent_object(
+        &child,
+        &census,
+        &[input.as_raw_handle().cast(), output.as_raw_handle().cast()],
+    );
+
+    child.resume().expect("resume audited LPAC child");
+    let exit = child.wait(10_000).expect("wait for hostile LPAC probe");
+
+    output
+        .seek(SeekFrom::Start(0))
+        .expect("rewind probe output");
+    let mut observed = String::new();
+    output
+        .read_to_string(&mut observed)
+        .expect("read hostile probe output");
+    assert_eq!(
+        exit, 0,
+        "LPAC probe exited unsuccessfully; output: {observed}"
+    );
+    assert!(
+        observed.contains(
+            "LPAC_PROBE private_write=true forbidden_read_denied=true all_packages_denied=true \
+             network_denied=true registry_denied=true controller_open_denied=true \
+             dll_load_denied=true update_stage_denied=true"
+        ),
+        "unexpected hostile LPAC output: {observed}"
+    );
+    assert!(
+        observed.contains(
+            "LPAC_DESCENDANT app_container=true capability_count=0 all_packages_denied=true"
+        ) || observed.contains("LPAC_DESCENDANT spawn_denied=true"),
+        "descendant neither inherited LPAC nor received an OS spawn deny: {observed}"
+    );
+    assert!(
+        !handle_inheritable(input.as_raw_handle().cast()),
+        "stdin inherit flag was not restored"
+    );
+    assert!(
+        !handle_inheritable(output.as_raw_handle().cast()),
+        "log inherit flag was not restored"
+    );
+    set_inheritable(marker.as_raw_handle().cast(), false);
+}
+
+#[test]
+#[ignore = "private LPAC subprocess entry point"]
+fn windows_lpac_process_helper() {
+    if env::var(HELPER_ENV).as_deref() == Ok("descendant") {
+        run_lpac_descendant_probe();
+        return;
+    }
+    assert_eq!(env::var(HELPER_ENV).as_deref(), Ok("probe"));
+    let allowed = PathBuf::from(env::var_os("KELD_LPAC_ALLOWED").expect("allowed path"));
+    let denied = PathBuf::from(env::var_os("KELD_LPAC_DENIED").expect("denied path"));
+    let blocked_dll =
+        PathBuf::from(env::var_os("KELD_LPAC_BLOCKED_DLL").expect("blocked DLL path"));
+    let all_packages_file = PathBuf::from(
+        env::var_os("KELD_LPAC_ALL_PACKAGES_FILE").expect("All Application Packages path"),
+    );
+    let update_stage =
+        PathBuf::from(env::var_os("KELD_LPAC_UPDATE_STAGE").expect("update stage path"));
+    let controller_pid: u32 = env::var("KELD_LPAC_CONTROLLER_PID")
+        .expect("controller PID")
+        .parse()
+        .expect("numeric controller PID");
+
+    let private_write = std::fs::write(&allowed, b"role data").is_ok();
+    let forbidden_read_denied = std::fs::read(&denied).is_err();
+    let all_packages_denied = std::fs::read(&all_packages_file).is_err();
+    let network_denied = direct_network_denied();
+    let registry_denied = registry_open_denied();
+    let controller_open_denied = process_open_denied(controller_pid);
+    let dll_load_denied = library_load_denied(&blocked_dll);
+    let update_stage_denied = std::fs::read(&update_stage).is_err()
+        && OpenOptions::new().write(true).open(&update_stage).is_err();
+    let descendant_contained = spawn_contained_descendant();
+    println!(
+        "LPAC_PROBE private_write={private_write} forbidden_read_denied={forbidden_read_denied} \
+         all_packages_denied={all_packages_denied} network_denied={network_denied} \
+         registry_denied={registry_denied} controller_open_denied={controller_open_denied} \
+         dll_load_denied={dll_load_denied} update_stage_denied={update_stage_denied} \
+         descendant_contained={descendant_contained}"
+    );
+    std::io::stdout().flush().expect("flush LPAC probe output");
+    assert!(private_write);
+    assert!(forbidden_read_denied);
+    assert!(all_packages_denied);
+    assert!(network_denied);
+    assert!(registry_denied);
+    assert!(controller_open_denied);
+    assert!(dll_load_denied);
+    assert!(update_stage_denied);
+    assert!(descendant_contained);
+}
+
+fn spawn_contained_descendant() -> bool {
+    match Command::new(env::current_exe().expect("current LPAC fixture executable"))
+        .args(["--exact", HELPER_TEST, "--ignored", "--nocapture"])
+        .env(HELPER_ENV, "descendant")
+        .status()
+    {
+        Ok(status) => status.success(),
+        Err(error) => {
+            let denied = error.kind() == std::io::ErrorKind::PermissionDenied
+                || error.raw_os_error() == Some(5);
+            println!(
+                "LPAC_DESCENDANT spawn_denied={denied} raw_error={:?}",
+                error.raw_os_error()
+            );
+            std::io::stdout()
+                .flush()
+                .expect("flush descendant spawn denial");
+            denied
+        }
+    }
+}
+
+fn run_lpac_descendant_probe() {
+    let (is_app_container, capability_count) = observe_current_token();
+    let all_packages_file = PathBuf::from(
+        env::var_os("KELD_LPAC_ALL_PACKAGES_FILE").expect("All Application Packages path"),
+    );
+    let all_packages_denied = std::fs::read(all_packages_file).is_err();
+    println!(
+        "LPAC_DESCENDANT app_container={is_app_container} capability_count={capability_count} \
+         all_packages_denied={all_packages_denied}"
+    );
+    std::io::stdout()
+        .flush()
+        .expect("flush descendant LPAC observation");
+    assert!(is_app_container);
+    assert_eq!(capability_count, 0);
+    assert!(all_packages_denied);
+}
+
+fn observe_current_token() -> (bool, u32) {
+    let mut raw_token = std::ptr::null_mut();
+    // SAFETY: current-process pseudo-handle is valid and token output writable.
+    assert_ne!(
+        unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut raw_token) },
+        0,
+        "open current LPAC token: {}",
+        std::io::Error::last_os_error()
+    );
+    // SAFETY: successful open returned one fresh owning token handle.
+    let token = unsafe { OwnedHandle::from_raw_handle(raw_token.cast()) };
+    let mut is_app_container = 0_u32;
+    let mut returned = 0_u32;
+    // SAFETY: token and both output slots are live.
+    assert_ne!(
+        unsafe {
+            GetTokenInformation(
+                token.as_raw_handle().cast(),
+                TokenIsAppContainer,
+                (&raw mut is_app_container).cast(),
+                u32::try_from(std::mem::size_of_val(&is_app_container)).unwrap_or(u32::MAX),
+                &raw mut returned,
+            )
+        },
+        0,
+        "query descendant TokenIsAppContainer"
+    );
+    let mut capability_bytes = 0_u32;
+    // SAFETY: null sizing call with writable returned length.
+    let _ = unsafe {
+        GetTokenInformation(
+            token.as_raw_handle().cast(),
+            TokenCapabilities,
+            std::ptr::null_mut(),
+            0,
+            &raw mut capability_bytes,
+        )
+    };
+    let mut capabilities = vec![
+        0_usize;
+        usize::try_from(capability_bytes)
+            .expect("capability size fits usize")
+            .div_ceil(std::mem::size_of::<usize>())
+    ];
+    // SAFETY: aligned storage has capability_bytes writable bytes.
+    assert_ne!(
+        unsafe {
+            GetTokenInformation(
+                token.as_raw_handle().cast(),
+                TokenCapabilities,
+                capabilities.as_mut_ptr().cast(),
+                capability_bytes,
+                &raw mut capability_bytes,
+            )
+        },
+        0,
+        "query descendant TokenCapabilities"
+    );
+    // SAFETY: the returned buffer is a live aligned TOKEN_GROUPS instance.
+    let capability_count = unsafe { (*(capabilities.as_ptr().cast::<TOKEN_GROUPS>())).GroupCount };
+    (is_app_container != 0, capability_count)
+}
+
+fn grant_all_application_packages_read(path: &Path) {
+    let mut sid_bytes = 0_u32;
+    // SAFETY: null is the documented sizing call and sid_bytes is writable.
+    let _ = unsafe {
+        CreateWellKnownSid(
+            WinBuiltinAnyPackageSid,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &raw mut sid_bytes,
+        )
+    };
+    assert_ne!(sid_bytes, 0, "All Application Packages SID sizing failed");
+    let mut sid_storage = vec![
+        0_usize;
+        usize::try_from(sid_bytes)
+            .expect("SID size fits usize")
+            .div_ceil(std::mem::size_of::<usize>())
+    ];
+    // SAFETY: aligned storage contains sid_bytes writable bytes.
+    assert_ne!(
+        unsafe {
+            CreateWellKnownSid(
+                WinBuiltinAnyPackageSid,
+                std::ptr::null_mut(),
+                sid_storage.as_mut_ptr().cast(),
+                &raw mut sid_bytes,
+            )
+        },
+        0,
+        "create All Application Packages SID: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let path_wide = wide_nul(path.as_os_str());
+    let mut old_acl = std::ptr::null_mut();
+    let mut descriptor = std::ptr::null_mut();
+    // SAFETY: path is NUL terminated and output slots are writable.
+    assert_eq!(
+        unsafe {
+            GetNamedSecurityInfoW(
+                path_wide.as_ptr(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &raw mut old_acl,
+                std::ptr::null_mut(),
+                &raw mut descriptor,
+            )
+        },
+        0,
+        "read All Application Packages fixture DACL"
+    );
+    let entry = EXPLICIT_ACCESS_W {
+        grfAccessPermissions: FILE_GENERIC_READ,
+        grfAccessMode: SET_ACCESS,
+        grfInheritance: 0,
+        Trustee: TRUSTEE_W {
+            pMultipleTrustee: std::ptr::null_mut(),
+            MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_WELL_KNOWN_GROUP,
+            ptstrName: sid_storage.as_mut_ptr().cast(),
+        },
+    };
+    let mut new_acl = std::ptr::null_mut();
+    // SAFETY: entry and old ACL are live; new ACL output is writable.
+    assert_eq!(
+        unsafe { SetEntriesInAclW(1, &raw const entry, old_acl, &raw mut new_acl) },
+        0,
+        "merge All Application Packages fixture DACL"
+    );
+    // SAFETY: path and merged ACL are live for the synchronous update.
+    let status = unsafe {
+        SetNamedSecurityInfoW(
+            path_wide.as_ptr().cast_mut(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            new_acl,
+            std::ptr::null(),
+        )
+    };
+    // SAFETY: both are LocalAlloc-family allocations returned above.
+    let _ = unsafe { LocalFree(new_acl.cast()) };
+    let _ = unsafe { LocalFree(descriptor) };
+    assert_eq!(status, 0, "write All Application Packages fixture DACL");
+}
+
+fn registry_open_denied() -> bool {
+    let subkey = wide_nul(OsStr::new("Software"));
+    let mut key = std::ptr::null_mut();
+    // SAFETY: subkey is NUL terminated and key output is writable.
+    let status = unsafe {
+        RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            subkey.as_ptr(),
+            0,
+            KEY_READ,
+            &raw mut key,
+        )
+    };
+    if status == 0 && !key.is_null() {
+        // SAFETY: successful open returned one owning registry handle.
+        let _ = unsafe { RegCloseKey(key) };
+        false
+    } else {
+        true
+    }
+}
+
+fn direct_network_denied() -> bool {
+    let mut data = WSADATA::default();
+    // SAFETY: WSADATA output is writable. A startup failure under the
+    // zero-capability token is itself an OS-layer network denial.
+    if unsafe { WSAStartup(0x0202, &raw mut data) } != 0 {
+        return true;
+    }
+    // SAFETY: constant address family/type/protocol tuple.
+    let socket = unsafe { socket(i32::from(AF_INET), SOCK_STREAM, IPPROTO_TCP) };
+    if socket == INVALID_SOCKET {
+        // SAFETY: balances the successful WSAStartup above.
+        let _ = unsafe { WSACleanup() };
+        return true;
+    }
+    let address = SOCKADDR_IN {
+        sin_family: AF_INET,
+        ..SOCKADDR_IN::default()
+    };
+    // Port zero and address zero ask the OS for any local endpoint; no fixed
+    // resource or timing is involved.
+    // SAFETY: socket is live and address has the exact SOCKADDR_IN layout.
+    let result = unsafe {
+        bind(
+            socket,
+            (&raw const address).cast::<SOCKADDR>(),
+            i32::try_from(std::mem::size_of_val(&address)).unwrap_or(i32::MAX),
+        )
+    };
+    // SAFETY: both calls release only resources created above.
+    let _ = unsafe { closesocket(socket) };
+    let _ = unsafe { WSACleanup() };
+    result == SOCKET_ERROR
+}
+
+fn process_open_denied(pid: u32) -> bool {
+    // SAFETY: numeric controller PID; no output pointer.
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if process.is_null() {
+        true
+    } else {
+        // SAFETY: successful open returned one owning process handle.
+        let _ = unsafe { CloseHandle(process) };
+        false
+    }
+}
+
+fn library_load_denied(path: &Path) -> bool {
+    let path = wide_nul(path.as_os_str());
+    // SAFETY: path is a live NUL-terminated UTF-16 buffer. A successful load
+    // would be a failed boundary and the short-lived probe then aborts.
+    unsafe { LoadLibraryW(path.as_ptr()) }.is_null()
+}
+
+fn raw_process_handle_census(pid: u32) -> Vec<SystemHandleEntry> {
+    let mut bytes = 1_u32 << 20;
+    loop {
+        let words = usize::try_from(bytes)
+            .expect("NT census size fits usize")
+            .div_ceil(std::mem::size_of::<usize>());
+        let mut storage = vec![0_usize; words];
+        let mut returned = 0_u32;
+        // SAFETY: aligned storage provides `bytes` writable bytes; returned
+        // length is writable. Class 64 is the raw extended system handle table.
+        let status = unsafe {
+            NtQuerySystemInformation(
+                SYSTEM_EXTENDED_HANDLE_INFORMATION,
+                storage.as_mut_ptr().cast(),
+                bytes,
+                &raw mut returned,
+            )
+        };
+        if status == STATUS_INFO_LENGTH_MISMATCH {
+            bytes = returned.max(bytes.saturating_mul(2));
+            continue;
+        }
+        assert_eq!(
+            status,
+            0,
+            "NtQuerySystemInformation failed: 0x{:08x}",
+            status.cast_unsigned()
+        );
+
+        let count = storage[0];
+        let header_bytes = 2 * std::mem::size_of::<usize>();
+        let available = usize::try_from(bytes)
+            .expect("NT census size fits usize")
+            .saturating_sub(header_bytes)
+            / std::mem::size_of::<SystemHandleEntry>();
+        assert!(count <= available, "NT handle census count exceeds buffer");
+        // SAFETY: the class-64 buffer begins with two usize fields followed by
+        // `count` aligned SystemHandleEntry records, bounded above by available.
+        let entries = unsafe {
+            std::slice::from_raw_parts(storage.as_ptr().add(2).cast::<SystemHandleEntry>(), count)
+        };
+        return entries
+            .iter()
+            .copied()
+            .filter(|entry| entry.unique_process_id == pid as usize)
+            .collect();
+    }
+}
+
+fn process_handle_count(process: HANDLE) -> u32 {
+    let mut count = 0_u32;
+    // SAFETY: process is a live borrowed process handle; count is writable.
+    assert_ne!(
+        unsafe { GetProcessHandleCount(process, &raw mut count) },
+        0,
+        "GetProcessHandleCount failed: {}",
+        std::io::Error::last_os_error()
+    );
+    count
+}
+
+fn child_contains_object(
+    child: &keld_runtime::windows_lpac::WindowsLpacChild,
+    census: &[SystemHandleEntry],
+    parent_object: HANDLE,
+) -> bool {
+    census.iter().any(|entry| {
+        let mut duplicate = std::ptr::null_mut();
+        // SAFETY: child process handle is live; entry came from that exact PID
+        // in the raw table; current-process pseudo-handle is valid; duplicate
+        // output receives one handle on success.
+        if unsafe {
+            DuplicateHandle(
+                child.process_handle().as_raw_handle().cast(),
+                entry.handle_value as HANDLE,
+                GetCurrentProcess(),
+                &raw mut duplicate,
+                0,
+                0,
+                DUPLICATE_SAME_ACCESS,
+            )
+        } == 0
+            || duplicate.is_null()
+        {
+            return false;
+        }
+        // SAFETY: duplicate is the fresh owning handle returned above.
+        let duplicate = unsafe { OwnedHandle::from_raw_handle(duplicate.cast()) };
+        // SAFETY: both compared handles are live for this call.
+        (unsafe { CompareObjectHandles(parent_object, duplicate.as_raw_handle().cast()) }) != 0
+    })
+}
+
+fn assert_no_other_inheritable_parent_object(
+    child: &keld_runtime::windows_lpac::WindowsLpacChild,
+    child_census: &[SystemHandleEntry],
+    allowed: &[HANDLE],
+) {
+    let parent_census = raw_process_handle_census(std::process::id());
+    for entry in parent_census {
+        let handle = entry.handle_value as HANDLE;
+        if allowed.contains(&handle) || !handle_inheritable(handle) {
+            continue;
+        }
+        assert!(
+            !child_contains_object(child, child_census, handle),
+            "inheritable parent handle 0x{:x} crossed outside HANDLE_LIST",
+            entry.handle_value
+        );
+    }
+}
+
+fn set_inheritable(handle: HANDLE, inheritable: bool) {
+    let value = if inheritable { HANDLE_FLAG_INHERIT } else { 0 };
+    // SAFETY: handle is live; only the inherit bit is changed.
+    assert_ne!(
+        unsafe { SetHandleInformation(handle, HANDLE_FLAG_INHERIT, value) },
+        0,
+        "SetHandleInformation failed: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+fn handle_inheritable(handle: HANDLE) -> bool {
+    let mut flags = 0_u32;
+    // SAFETY: census supplied a handle value; failure means the value is no
+    // longer live and therefore cannot cross this spawn boundary.
+    (unsafe { GetHandleInformation(handle, &raw mut flags) }) != 0
+        && flags & HANDLE_FLAG_INHERIT != 0
+}
+
+fn unique_profile_name() -> OsString {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_nanos();
+    OsString::from(format!("Keld.Test.{}.{nanos}", std::process::id()))
+}
+
+fn wide_nul(value: &OsStr) -> Vec<u16> {
+    value.encode_wide().chain(std::iter::once(0)).collect()
+}

--- a/crates/keld-runtime/tests/windows_lpac_boundary.rs
+++ b/crates/keld-runtime/tests/windows_lpac_boundary.rs
@@ -16,6 +16,7 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use keld_runtime::windows_lpac::{WindowsLpacPathAccess, WindowsLpacProfile, WindowsLpacStdio};
+use sha2::{Digest as _, Sha256};
 use tempfile::tempdir;
 use windows_sys::Win32::Foundation::{
     CloseHandle, CompareObjectHandles, DUPLICATE_SAME_ACCESS, DuplicateHandle,
@@ -176,7 +177,7 @@ fn zero_capability_lpac_denies_host_authority_and_inherits_only_allowlisted_hand
             OsString::from("KELD_LPAC_CONTROLLER_PID"),
             OsString::from(std::process::id().to_string()),
         ),
-        (OsString::from("SystemRoot"), system_root),
+        (OsString::from("SystemRoot"), system_root.clone()),
         (OsString::from("TEMP"), role_dir.clone().into_os_string()),
         (OsString::from("TMP"), role_dir.clone().into_os_string()),
     ];
@@ -264,6 +265,11 @@ fn zero_capability_lpac_denies_host_authority_and_inherits_only_allowlisted_hand
         ) || observed.contains("LPAC_DESCENDANT spawn_denied=true"),
         "descendant neither inherited LPAC nor received an OS spawn deny: {observed}"
     );
+    println!(
+        "KELD_WINDOWS_T3_HOSTILE synthetic_handle_count={} fs=deny private=allow network=deny \
+         registry=deny process=deny dll=deny update_stage=deny descendant=deny-or-same-lpac",
+        census.len()
+    );
     assert!(
         !handle_inheritable(input.as_raw_handle().cast()),
         "stdin inherit flag was not restored"
@@ -272,7 +278,135 @@ fn zero_capability_lpac_denies_host_authority_and_inherits_only_allowlisted_hand
         !handle_inheritable(output.as_raw_handle().cast()),
         "log inherit flag was not restored"
     );
+    prove_bun_artifact_starts_under_lpac(
+        &profile,
+        &runtime_dir,
+        &role_dir,
+        &system_root,
+        marker.as_raw_handle().cast(),
+    );
     set_inheritable(marker.as_raw_handle().cast(), false);
+}
+
+fn prove_bun_artifact_starts_under_lpac(
+    profile: &WindowsLpacProfile,
+    runtime_dir: &Path,
+    role_dir: &Path,
+    system_root: &OsStr,
+    excluded_marker: HANDLE,
+) {
+    let bun_source = env::split_paths(&env::var_os("PATH").expect("PATH for Bun lookup"))
+        .map(|directory| directory.join("bun.exe"))
+        .find(|candidate| candidate.is_file())
+        .expect("bun.exe on PATH");
+    let revision_output = Command::new(&bun_source)
+        .arg("--revision")
+        .output()
+        .expect("read Bun revision");
+    assert!(
+        revision_output.status.success(),
+        "Bun revision query failed"
+    );
+    let revision = String::from_utf8(revision_output.stdout)
+        .expect("Bun revision is UTF-8")
+        .trim()
+        .to_owned();
+    let artifact_bytes = std::fs::read(&bun_source).expect("read Bun artifact for digest");
+    let artifact_digest = format!("{:x}", Sha256::digest(&artifact_bytes));
+    let bun = runtime_dir.join("bun.exe");
+    std::fs::copy(&bun_source, &bun).expect("copy pinned Bun artifact into reviewed runtime ACL");
+
+    let output_path = role_dir.join("bun-output.txt");
+    let mut output = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .read(true)
+        .write(true)
+        .open(output_path)
+        .expect("open Bun log sink");
+    let input = File::open("NUL").expect("open Bun null stdin");
+    let stdio = WindowsLpacStdio {
+        stdin: input.as_handle(),
+        stdout: output.as_handle(),
+        stderr: output.as_handle(),
+    };
+    let mut environment = vec![
+        (OsString::from("SystemRoot"), system_root.to_os_string()),
+        (OsString::from("TEMP"), role_dir.as_os_str().to_os_string()),
+        (OsString::from("TMP"), role_dir.as_os_str().to_os_string()),
+    ];
+    for key in ["LOCALAPPDATA", "USERPROFILE", "WINDIR"] {
+        if let Some(value) = env::var_os(key) {
+            environment.push((OsString::from(key), value));
+        }
+    }
+    let arguments = vec![
+        OsString::from("--eval"),
+        OsString::from("console.log(`BUN_LPAC_OK ${Bun.version}`)"),
+    ];
+    let mut child = profile
+        .spawn_suspended(
+            &bun,
+            &arguments,
+            &environment,
+            Some(role_dir),
+            Some(stdio),
+            &[],
+        )
+        .expect("create suspended Bun LPAC process");
+    let token = child.observe_token().expect("observe Bun LPAC token");
+    assert!(token.is_app_container);
+    assert!(token.all_application_packages_opt_out_configured);
+    assert_eq!(token.capability_count, 0);
+
+    let census = raw_process_handle_census(child.id());
+    assert!(child_contains_object(
+        &child,
+        &census,
+        input.as_raw_handle().cast()
+    ));
+    assert!(child_contains_object(
+        &child,
+        &census,
+        output.as_raw_handle().cast()
+    ));
+    assert!(
+        !child_contains_object(&child, &census, excluded_marker),
+        "Bun inherited the excluded host marker"
+    );
+
+    child.resume().expect("resume audited Bun LPAC process");
+    let exit = child.wait(10_000).expect("wait for Bun LPAC probe");
+    output.seek(SeekFrom::Start(0)).expect("rewind Bun output");
+    let mut observed = String::new();
+    output
+        .read_to_string(&mut observed)
+        .expect("read Bun LPAC output");
+    assert_eq!(exit, 0, "Bun LPAC process failed; output: {observed}");
+    assert!(
+        observed.contains("BUN_LPAC_OK 1.4.0"),
+        "unexpected Bun LPAC output: {observed}"
+    );
+    print_bun_evidence(profile, &revision, &artifact_digest, census.len());
+}
+
+fn print_bun_evidence(
+    profile: &WindowsLpacProfile,
+    revision: &str,
+    artifact_digest: &str,
+    raw_handle_count: usize,
+) {
+    let sid = profile.sid_string().expect("serialize AppContainer SID");
+    let profile_material = format!(
+        "keld.windows-lpac/v1\0sid={sid}\0capabilities=0\0all_application_packages=opt_out\0\
+         acl=root:traverse,runtime:read_execute,role:private\0handles=stdin,stdout,stderr"
+    );
+    let profile_digest = format!("{:x}", Sha256::digest(profile_material.as_bytes()));
+    println!(
+        "KELD_WINDOWS_T3_BUN revision={revision} artifact_sha256={artifact_digest} \
+         profile_sha256={profile_digest} package_sid={sid} raw_handle_count={raw_handle_count} \
+         capabilities=0 all_application_packages=opt_out"
+    );
 }
 
 #[test]

--- a/docs/engineering/keld-error-codes.md
+++ b/docs/engineering/keld-error-codes.md
@@ -487,6 +487,18 @@ match the crate that already emits the code. Do not invent a third spelling.
 - message: The private macOS host-death guardian exited while the host session was still live
 - fix: Confirm the registered-group fail-safe completed; restart the host session, diagnose the guardian exit, then relaunch the app.
 
+## KELD-RUNTIME-014
+
+- crate: keld-runtime
+- message: Windows host-death Job installation failed before child creation
+- fix: Stop before spawning Bun, verify nested Job support and exact non-breakaway `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` configuration, then retry.
+
+## KELD-RUNTIME-015
+
+- crate: keld-runtime
+- message: Windows zero-capability LPAC admission failed
+- fix: Do not start an unconfined replacement. Repair the AppContainer profile, reviewed path ACLs, explicit environment, or private inherited-handle allowlist and refresh the hostile proof.
+
 ## KELD-NATIVE-001
 
 - crate: keld-native

--- a/docs/specs/kel78-primary-sources.md
+++ b/docs/specs/kel78-primary-sources.md
@@ -214,7 +214,7 @@ of a sandbox, not containment.
 - **Publisher:** Microsoft Learn
 - **Dated:** current Win32 API page; accessed 2026-08-19
 - **Quote:** "If this parameter is TRUE, each inheritable handle in the calling process is inherited by the new process. If the parameter is FALSE, the handles are not inherited. Note that inherited handles have the same value and access rights as the original handles." The attribute-list contract adds: "if you use this attribute, pass in a value of TRUE for the bInheritHandles parameter of the CreateProcess function."
-- **Use:** A strict spawn with no admitted handles uses `bInheritHandles = FALSE`. An explicit `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` launch uses `TRUE` as Win32 requires, but only after the app-link/log handles in that list are marked inheritable. `TRUE` without the list is forbidden. A raw post-spawn child-handle census rejects every non-allowlisted handle.
+- **Use:** A strict spawn with no admitted handles uses `bInheritHandles = FALSE`. An explicit `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` launch uses `TRUE` as Win32 requires, but the list contains only private inheritable duplicates of the admitted app-link/log handles; caller-owned handle flags are never toggled. `TRUE` without the list is forbidden. A raw post-spawn child-handle census rejects every non-allowlisted handle.
 
 ---
 

--- a/docs/specs/kel78-primary-sources.md
+++ b/docs/specs/kel78-primary-sources.md
@@ -210,11 +210,11 @@ of a sandbox, not containment.
 
 ### W6. Handle inheritance is opt-in and listed
 
-- **Source:** <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw>
+- **Sources:** <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw>, <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute>
 - **Publisher:** Microsoft Learn
 - **Dated:** current Win32 API page; accessed 2026-08-19
-- **Quote:** "If this parameter is TRUE, each inheritable handle in the calling process is inherited by the new process. If the parameter is FALSE, the handles are not inherited. Note that inherited handles have the same value and access rights as the original handles." Also: "Applications can use the UpdateProcThreadAttributeList function with the PROC_THREAD_ATTRIBUTE_HANDLE_LIST parameter to provide a list of handles to be inherited by a particular process."
-- **Use:** Strict spawn uses `bInheritHandles = FALSE` except for an explicit `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` allowlist (stdio / authenticated link only). A leftover host handle in the child is a failed proof.
+- **Quote:** "If this parameter is TRUE, each inheritable handle in the calling process is inherited by the new process. If the parameter is FALSE, the handles are not inherited. Note that inherited handles have the same value and access rights as the original handles." The attribute-list contract adds: "if you use this attribute, pass in a value of TRUE for the bInheritHandles parameter of the CreateProcess function."
+- **Use:** A strict spawn with no admitted handles uses `bInheritHandles = FALSE`. An explicit `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` launch uses `TRUE` as Win32 requires, but only after the app-link/log handles in that list are marked inheritable. `TRUE` without the list is forbidden. A raw post-spawn child-handle census rejects every non-allowlisted handle.
 
 ---
 

--- a/docs/specs/kel78-strict-profile-sandbox.md
+++ b/docs/specs/kel78-strict-profile-sandbox.md
@@ -377,8 +377,12 @@ Required:
   experiment proves them required. Each such SID is a **permission-model
   review gate** (same class as macOS extra entitlements). A network SID
   MUST NOT be added because of a `keld-guard` net grant.
-- Handle allowlist via `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`. Default
-  `bInheritHandles = FALSE` (ledger W6).
+- Handle allowlist via `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`. A spawn with no
+  admitted handles uses `bInheritHandles = FALSE`. Win32 requires `TRUE` when
+  the explicit handle-list attribute is present, so that path MUST first mark
+  only the listed app-link/log handles inheritable, pass `TRUE`, and verify by
+  raw child-handle census that no other handle crossed the boundary (ledger
+  W6). `TRUE` without the attribute list is forbidden.
 - Job object for descendants: no `BREAKAWAY_OK` / `SILENT_BREAKAWAY_OK`;
   `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` for host-death cleanup (ledger W5).
   The job is **not** the authority sandbox.

--- a/docs/specs/kel78-strict-profile-sandbox.md
+++ b/docs/specs/kel78-strict-profile-sandbox.md
@@ -613,7 +613,7 @@ Renderer sandbox is a different column.
       requires them. Enumerate `temporary-exception.*` as unexpected.
       Integrate the approved T2b guardian without duplicating lifecycle policy,
       and prove the strict child/descendant enrollment separately.
-- [ ] T3: Windows zero-capability LPAC + ACL + handle allowlist + job
+- [x] T3: Windows zero-capability LPAC + ACL + handle allowlist + job
       descendant proof.
 - [ ] T4: Linux namespace + explicit host-path deny (role-private paths still
       work; mount-table change or `pivot_root`, not Landlock) +

--- a/docs/specs/kel78-strict-profile-sandbox.md
+++ b/docs/specs/kel78-strict-profile-sandbox.md
@@ -1,7 +1,14 @@
 # Spec: strict-profile OS sandbox and native-addon-worker proof
 
-Status: draft
-Linear: KEL-78 · Owner: GYLDLAB · Updated: 2026-08-19
+Status: approved
+Linear: KEL-78 · Owner: GYLDLAB · Updated: 2026-08-31
+
+Approval provenance: direct-session human authorization for the frozen Windows
+T3 contract is recorded in Linear comment
+`79e0c22e-6807-4a3d-a371-edbc11fd9f9b`. The approval covers the exact
+zero-capability LPAC + reviewed ACL + handle allowlist + non-breakaway Job
+Object scope below. It does not waive unsafe, public-API, permission-model,
+dependency, hostile-test, real-OS, or merge review gates.
 
 Primary sources: [`kel78-primary-sources.md`](kel78-primary-sources.md)
 Written against `origin/main` `67f39cdc898254f1e0c9cd50800f242ae7a4c493`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4125,6 +4125,18 @@ match the crate that already emits the code. Do not invent a third spelling.
 - message: The private macOS host-death guardian exited while the host session was still live
 - fix: Confirm the registered-group fail-safe completed; restart the host session, diagnose the guardian exit, then relaunch the app.
 
+## KELD-RUNTIME-014
+
+- crate: keld-runtime
+- message: Windows host-death Job installation failed before child creation
+- fix: Stop before spawning Bun, verify nested Job support and exact non-breakaway `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` configuration, then retry.
+
+## KELD-RUNTIME-015
+
+- crate: keld-runtime
+- message: Windows zero-capability LPAC admission failed
+- fix: Do not start an unconfined replacement. Repair the AppContainer profile, reviewed path ACLs, explicit environment, or private inherited-handle allowlist and refresh the hostile proof.
+
 ## KELD-NATIVE-001
 
 - crate: keld-native


### PR DESCRIPTION
## Summary

- implements the approved KEL-78/T3 Windows boundary: an unnamed non-breakaway host Job with KILL_ON_JOB_CLOSE plus zero-capability LPAC process creation
- applies reviewed package-SID ACLs, explicit environment admission, private inheritable handle duplicates, and an exact PROC_THREAD_ATTRIBUTE_HANDLE_LIST
- creates LPAC children suspended for token and raw cross-process handle-table evidence before resume
- proves the pinned Bun 1.4.0 artifact, hostile OS denies, descendant behavior, host-only death reaping, and clean relaunch on real Windows
- adds the non-hollow keld-runtime unsafe-invariant owner required by repository governance

## Spec refs

- KEL-78
- docs/specs/kel78-strict-profile-sandbox.md T3 and AC4/5/9/10
- docs/specs/kel78-primary-sources.md W2-W6

## Review gates

- unsafe: yes — isolated Win32 Job/LPAC and NT handle-census ABI; human sign-off required
- public API: yes — new Windows-only runtime Job and LPAC owners; human sign-off required
- permission model: yes — LPAC capabilities, ACLs, environment, and inherited handles; human sign-off required
- dependency addition: yes — target-only exact windows-sys 0.61.2, already locked transitively; human sign-off required
- wire protocol: none
- root/shared agent instruction: yes — runtime nested owner and unchanged budgets; human sign-off required

## Tests

- cargo fmt --all --check: pass
- cargo clippy --workspace --all-targets -- -D warnings: pass
- cargo nextest run --workspace --profile ci: 467/467 pass, 2 helper entries skipped
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps: pass
- real Windows Job test: pass; removing KILL_ON_JOB_CLOSE leaves the direct child alive and fails the oracle
- real Windows LPAC/Bun test: pass; removing the LPAC opt-out exposes ALL APPLICATION PACKAGES/network/registry and fails; removing HANDLE_LIST leaks the planted host handle and fails
- CodeRabbit CLI current range: major inherit-flag race fixed with private duplicates; final minor dynamic-version suggestion refuted because the CI/runtime artifact is deliberately pinned to 1.4.0
- instruction review: agents-md, agent-context 13/13, atomic-protocol 16/16, llms-test 5/5, llms-check, and all nested prompt traces pass
- local limitations: ci-router-test is Ubuntu-owned because documented Git Bash/cargo metadata path forms force fail-safe all-lane routing; Mermaid Docker daemon and cargo-deny are unavailable locally and remain required in CI

## Platforms

- Windows 11 build 26200 on RAMANI: passed real Job, LPAC, ACL, raw handle census, hostile direct-API, pinned Bun, and relaunch evidence
- Bun: 1.4.0+34cbb9a40; SHA-256 627d2e4775c24bdedee2cd7ccc18dcadae061e5345274ab6e3c4c797927bfb8f
- macOS/Linux behavior is unchanged and not claimed by this T3 PR

## Perf impact

Cold spawn adds AppContainer profile/ACL setup, private handle duplication, suspended token/census admission, and Job installation. No steady-state hot path changes and no performance claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows host-death cleanup to terminate child processes when the host exits.
  * Added zero-capability LPAC sandboxing for restricted Windows child processes.
  * Added controlled filesystem access, environment handling, standard I/O, and inherited-handle support.
  * Added token and process lifecycle observations, timeout waiting, and termination controls.

* **Bug Fixes**
  * Added fail-closed handling and documented error codes for Windows runtime setup failures.

* **Tests**
  * Added Windows integration coverage for host cleanup, sandbox boundaries, handle inheritance, and restricted resource access.

* **Documentation**
  * Approved and updated Windows sandbox and handle-inheritance specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->