### PR TITLE
feat(ipc): add Windows named-pipe bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,6 +1338,8 @@ dependencies = [
  "keld-guard",
  "postcard",
  "serde",
+ "windows-permissions",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/keld-ipc/Cargo.toml
+++ b/crates/keld-ipc/Cargo.toml
@@ -14,5 +14,9 @@ postcard = { workspace = true }
 serde = { workspace = true }
 getrandom = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-permissions = { workspace = true }
+windows-sys = { workspace = true, features = ["Win32_System_IO"] }
+
 [lints]
 workspace = true

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -38,8 +38,6 @@ use crate::{APP_LINK_IO_DEADLINE, APP_LINK_READER_POLL};
 pub use crate::admission::{BootstrapRejection, BootstrapRejectionObserver};
 use crate::link::{AppLinkDeadlines, handshake_server_interruptible_until};
 use crate::token::{SessionToken, format_app_link};
-#[cfg(all(windows, test))]
-use crate::windows_named_pipe::PipeSecurityFacts;
 #[cfg(windows)]
 use crate::windows_named_pipe::{
     WaitOutcome, WindowsNamedPipeCanceller, WindowsNamedPipeServer, WindowsNamedPipeStream,
@@ -82,13 +80,36 @@ pub struct BootstrapListener {
 
 /// Result of one bounded bootstrap admission attempt.
 #[derive(Debug)]
-pub enum BootstrapAdmission<S = BootstrapStream> {
+pub enum BootstrapAdmissionFor<S> {
     /// A peer proved possession of the listener's token.
     Authenticated(S),
     /// The host cancelled admission before authentication completed.
     Cancelled,
     /// The generation-wide admission deadline elapsed before authentication.
     DeadlineElapsed,
+}
+
+/// Admission result for the currently selected platform stream.
+///
+/// This concrete alias preserves the original public construction syntax,
+/// including unconstrained terminal variants such as
+/// `BootstrapAdmission::Cancelled`.
+pub type BootstrapAdmission = BootstrapAdmissionFor<BootstrapStream>;
+
+/// Admission result for the opt-in Windows named-pipe stream.
+#[cfg(windows)]
+pub type WindowsNamedPipeBootstrapAdmission =
+    BootstrapAdmissionFor<WindowsNamedPipeBootstrapStream>;
+
+#[cfg(test)]
+mod admission_type_tests {
+    use super::BootstrapAdmission;
+
+    #[test]
+    fn terminal_variant_keeps_original_unconstrained_construction() {
+        let admission = BootstrapAdmission::Cancelled;
+        assert!(matches!(admission, BootstrapAdmission::Cancelled));
+    }
 }
 
 struct NoopRejectionObserver;
@@ -626,7 +647,7 @@ impl WindowsNamedPipeBootstrapListener {
         &self,
         deadline: Instant,
         observer: &dyn BootstrapRejectionObserver,
-    ) -> io::Result<BootstrapAdmission<WindowsNamedPipeBootstrapStream>> {
+    ) -> io::Result<WindowsNamedPipeBootstrapAdmission> {
         let _admission = lock_or_recover(&self.admission);
         self.accept_loop(deadline, APP_LINK_IO_DEADLINE, observer)
     }
@@ -636,7 +657,7 @@ impl WindowsNamedPipeBootstrapListener {
         deadline: Instant,
         handshake_deadline: Duration,
         observer: &dyn BootstrapRejectionObserver,
-    ) -> io::Result<BootstrapAdmission<WindowsNamedPipeBootstrapStream>> {
+    ) -> io::Result<WindowsNamedPipeBootstrapAdmission> {
         loop {
             let server = lock_or_recover(&self.server)
                 .as_ref()
@@ -650,16 +671,21 @@ impl WindowsNamedPipeBootstrapListener {
             if self.stopping.load(Ordering::Acquire) {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(BootstrapAdmission::Cancelled);
+                return Ok(WindowsNamedPipeBootstrapAdmission::Cancelled);
+            }
+            if Instant::now() >= deadline {
+                server.close_terminal()?;
+                drop(lock_or_recover(&self.server).take());
+                return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
             }
             match server.accept_until(Some(deadline))? {
                 WaitOutcome::Cancelled => {
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(BootstrapAdmission::Cancelled);
+                    return Ok(WindowsNamedPipeBootstrapAdmission::Cancelled);
                 }
                 WaitOutcome::DeadlineElapsed => {
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(BootstrapAdmission::DeadlineElapsed);
+                    return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
                 }
                 WaitOutcome::PeerClosed => {
                     observer.rejected(BootstrapRejection::Io);
@@ -671,23 +697,23 @@ impl WindowsNamedPipeBootstrapListener {
             if self.stopping.load(Ordering::Acquire) {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(BootstrapAdmission::Cancelled);
+                return Ok(WindowsNamedPipeBootstrapAdmission::Cancelled);
             }
             let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(BootstrapAdmission::DeadlineElapsed);
+                return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
             };
             if remaining.is_zero() {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(BootstrapAdmission::DeadlineElapsed);
+                return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
             }
             let peer_timeout = remaining.min(handshake_deadline);
             let Some(peer_deadline) = Instant::now().checked_add(peer_timeout) else {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(BootstrapAdmission::DeadlineElapsed);
+                return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
             };
             let mut stream = WindowsNamedPipeBootstrapStream(server.stream()?);
             stream.set_app_link_read_deadline(Some(APP_LINK_READER_POLL.min(peer_timeout)))?;
@@ -703,25 +729,25 @@ impl WindowsNamedPipeBootstrapListener {
                     stream.0.set_absolute_deadline(None);
                     server.consume();
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(BootstrapAdmission::Authenticated(stream));
+                    return Ok(WindowsNamedPipeBootstrapAdmission::Authenticated(stream));
                 }
                 Ok(false) => {
                     drop(stream);
                     server.close_terminal()?;
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(BootstrapAdmission::Cancelled);
+                    return Ok(WindowsNamedPipeBootstrapAdmission::Cancelled);
                 }
                 Err(_) if self.stopping.load(Ordering::Acquire) => {
                     drop(stream);
                     server.close_terminal()?;
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(BootstrapAdmission::Cancelled);
+                    return Ok(WindowsNamedPipeBootstrapAdmission::Cancelled);
                 }
                 Err(IpcError::Timeout) if Instant::now() >= deadline => {
                     drop(stream);
                     server.close_terminal()?;
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(BootstrapAdmission::DeadlineElapsed);
+                    return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
                 }
                 Err(error) => {
                     observer.rejected(BootstrapRejection::classify(&error));
@@ -733,11 +759,14 @@ impl WindowsNamedPipeBootstrapListener {
     }
 
     #[cfg(test)]
-    fn security_facts(&self) -> io::Result<PipeSecurityFacts> {
+    fn inspect_pipe_handle<T>(
+        &self,
+        inspect: impl FnOnce(&std::os::windows::io::OwnedHandle) -> io::Result<T>,
+    ) -> io::Result<T> {
         lock_or_recover(&self.server)
             .as_ref()
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "bootstrap consumed"))?
-            .security_facts()
+            .inspect_owned_pipe(inspect)
     }
 
     #[cfg(test)]
@@ -820,23 +849,46 @@ impl WindowsNamedPipeBootstrapStream {
     pub fn try_clone(&self) -> io::Result<Self> {
         self.0.try_clone().map(Self)
     }
+
+    /// Waits until the peer has consumed every written byte, then disconnects.
+    ///
+    /// This is the orderly reply-before-close path. [`AppLinkDeadlines::shutdown_app_link`]
+    /// remains abortive and may discard unread pipe bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns a timeout if `deadline` wins; synchronous Windows flush is
+    /// cancelled and joined before the pipe is disconnected.
+    pub fn shutdown_after_drain(&self, deadline: Instant) -> io::Result<()> {
+        self.0.shutdown_after_drain(deadline)
+    }
 }
 
 #[cfg(all(test, windows))]
 mod named_pipe_tests {
+    #![allow(unsafe_code)] // test-only independent Win32 descriptor/handle oracle
+
     use std::io::{Read as _, Write as _};
-    use std::process::Command;
+    use std::os::windows::io::AsRawHandle as _;
+    use std::process::{Child, Command, Output, Stdio};
     use std::sync::{Arc, Mutex, mpsc};
     use std::thread;
     use std::time::{Duration, Instant};
 
+    use windows_permissions::constants::{AceFlags, AceType, SeObjectType, SecurityInformation};
+    use windows_permissions::utilities::current_process_sid;
+    use windows_permissions::wrappers::GetSecurityInfo;
+    use windows_sys::Win32::Foundation::{GetHandleInformation, HANDLE_FLAG_INHERIT};
+    use windows_sys::Win32::System::Pipes::{GetNamedPipeInfo, PIPE_REJECT_REMOTE_CLIENTS};
+
     use crate::link::{AppLinkDeadlines, handshake_client};
+    use crate::serve_echo_requests;
     use crate::token::{SessionToken, parse_app_link};
     use crate::windows_named_pipe::{WindowsNamedPipeServer, process_handle_count};
     use crate::{ChannelId, CorrelationId, FrameHeader, FrameKind, MAX_FRAME_LEN};
 
     use super::{
-        BootstrapAdmission, BootstrapRejection, BootstrapRejectionObserver,
+        BootstrapRejection, BootstrapRejectionObserver, WindowsNamedPipeBootstrapAdmission,
         WindowsNamedPipeBootstrapListener, WindowsNamedPipeBootstrapStream, lock_or_recover,
     };
 
@@ -855,6 +907,18 @@ mod named_pipe_tests {
         }
     }
 
+    struct BlockingObserver {
+        observed: mpsc::Sender<BootstrapRejection>,
+        release: Mutex<mpsc::Receiver<()>>,
+    }
+
+    impl BootstrapRejectionObserver for BlockingObserver {
+        fn rejected(&self, rejection: BootstrapRejection) {
+            let _ = self.observed.send(rejection);
+            let _ = lock_or_recover(&self.release).recv();
+        }
+    }
+
     fn client(endpoint: &str) -> std::io::Result<WindowsNamedPipeBootstrapStream> {
         WindowsNamedPipeServer::connect_client_until(
             endpoint,
@@ -867,6 +931,115 @@ mod named_pipe_tests {
         let mut bytes = header.encode().to_vec();
         bytes.extend_from_slice(payload);
         bytes
+    }
+
+    const BUN_NAMED_PIPE_ECHO: &str = r##"
+import { createConnection } from "node:net";
+
+const link = process.env.KELD_APP_LINK;
+if (!link) throw new Error("missing KELD_APP_LINK");
+const split = link.lastIndexOf("#");
+if (split <= 0) throw new Error("invalid app link");
+const endpoint = link.slice(0, split);
+const token = Buffer.from(link.slice(split + 1), "hex");
+if (token.length !== 32) throw new Error("invalid token length");
+
+const socket = createConnection({ path: endpoint });
+let buffered = Buffer.alloc(0);
+const readers = [];
+let terminalError = null;
+
+function pump() {
+  while (readers.length > 0 && buffered.length >= readers[0].length) {
+    const { length, resolve } = readers.shift();
+    const value = buffered.subarray(0, length);
+    buffered = buffered.subarray(length);
+    resolve(value);
+  }
+}
+
+socket.on("data", (chunk) => {
+  buffered = Buffer.concat([buffered, Buffer.from(chunk)]);
+  pump();
+});
+socket.on("error", (error) => {
+  terminalError = error;
+  while (readers.length > 0) readers.shift().reject(error);
+});
+socket.on("close", () => {
+  if (!terminalError) terminalError = new Error("pipe closed before reply");
+  while (readers.length > 0) readers.shift().reject(terminalError);
+});
+
+function readExact(length) {
+  if (terminalError) return Promise.reject(terminalError);
+  return new Promise((resolve, reject) => {
+    readers.push({ length, resolve, reject });
+    pump();
+  });
+}
+
+function makeFrame(kind, channel, corr, payload) {
+  const header = Buffer.alloc(16);
+  header.writeUInt16LE(0x494b, 0);
+  header[2] = 2;
+  header[3] = kind;
+  header.writeUInt16LE(0, 4);
+  header.writeUInt16LE(channel, 6);
+  header.writeUInt32LE(corr, 8);
+  header.writeUInt32LE(payload.length, 12);
+  return Buffer.concat([header, payload]);
+}
+
+async function readFrame() {
+  const header = await readExact(16);
+  if (header.readUInt16LE(0) !== 0x494b || header[2] !== 2) {
+    throw new Error("invalid kipc header");
+  }
+  return {
+    kind: header[3],
+    channel: header.readUInt16LE(6),
+    corr: header.readUInt32LE(8),
+    payload: await readExact(header.readUInt32LE(12)),
+  };
+}
+
+await new Promise((resolve, reject) => {
+  socket.once("connect", resolve);
+  socket.once("error", reject);
+});
+socket.write(makeFrame(0, 0, 0, token));
+const hello = await readFrame();
+if (hello.kind !== 0 || hello.channel !== 0 || hello.corr !== 0 || !hello.payload.equals(token)) {
+  throw new Error("HELLO mismatch");
+}
+
+const message = Buffer.from("bun-pipe", "utf8");
+const echoPayload = Buffer.concat([Buffer.from([message.length]), message, Buffer.from([42])]);
+socket.write(makeFrame(1, 1, 7, echoPayload));
+const reply = await readFrame();
+if (reply.kind !== 2 || reply.channel !== 1 || reply.corr !== 7 || !reply.payload.equals(echoPayload)) {
+  throw new Error("echo reply mismatch");
+}
+console.log("KELD_BUN_PIPE_ECHO_OK");
+socket.end();
+"##;
+
+    fn wait_child_output(mut child: Child, deadline: Instant) -> std::io::Result<Output> {
+        loop {
+            if child.try_wait()?.is_some() {
+                return child.wait_with_output();
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "Bun named-pipe fixture exceeded deadline",
+                ));
+            }
+            thread::yield_now();
+        }
     }
 
     #[expect(
@@ -910,7 +1083,10 @@ mod named_pipe_tests {
                 .expect("legitimate deadlines");
             handshake_client(&mut legitimate, &token).expect("legitimate HELLO");
             let outcome = worker.join().expect("join").expect("admission");
-            assert!(matches!(outcome, BootstrapAdmission::Authenticated(_)));
+            assert!(matches!(
+                outcome,
+                WindowsNamedPipeBootstrapAdmission::Authenticated(_)
+            ));
             assert_eq!(*lock_or_recover(&seen), vec![expected]);
             return;
         }
@@ -933,7 +1109,10 @@ mod named_pipe_tests {
             .expect("legitimate deadlines");
         handshake_client(&mut legitimate, &token).expect("legitimate HELLO");
         let outcome = worker.join().expect("join").expect("admission");
-        assert!(matches!(outcome, BootstrapAdmission::Authenticated(_)));
+        assert!(matches!(
+            outcome,
+            WindowsNamedPipeBootstrapAdmission::Authenticated(_)
+        ));
         assert_eq!(*lock_or_recover(&seen), vec![expected]);
     }
 
@@ -957,15 +1136,57 @@ mod named_pipe_tests {
             token.to_hex(),
             "pipe namespace nonce must be minted independently from the HELLO token"
         );
-        let facts = listener.security_facts().expect("security readback");
-        assert!(facts.protected_dacl);
-        assert_eq!(facts.ace_count, 1);
-        assert!(facts.one_ace_is_current_user);
-        assert_eq!(facts.one_ace_type, 0);
-        assert_eq!(facts.one_ace_flags, 0);
-        assert_eq!(facts.one_ace_mask, 0x0012_019B);
-        assert_eq!(facts.one_ace_mask & 0x4, 0);
-        assert_eq!(facts.handle_flags & 1, 0);
+        listener
+            .inspect_pipe_handle(|handle| {
+                let current_sid = current_process_sid()?;
+                let descriptor = GetSecurityInfo(
+                    handle,
+                    SeObjectType::SE_KERNEL_OBJECT,
+                    SecurityInformation::Dacl,
+                )?;
+                let sddl = descriptor.as_sddl()?;
+                assert!(sddl.to_string_lossy().contains("D:P"));
+                let dacl = descriptor
+                    .dacl()
+                    .ok_or_else(|| std::io::Error::other("test readback found no DACL"))?;
+                assert_eq!(dacl.len(), 1);
+                let ace = dacl
+                    .get_ace(0)
+                    .ok_or_else(|| std::io::Error::other("test readback found no ACE"))?;
+                assert_eq!(ace.sid(), Some(&*current_sid));
+                assert_eq!(ace.ace_type(), AceType::ACCESS_ALLOWED_ACE_TYPE);
+                assert_eq!(ace.flags(), AceFlags::empty());
+                assert_eq!(ace.mask().bits(), 0x0012_019B);
+                assert_eq!(ace.mask().bits() & 0x4, 0);
+
+                let mut handle_flags = 0;
+                // SAFETY: the borrowed server handle is live for this closure
+                // and `handle_flags` is a valid writable u32.
+                assert_ne!(
+                    unsafe { GetHandleInformation(handle.as_raw_handle(), &raw mut handle_flags) },
+                    0
+                );
+                assert_eq!(handle_flags & HANDLE_FLAG_INHERIT, 0);
+
+                let mut pipe_flags = 0;
+                // SAFETY: the borrowed server handle is live, `pipe_flags` is
+                // writable, and the remaining outputs are documented optional.
+                assert_ne!(
+                    unsafe {
+                        GetNamedPipeInfo(
+                            handle.as_raw_handle(),
+                            &raw mut pipe_flags,
+                            std::ptr::null_mut(),
+                            std::ptr::null_mut(),
+                            std::ptr::null_mut(),
+                        )
+                    },
+                    0
+                );
+                assert_ne!(pipe_flags & PIPE_REJECT_REMOTE_CLIENTS, 0);
+                Ok(())
+            })
+            .expect("independent pipe security readback");
 
         let collision = WindowsNamedPipeServer::bind(endpoint)
             .expect_err("FILE_FLAG_FIRST_PIPE_INSTANCE must reject a second server");
@@ -996,7 +1217,10 @@ mod named_pipe_tests {
             .join()
             .expect("join accept worker")
             .expect("admission");
-        assert!(matches!(outcome, BootstrapAdmission::Cancelled));
+        assert!(matches!(
+            outcome,
+            WindowsNamedPipeBootstrapAdmission::Cancelled
+        ));
     }
 
     #[test]
@@ -1023,7 +1247,10 @@ mod named_pipe_tests {
         }
         cancellation.cancel().expect("cancel active HELLO");
         let outcome = worker.join().expect("join").expect("admission");
-        assert!(matches!(outcome, BootstrapAdmission::Cancelled));
+        assert!(matches!(
+            outcome,
+            WindowsNamedPipeBootstrapAdmission::Cancelled
+        ));
         drop(partial);
         let stale = WindowsNamedPipeServer::connect_client(&endpoint)
             .expect_err("cancelled generation must close its pipe handle");
@@ -1067,10 +1294,91 @@ mod named_pipe_tests {
             .expect("legitimate deadlines");
         handshake_client(&mut legitimate, &token).expect("matching HELLO accepted");
         let outcome = worker.join().expect("join").expect("admission");
-        assert!(matches!(outcome, BootstrapAdmission::Authenticated(_)));
+        assert!(matches!(
+            outcome,
+            WindowsNamedPipeBootstrapAdmission::Authenticated(_)
+        ));
         let seen = lock_or_recover(&seen);
         assert_eq!(*seen, vec![BootstrapRejection::HelloAuth]);
         assert_eq!(seen[0].code(), "KELD-IPC-007");
+    }
+
+    #[test]
+    fn rejected_peer_then_bun_node_net_child_completes_hello_and_echo() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (notify_tx, notify_rx) = mpsc::channel();
+        let observer = RecordingObserver {
+            seen: Arc::clone(&seen),
+            notify: Some(notify_tx),
+        };
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || -> Result<(), String> {
+            let outcome = worker_listener
+                .accept_authenticated_until(Instant::now() + Duration::from_secs(10), &observer)
+                .map_err(|error| error.to_string())?;
+            let WindowsNamedPipeBootstrapAdmission::Authenticated(mut stream) = outcome else {
+                return Err("Bun child did not authenticate before terminal admission".to_owned());
+            };
+            match serve_echo_requests(&mut stream) {
+                Ok(()) => Ok(()),
+                Err(crate::IpcError::Io(error)) if error.raw_os_error() == Some(109) => Ok(()),
+                Err(error) => Err(error.to_string()),
+            }
+        });
+
+        let mut foreign_bytes = *token.as_bytes();
+        foreign_bytes[0] ^= 1;
+        let mut hostile = client(&endpoint).expect("open hostile client");
+        hostile
+            .set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("hostile deadlines");
+        let _ = handshake_client(&mut hostile, &SessionToken::from_bytes(foreign_bytes))
+            .expect_err("foreign HELLO denied");
+        drop(hostile);
+        assert_eq!(
+            notify_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("HELLO rejection record"),
+            BootstrapRejection::HelloAuth
+        );
+        let pending_deadline = Instant::now() + Duration::from_secs(1);
+        while !listener.is_accept_pending() {
+            assert!(
+                Instant::now() < pending_deadline,
+                "server did not re-enter named-pipe accept after rejection"
+            );
+            thread::yield_now();
+        }
+
+        let child = Command::new("bun")
+            .args(["-e", BUN_NAMED_PIPE_ECHO])
+            .env("KELD_APP_LINK", &link)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn Bun named-pipe fixture");
+        let output = wait_child_output(child, Instant::now() + Duration::from_secs(5))
+            .expect("bounded Bun fixture");
+        assert!(
+            output.status.success(),
+            "Bun named-pipe fixture failed: stdout={}, stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "KELD_BUN_PIPE_ECHO_OK"
+        );
+        worker
+            .join()
+            .expect("join Bun echo server")
+            .expect("serve Bun echo");
+        assert_eq!(*lock_or_recover(&seen), vec![BootstrapRejection::HelloAuth]);
     }
 
     #[test]
@@ -1110,7 +1418,10 @@ mod named_pipe_tests {
             .expect("legitimate deadlines");
         handshake_client(&mut legitimate, &token).expect("same pipe reaccepted");
         let outcome = worker.join().expect("join").expect("admission");
-        assert!(matches!(outcome, BootstrapAdmission::Authenticated(_)));
+        assert!(matches!(
+            outcome,
+            WindowsNamedPipeBootstrapAdmission::Authenticated(_)
+        ));
         assert_eq!(*lock_or_recover(&seen), vec![BootstrapRejection::Timeout]);
     }
 
@@ -1123,10 +1434,78 @@ mod named_pipe_tests {
                 &super::NoopRejectionObserver,
             )
             .expect("deadline admission");
-        assert!(matches!(outcome, BootstrapAdmission::DeadlineElapsed));
+        assert!(matches!(
+            outcome,
+            WindowsNamedPipeBootstrapAdmission::DeadlineElapsed
+        ));
         let error = WindowsNamedPipeServer::connect_client(listener.endpoint())
             .expect_err("terminal generation must not accept a late connector");
         assert!(matches!(error.raw_os_error(), Some(2 | 231)));
+    }
+
+    #[test]
+    fn already_expired_generation_never_enters_pipe_accept() {
+        let listener = WindowsNamedPipeBootstrapListener::bind().expect("bind");
+        let deadline = Instant::now()
+            .checked_sub(Duration::from_millis(1))
+            .expect("representable expired deadline");
+        let outcome = listener
+            .accept_authenticated_until(deadline, &super::NoopRejectionObserver)
+            .expect("expired admission");
+        assert!(matches!(
+            outcome,
+            WindowsNamedPipeBootstrapAdmission::DeadlineElapsed
+        ));
+        let stale = WindowsNamedPipeServer::connect_client(listener.endpoint())
+            .expect_err("expired generation must close before accepting");
+        assert_eq!(stale.raw_os_error(), Some(2));
+    }
+
+    #[test]
+    fn generation_expiry_during_rejection_blocks_reaccept() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let endpoint = listener.endpoint().to_owned();
+        let cancellation = listener.cancellation();
+        let deadline = Instant::now() + Duration::from_millis(100);
+        let (observed_tx, observed_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let observer = BlockingObserver {
+            observed: observed_tx,
+            release: Mutex::new(release_rx),
+        };
+        let worker_listener = Arc::clone(&listener);
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            let _ = result_tx.send(worker_listener.accept_authenticated_until(deadline, &observer));
+        });
+
+        let mut hostile = client(&endpoint).expect("open hostile client");
+        hostile.write_all(&[0_u8; 16]).expect("bad header");
+        assert_eq!(
+            observed_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("header rejection"),
+            BootstrapRejection::Header
+        );
+        while Instant::now() < deadline {
+            thread::yield_now();
+        }
+        release_tx.send(()).expect("release observer after expiry");
+
+        let outcome = match result_rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => result.expect("admission result"),
+            Err(error) => {
+                cancellation.cancel().expect("cancel wedged reaccept");
+                worker.join().expect("join cancelled reaccept");
+                panic!("expired rejection path re-entered an unbounded accept: {error}");
+            }
+        };
+        assert!(matches!(
+            outcome,
+            WindowsNamedPipeBootstrapAdmission::DeadlineElapsed
+        ));
+        drop(hostile);
+        worker.join().expect("join expired rejection worker");
     }
 
     #[test]
@@ -1216,7 +1595,7 @@ mod named_pipe_tests {
             .expect("deadlines");
         handshake_client(&mut role, &token).expect("authenticate");
         let outcome = worker.join().expect("join").expect("admission");
-        let BootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+        let WindowsNamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
             panic!("expected authenticated named-pipe session")
         };
         stale_cancellation
@@ -1257,7 +1636,7 @@ mod named_pipe_tests {
             .expect("role deadlines");
         handshake_client(&mut role, &token).expect("authenticate");
         let outcome = worker.join().expect("join").expect("admission");
-        let BootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+        let WindowsNamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
             panic!("expected authenticated named-pipe session")
         };
         server_stream
@@ -1288,7 +1667,7 @@ mod named_pipe_tests {
             .expect("role deadlines");
         handshake_client(&mut role, &token).expect("authenticate");
         let outcome = worker.join().expect("join admission").expect("admission");
-        let BootstrapAdmission::Authenticated(server_stream) = outcome else {
+        let WindowsNamedPipeBootstrapAdmission::Authenticated(server_stream) = outcome else {
             panic!("expected authenticated named-pipe session")
         };
         let mut blocked_reader = server_stream.try_clone().expect("clone server stream");
@@ -1322,6 +1701,89 @@ mod named_pipe_tests {
             .read(&mut peer_byte)
             .expect_err("shutdown must also close the peer-facing connection");
         assert!(matches!(peer_error.raw_os_error(), Some(109 | 232 | 233)));
+    }
+
+    #[test]
+    fn orderly_shutdown_waits_for_peer_read_then_preserves_bytes() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(
+                Instant::now() + Duration::from_secs(2),
+                &super::NoopRejectionObserver,
+            )
+        });
+        let mut role = client(&endpoint).expect("open role");
+        role.set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("role deadlines");
+        handshake_client(&mut role, &token).expect("authenticate");
+        let outcome = worker.join().expect("join admission").expect("admission");
+        let WindowsNamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+            panic!("expected authenticated named-pipe session")
+        };
+        server_stream
+            .write_all(b"reply")
+            .expect("write orderly reply");
+        let drain_stream = server_stream.try_clone().expect("clone drain stream");
+        let (drain_tx, drain_rx) = mpsc::channel();
+        let drain = thread::spawn(move || {
+            let _ = drain_tx
+                .send(drain_stream.shutdown_after_drain(Instant::now() + Duration::from_secs(2)));
+        });
+        let pending_deadline = Instant::now() + Duration::from_secs(1);
+        while !server_stream.0.is_drain_pending() {
+            assert!(
+                Instant::now() < pending_deadline,
+                "orderly drain never entered FlushFileBuffers"
+            );
+            thread::yield_now();
+        }
+        assert!(
+            matches!(drain_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "drain must not complete before the peer consumes the reply"
+        );
+        let mut reply = [0_u8; 5];
+        role.read_exact(&mut reply).expect("read orderly reply");
+        assert_eq!(&reply, b"reply");
+        drain_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("drain completion")
+            .expect("orderly drain");
+        drain.join().expect("join orderly drain");
+    }
+
+    #[test]
+    fn orderly_shutdown_times_out_and_joins_for_non_reading_peer() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(
+                Instant::now() + Duration::from_secs(2),
+                &super::NoopRejectionObserver,
+            )
+        });
+        let mut role = client(&endpoint).expect("open role");
+        role.set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("role deadlines");
+        handshake_client(&mut role, &token).expect("authenticate");
+        let outcome = worker.join().expect("join admission").expect("admission");
+        let WindowsNamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+            panic!("expected authenticated named-pipe session")
+        };
+        server_stream
+            .write_all(b"reply")
+            .expect("write orderly reply");
+        let error = server_stream
+            .shutdown_after_drain(Instant::now() + Duration::from_millis(50))
+            .expect_err("non-reading peer must not wedge orderly shutdown");
+        assert_eq!(error.raw_os_error(), Some(121));
+        drop(role);
     }
 
     #[test]
@@ -1363,7 +1825,7 @@ mod named_pipe_tests {
         cancellation.cancel().expect("cancel cycle");
         assert!(matches!(
             worker.join().expect("join cycle").expect("cycle result"),
-            BootstrapAdmission::Cancelled
+            WindowsNamedPipeBootstrapAdmission::Cancelled
         ));
     }
 

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -825,13 +825,14 @@ impl WindowsNamedPipeBootstrapStream {
 #[cfg(all(test, windows))]
 mod named_pipe_tests {
     use std::io::{Read as _, Write as _};
+    use std::process::Command;
     use std::sync::{Arc, Mutex, mpsc};
     use std::thread;
     use std::time::{Duration, Instant};
 
     use crate::link::{AppLinkDeadlines, handshake_client};
     use crate::token::{SessionToken, parse_app_link};
-    use crate::windows_named_pipe::WindowsNamedPipeServer;
+    use crate::windows_named_pipe::{WindowsNamedPipeServer, process_handle_count};
     use crate::{ChannelId, CorrelationId, FrameHeader, FrameKind, MAX_FRAME_LEN};
 
     use super::{
@@ -1276,6 +1277,70 @@ mod named_pipe_tests {
         let stale = WindowsNamedPipeServer::connect_client(&endpoint)
             .expect_err("non-owning cancellation view must not preserve pipe handle");
         assert_eq!(stale.raw_os_error(), Some(2));
+    }
+
+    #[expect(
+        clippy::expect_used,
+        reason = "test cycle helper reports the exact failed handle-lifecycle boundary"
+    )]
+    fn run_cancelled_accept_cycle() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind cycle"));
+        let cancellation = listener.cancellation();
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(
+                Instant::now() + Duration::from_secs(2),
+                &super::NoopRejectionObserver,
+            )
+        });
+        let pending_deadline = Instant::now() + Duration::from_secs(1);
+        while !listener.is_accept_pending() {
+            assert!(
+                Instant::now() < pending_deadline,
+                "cycle accept never became pending"
+            );
+            thread::yield_now();
+        }
+        cancellation.cancel().expect("cancel cycle");
+        assert!(matches!(
+            worker.join().expect("join cycle").expect("cycle result"),
+            BootstrapAdmission::Cancelled
+        ));
+    }
+
+    #[test]
+    fn repeated_cancellation_returns_process_handle_count_to_baseline() {
+        const CHILD_ENV: &str = "KELD_TEST_PIPE_HANDLE_CENSUS_CHILD";
+        if std::env::var_os(CHILD_ENV).is_none() {
+            let output = Command::new(std::env::current_exe().expect("current test binary"))
+                .args([
+                    "--exact",
+                    "bootstrap::named_pipe_tests::repeated_cancellation_returns_process_handle_count_to_baseline",
+                    "--nocapture",
+                ])
+                .env(CHILD_ENV, "1")
+                .output()
+                .expect("run isolated handle census");
+            assert!(
+                output.status.success(),
+                "isolated handle census failed: status={:?}, stdout={}, stderr={}",
+                output.status.code(),
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        run_cancelled_accept_cycle();
+        let baseline = process_handle_count().expect("baseline handle count");
+        for _ in 0..32 {
+            run_cancelled_accept_cycle();
+        }
+        let final_count = process_handle_count().expect("final handle count");
+        assert_eq!(
+            final_count, baseline,
+            "pipe, cancel-event, or per-accept event handle leaked across cycles"
+        );
     }
 }
 

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -883,7 +883,8 @@ impl WindowsNamedPipeBootstrapStream {
     ///
     /// # Errors
     ///
-    /// Reserved for parity with other platform streams.
+    /// Returns [`io::Error`] if either manual-reset event for the cloned
+    /// stream cannot be created with `CreateEventW`.
     pub fn try_clone(&self) -> io::Result<Self> {
         self.0.try_clone().map(Self)
     }
@@ -1864,6 +1865,11 @@ socket.end();
                 output.status.code(),
                 String::from_utf8_lossy(&output.stdout),
                 String::from_utf8_lossy(&output.stderr)
+            );
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert!(
+                stdout.contains("test result: ok. 1 passed; 0 failed;"),
+                "isolated census must execute exactly one test: {stdout}"
             );
             return;
         }

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -895,8 +895,9 @@ impl WindowsNamedPipeBootstrapStream {
     ///
     /// # Errors
     ///
-    /// Returns a timeout if `deadline` wins; synchronous Windows flush is
-    /// cancelled and joined before the pipe is disconnected.
+    /// Returns a timeout if `deadline` wins. Timeout starts an abortive
+    /// disconnect, requests cancellation of the synchronous Windows flush,
+    /// and observes the drain worker's completion before returning.
     pub fn shutdown_after_drain(&self, deadline: Instant) -> io::Result<()> {
         self.0.shutdown_after_drain(deadline)
     }
@@ -1861,6 +1862,19 @@ socket.end();
             .shutdown_after_drain(Instant::now() + Duration::from_millis(50))
             .expect_err("non-reading peer must not wedge orderly shutdown");
         assert_eq!(error.raw_os_error(), Some(121));
+        assert!(
+            !server_stream.0.is_drain_pending(),
+            "timeout must observe drain-worker completion before returning"
+        );
+        if let Err(followup) =
+            server_stream.shutdown_after_drain(Instant::now() + Duration::from_millis(50))
+        {
+            assert_ne!(
+                followup.kind(),
+                std::io::ErrorKind::WouldBlock,
+                "timeout must release the single-drain claim"
+            );
+        }
         drop(role);
     }
 

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -82,9 +82,9 @@ pub struct BootstrapListener {
 
 /// Result of one bounded bootstrap admission attempt.
 #[derive(Debug)]
-pub enum BootstrapAdmission {
+pub enum BootstrapAdmission<S = BootstrapStream> {
     /// A peer proved possession of the listener's token.
-    Authenticated(BootstrapStream),
+    Authenticated(S),
     /// The host cancelled admission before authentication completed.
     Cancelled,
     /// The generation-wide admission deadline elapsed before authentication.
@@ -626,7 +626,7 @@ impl WindowsNamedPipeBootstrapListener {
         &self,
         deadline: Instant,
         observer: &dyn BootstrapRejectionObserver,
-    ) -> io::Result<NamedPipeBootstrapAdmission> {
+    ) -> io::Result<BootstrapAdmission<WindowsNamedPipeBootstrapStream>> {
         let _admission = lock_or_recover(&self.admission);
         self.accept_loop(deadline, APP_LINK_IO_DEADLINE, observer)
     }
@@ -636,7 +636,7 @@ impl WindowsNamedPipeBootstrapListener {
         deadline: Instant,
         handshake_deadline: Duration,
         observer: &dyn BootstrapRejectionObserver,
-    ) -> io::Result<NamedPipeBootstrapAdmission> {
+    ) -> io::Result<BootstrapAdmission<WindowsNamedPipeBootstrapStream>> {
         loop {
             let server = lock_or_recover(&self.server)
                 .as_ref()
@@ -650,16 +650,16 @@ impl WindowsNamedPipeBootstrapListener {
             if self.stopping.load(Ordering::Acquire) {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(NamedPipeBootstrapAdmission::Cancelled);
+                return Ok(BootstrapAdmission::Cancelled);
             }
             match server.accept_until(Some(deadline))? {
                 WaitOutcome::Cancelled => {
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(NamedPipeBootstrapAdmission::Cancelled);
+                    return Ok(BootstrapAdmission::Cancelled);
                 }
                 WaitOutcome::DeadlineElapsed => {
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+                    return Ok(BootstrapAdmission::DeadlineElapsed);
                 }
                 WaitOutcome::PeerClosed => {
                     observer.rejected(BootstrapRejection::Io);
@@ -671,23 +671,23 @@ impl WindowsNamedPipeBootstrapListener {
             if self.stopping.load(Ordering::Acquire) {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(NamedPipeBootstrapAdmission::Cancelled);
+                return Ok(BootstrapAdmission::Cancelled);
             }
             let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+                return Ok(BootstrapAdmission::DeadlineElapsed);
             };
             if remaining.is_zero() {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+                return Ok(BootstrapAdmission::DeadlineElapsed);
             }
             let peer_timeout = remaining.min(handshake_deadline);
             let Some(peer_deadline) = Instant::now().checked_add(peer_timeout) else {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
-                return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+                return Ok(BootstrapAdmission::DeadlineElapsed);
             };
             let mut stream = WindowsNamedPipeBootstrapStream(server.stream());
             stream.set_app_link_read_deadline(Some(APP_LINK_READER_POLL.min(peer_timeout)))?;
@@ -703,25 +703,25 @@ impl WindowsNamedPipeBootstrapListener {
                     stream.0.set_absolute_deadline(None);
                     server.consume();
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(NamedPipeBootstrapAdmission::Authenticated(stream));
+                    return Ok(BootstrapAdmission::Authenticated(stream));
                 }
                 Ok(false) => {
                     drop(stream);
                     server.close_terminal()?;
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(NamedPipeBootstrapAdmission::Cancelled);
+                    return Ok(BootstrapAdmission::Cancelled);
                 }
                 Err(_) if self.stopping.load(Ordering::Acquire) => {
                     drop(stream);
                     server.close_terminal()?;
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(NamedPipeBootstrapAdmission::Cancelled);
+                    return Ok(BootstrapAdmission::Cancelled);
                 }
                 Err(IpcError::Timeout) if Instant::now() >= deadline => {
                     drop(stream);
                     server.close_terminal()?;
                     drop(lock_or_recover(&self.server).take());
-                    return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+                    return Ok(BootstrapAdmission::DeadlineElapsed);
                 }
                 Err(error) => {
                     observer.rejected(BootstrapRejection::classify(&error));
@@ -753,18 +753,6 @@ impl WindowsNamedPipeBootstrapListener {
             .as_ref()
             .is_some_and(WindowsNamedPipeServer::is_accept_pending)
     }
-}
-
-/// Result of one bounded named-pipe bootstrap admission attempt.
-#[cfg(windows)]
-#[derive(Debug)]
-pub enum NamedPipeBootstrapAdmission {
-    /// A peer proved possession of the generation token.
-    Authenticated(WindowsNamedPipeBootstrapStream),
-    /// Host cancellation won.
-    Cancelled,
-    /// The absolute generation deadline elapsed.
-    DeadlineElapsed,
 }
 
 #[cfg(windows)]
@@ -847,7 +835,7 @@ mod named_pipe_tests {
     use crate::{ChannelId, CorrelationId, FrameHeader, FrameKind, MAX_FRAME_LEN};
 
     use super::{
-        BootstrapRejection, BootstrapRejectionObserver, NamedPipeBootstrapAdmission,
+        BootstrapAdmission, BootstrapRejection, BootstrapRejectionObserver,
         WindowsNamedPipeBootstrapListener, WindowsNamedPipeBootstrapStream, lock_or_recover,
     };
 
@@ -921,10 +909,7 @@ mod named_pipe_tests {
                 .expect("legitimate deadlines");
             handshake_client(&mut legitimate, &token).expect("legitimate HELLO");
             let outcome = worker.join().expect("join").expect("admission");
-            assert!(matches!(
-                outcome,
-                NamedPipeBootstrapAdmission::Authenticated(_)
-            ));
+            assert!(matches!(outcome, BootstrapAdmission::Authenticated(_)));
             assert_eq!(*lock_or_recover(&seen), vec![expected]);
             return;
         }
@@ -947,10 +932,7 @@ mod named_pipe_tests {
             .expect("legitimate deadlines");
         handshake_client(&mut legitimate, &token).expect("legitimate HELLO");
         let outcome = worker.join().expect("join").expect("admission");
-        assert!(matches!(
-            outcome,
-            NamedPipeBootstrapAdmission::Authenticated(_)
-        ));
+        assert!(matches!(outcome, BootstrapAdmission::Authenticated(_)));
         assert_eq!(*lock_or_recover(&seen), vec![expected]);
     }
 
@@ -1008,7 +990,7 @@ mod named_pipe_tests {
             .join()
             .expect("join accept worker")
             .expect("admission");
-        assert!(matches!(outcome, NamedPipeBootstrapAdmission::Cancelled));
+        assert!(matches!(outcome, BootstrapAdmission::Cancelled));
     }
 
     #[test]
@@ -1035,7 +1017,7 @@ mod named_pipe_tests {
         }
         cancellation.cancel().expect("cancel active HELLO");
         let outcome = worker.join().expect("join").expect("admission");
-        assert!(matches!(outcome, NamedPipeBootstrapAdmission::Cancelled));
+        assert!(matches!(outcome, BootstrapAdmission::Cancelled));
         drop(partial);
         let stale = WindowsNamedPipeServer::connect_client(&endpoint)
             .expect_err("cancelled generation must close its pipe handle");
@@ -1079,10 +1061,7 @@ mod named_pipe_tests {
             .expect("legitimate deadlines");
         handshake_client(&mut legitimate, &token).expect("matching HELLO accepted");
         let outcome = worker.join().expect("join").expect("admission");
-        assert!(matches!(
-            outcome,
-            NamedPipeBootstrapAdmission::Authenticated(_)
-        ));
+        assert!(matches!(outcome, BootstrapAdmission::Authenticated(_)));
         let seen = lock_or_recover(&seen);
         assert_eq!(*seen, vec![BootstrapRejection::HelloAuth]);
         assert_eq!(seen[0].code(), "KELD-IPC-007");
@@ -1125,10 +1104,7 @@ mod named_pipe_tests {
             .expect("legitimate deadlines");
         handshake_client(&mut legitimate, &token).expect("same pipe reaccepted");
         let outcome = worker.join().expect("join").expect("admission");
-        assert!(matches!(
-            outcome,
-            NamedPipeBootstrapAdmission::Authenticated(_)
-        ));
+        assert!(matches!(outcome, BootstrapAdmission::Authenticated(_)));
         assert_eq!(*lock_or_recover(&seen), vec![BootstrapRejection::Timeout]);
     }
 
@@ -1141,10 +1117,7 @@ mod named_pipe_tests {
                 &super::NoopRejectionObserver,
             )
             .expect("deadline admission");
-        assert!(matches!(
-            outcome,
-            NamedPipeBootstrapAdmission::DeadlineElapsed
-        ));
+        assert!(matches!(outcome, BootstrapAdmission::DeadlineElapsed));
         let error = WindowsNamedPipeServer::connect_client(listener.endpoint())
             .expect_err("terminal generation must not accept a late connector");
         assert!(matches!(error.raw_os_error(), Some(2 | 231)));
@@ -1237,7 +1210,7 @@ mod named_pipe_tests {
             .expect("deadlines");
         handshake_client(&mut role, &token).expect("authenticate");
         let outcome = worker.join().expect("join").expect("admission");
-        let NamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+        let BootstrapAdmission::Authenticated(mut server_stream) = outcome else {
             panic!("expected authenticated named-pipe session")
         };
         stale_cancellation
@@ -1278,7 +1251,7 @@ mod named_pipe_tests {
             .expect("role deadlines");
         handshake_client(&mut role, &token).expect("authenticate");
         let outcome = worker.join().expect("join").expect("admission");
-        let NamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+        let BootstrapAdmission::Authenticated(mut server_stream) = outcome else {
             panic!("expected authenticated named-pipe session")
         };
         server_stream

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -569,6 +569,15 @@ pub struct WindowsNamedPipeBootstrapListener {
     endpoint: String,
     token: SessionToken,
     stopping: Arc<AtomicBool>,
+    #[cfg(test)]
+    before_consume: Mutex<Option<TestConsumeGate>>,
+}
+
+#[cfg(all(test, windows))]
+#[derive(Debug)]
+struct TestConsumeGate {
+    entered: std::sync::mpsc::SyncSender<()>,
+    release: std::sync::mpsc::Receiver<()>,
 }
 
 /// Connected authenticated stream from [`WindowsNamedPipeBootstrapListener`].
@@ -608,6 +617,8 @@ impl WindowsNamedPipeBootstrapListener {
             endpoint,
             token,
             stopping: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            before_consume: Mutex::new(None),
         })
     }
 
@@ -652,6 +663,10 @@ impl WindowsNamedPipeBootstrapListener {
         self.accept_loop(deadline, APP_LINK_IO_DEADLINE, observer)
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "linear admission state machine keeps deadline and handle transitions auditable"
+    )]
     fn accept_loop(
         &self,
         deadline: Instant,
@@ -699,7 +714,8 @@ impl WindowsNamedPipeBootstrapListener {
                 drop(lock_or_recover(&self.server).take());
                 return Ok(WindowsNamedPipeBootstrapAdmission::Cancelled);
             }
-            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            let handshake_started = Instant::now();
+            let Some(remaining) = deadline.checked_duration_since(handshake_started) else {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
                 return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
@@ -710,7 +726,7 @@ impl WindowsNamedPipeBootstrapListener {
                 return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
             }
             let peer_timeout = remaining.min(handshake_deadline);
-            let Some(peer_deadline) = Instant::now().checked_add(peer_timeout) else {
+            let Some(peer_deadline) = handshake_started.checked_add(peer_timeout) else {
                 server.close_terminal()?;
                 drop(lock_or_recover(&self.server).take());
                 return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
@@ -726,6 +742,23 @@ impl WindowsNamedPipeBootstrapListener {
                 peer_deadline,
             ) {
                 Ok(true) => {
+                    #[cfg(test)]
+                    if let Some(gate) = lock_or_recover(&self.before_consume).as_ref() {
+                        let _ = gate.entered.send(());
+                        let _ = gate.release.recv();
+                    }
+                    if self.stopping.load(Ordering::Acquire) {
+                        drop(stream);
+                        server.close_terminal()?;
+                        drop(lock_or_recover(&self.server).take());
+                        return Ok(WindowsNamedPipeBootstrapAdmission::Cancelled);
+                    }
+                    if Instant::now() >= deadline {
+                        drop(stream);
+                        server.close_terminal()?;
+                        drop(lock_or_recover(&self.server).take());
+                        return Ok(WindowsNamedPipeBootstrapAdmission::DeadlineElapsed);
+                    }
                     stream.0.set_absolute_deadline(None);
                     server.consume();
                     drop(lock_or_recover(&self.server).take());
@@ -781,6 +814,11 @@ impl WindowsNamedPipeBootstrapListener {
         lock_or_recover(&self.server)
             .as_ref()
             .is_some_and(WindowsNamedPipeServer::is_accept_pending)
+    }
+
+    #[cfg(test)]
+    fn install_before_consume_gate(&self, gate: TestConsumeGate) {
+        *lock_or_recover(&self.before_consume) = Some(gate);
     }
 }
 
@@ -888,8 +926,9 @@ mod named_pipe_tests {
     use crate::{ChannelId, CorrelationId, FrameHeader, FrameKind, MAX_FRAME_LEN};
 
     use super::{
-        BootstrapRejection, BootstrapRejectionObserver, WindowsNamedPipeBootstrapAdmission,
-        WindowsNamedPipeBootstrapListener, WindowsNamedPipeBootstrapStream, lock_or_recover,
+        BootstrapRejection, BootstrapRejectionObserver, TestConsumeGate,
+        WindowsNamedPipeBootstrapAdmission, WindowsNamedPipeBootstrapListener,
+        WindowsNamedPipeBootstrapStream, lock_or_recover,
     };
 
     #[derive(Clone)]
@@ -1509,6 +1548,45 @@ socket.end();
     }
 
     #[test]
+    fn generation_expiry_at_final_auth_boundary_is_not_consumed() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+        let (release_tx, release_rx) = mpsc::channel();
+        listener.install_before_consume_gate(TestConsumeGate {
+            entered: entered_tx,
+            release: release_rx,
+        });
+        let deadline = Instant::now() + Duration::from_millis(100);
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(deadline, &super::NoopRejectionObserver)
+        });
+        let mut role = client(&endpoint).expect("open role");
+        role.set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("role deadlines");
+        handshake_client(&mut role, &token).expect("HELLO reaches final boundary");
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("final authentication boundary");
+        while Instant::now() < deadline {
+            thread::yield_now();
+        }
+        release_tx.send(()).expect("release final boundary");
+        let outcome = worker.join().expect("join admission").expect("admission");
+        assert!(matches!(
+            outcome,
+            WindowsNamedPipeBootstrapAdmission::DeadlineElapsed
+        ));
+        let stale = WindowsNamedPipeServer::connect_client(&endpoint)
+            .expect_err("expired final authentication must not consume a session");
+        assert_eq!(stale.raw_os_error(), Some(2));
+        drop(role);
+    }
+
+    #[test]
     fn every_pre_auth_failure_uses_shared_redacted_taxonomy_and_reaccepts() {
         run_rejection_then_authenticate(None, BootstrapRejection::Io);
 
@@ -1783,6 +1861,69 @@ socket.end();
             .shutdown_after_drain(Instant::now() + Duration::from_millis(50))
             .expect_err("non-reading peer must not wedge orderly shutdown");
         assert_eq!(error.raw_os_error(), Some(121));
+        drop(role);
+    }
+
+    #[test]
+    fn concurrent_drain_is_rejected_and_abort_breaks_active_flush() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(
+                Instant::now() + Duration::from_secs(2),
+                &super::NoopRejectionObserver,
+            )
+        });
+        let mut role = client(&endpoint).expect("open role");
+        role.set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("role deadlines");
+        handshake_client(&mut role, &token).expect("authenticate");
+        let outcome = worker.join().expect("join admission").expect("admission");
+        let WindowsNamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+            panic!("expected authenticated named-pipe session")
+        };
+        server_stream
+            .write_all(b"reply")
+            .expect("write orderly reply");
+        let first_drain = server_stream.try_clone().expect("clone first drain");
+        let second_drain = server_stream.try_clone().expect("clone second drain");
+        let (drain_tx, drain_rx) = mpsc::channel();
+        let drain = thread::spawn(move || {
+            let _ = drain_tx
+                .send(first_drain.shutdown_after_drain(Instant::now() + Duration::from_secs(5)));
+        });
+        let pending_deadline = Instant::now() + Duration::from_secs(1);
+        while !server_stream.0.is_drain_pending() {
+            assert!(
+                Instant::now() < pending_deadline,
+                "first drain never entered FlushFileBuffers"
+            );
+            thread::yield_now();
+        }
+        let second_error = second_drain
+            .shutdown_after_drain(Instant::now() + Duration::from_millis(50))
+            .expect_err("a concurrent drain must not queue behind the first");
+        assert_eq!(second_error.kind(), std::io::ErrorKind::WouldBlock);
+
+        let abort_started = Instant::now();
+        server_stream
+            .shutdown_app_link()
+            .expect("abort active orderly drain");
+        assert!(
+            abort_started.elapsed() < Duration::from_secs(1),
+            "abortive shutdown blocked behind orderly drain"
+        );
+        assert!(
+            drain_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("active drain completion after abort")
+                .is_err(),
+            "abortive shutdown must not report the interrupted drain as orderly"
+        );
+        drain.join().expect("join aborted drain");
         drop(role);
     }
 

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -2,11 +2,14 @@
 //!
 //! This cold-path primitive owns a platform listener, a fresh `HELLO`
 //! possession token, and cleanup. Unix uses an owner-only socket directory.
-//! Windows uses the explicitly unprivileged loopback interim allowed by
-//! KEL-96-D10 until KEL-101's named-pipe/DACL contract is approved and lands.
-//! Both deliberately accept another client after an invalid handshake so an
+//! The shipping Windows constructor retains the explicitly unprivileged
+//! loopback interim until KEL-101/T3 migrates consumers; KEL-101/T2 adds the
+//! opt-in owner-DACL named-pipe bootstrap beside it. Both deliberately accept
+//! another client after an invalid handshake so an
 //! untrusted connector cannot consume the legitimate role's bootstrap.
 
+#[cfg(windows)]
+use core::fmt::Write as _;
 #[cfg(unix)]
 use std::fs;
 use std::io;
@@ -35,6 +38,12 @@ use crate::{APP_LINK_IO_DEADLINE, APP_LINK_READER_POLL};
 pub use crate::admission::{BootstrapRejection, BootstrapRejectionObserver};
 use crate::link::{AppLinkDeadlines, handshake_server_interruptible_until};
 use crate::token::{SessionToken, format_app_link};
+#[cfg(all(windows, test))]
+use crate::windows_named_pipe::PipeSecurityFacts;
+#[cfg(windows)]
+use crate::windows_named_pipe::{
+    WaitOutcome, WindowsNamedPipeCanceller, WindowsNamedPipeServer, WindowsNamedPipeStream,
+};
 
 const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 #[cfg(unix)]
@@ -522,6 +531,778 @@ fn park_until_next_accept(deadline: Option<Instant>) {
 impl Drop for BootstrapListener {
     fn drop(&mut self) {
         let _ = self.shutdown();
+    }
+}
+
+/// Opt-in Windows owner-DACL named-pipe bootstrap added by KEL-101/T2.
+///
+/// [`BootstrapListener::bind`] deliberately remains the live loopback-TCP
+/// constructor until T3 migrates all consumers atomically. This type owns the
+/// shared named-pipe transport and reuses the same safe HELLO and rejection
+/// state machine without making a product-LIVE claim.
+#[cfg(windows)]
+#[derive(Debug)]
+pub struct WindowsNamedPipeBootstrapListener {
+    server: Mutex<Option<WindowsNamedPipeServer>>,
+    admission: Mutex<()>,
+    endpoint: String,
+    token: SessionToken,
+    stopping: Arc<AtomicBool>,
+}
+
+/// Connected authenticated stream from [`WindowsNamedPipeBootstrapListener`].
+#[cfg(windows)]
+#[derive(Debug)]
+pub struct WindowsNamedPipeBootstrapStream(WindowsNamedPipeStream);
+
+/// Cancellation handle for a pending named-pipe accept or HELLO.
+#[cfg(windows)]
+#[derive(Debug, Clone)]
+pub struct WindowsNamedPipeBootstrapCancellation {
+    server: WindowsNamedPipeCanceller,
+    stopping: Arc<AtomicBool>,
+}
+
+#[cfg(windows)]
+impl WindowsNamedPipeBootstrapListener {
+    /// Creates one first-instance, remote-rejecting named pipe protected by an
+    /// explicit current-TokenUser DACL and mints an independent HELLO token.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if randomness, SID/DACL construction, pipe
+    /// creation, handle validation, or descriptor readback fails.
+    pub fn bind() -> io::Result<Self> {
+        let token = SessionToken::random()?;
+        let mut nonce = [0_u8; 32];
+        getrandom::fill(&mut nonce).map_err(io::Error::other)?;
+        let mut endpoint = String::from(r"\\.\pipe\keld-");
+        for byte in nonce {
+            write!(&mut endpoint, "{byte:02x}").map_err(io::Error::other)?;
+        }
+        let server = WindowsNamedPipeServer::bind(&endpoint)?;
+        Ok(Self {
+            server: Mutex::new(Some(server)),
+            admission: Mutex::new(()),
+            endpoint,
+            token,
+            stopping: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    /// Canonical endpoint-plus-token value for this bootstrap generation.
+    #[must_use]
+    pub fn app_link(&self) -> String {
+        format_app_link(&self.endpoint, &self.token)
+    }
+
+    /// Pipe endpoint without the HELLO token.
+    #[must_use]
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Returns a handle that cancels pending accept or handshake I/O.
+    #[must_use]
+    pub fn cancellation(&self) -> WindowsNamedPipeBootstrapCancellation {
+        WindowsNamedPipeBootstrapCancellation {
+            server: lock_or_recover(&self.server).as_ref().map_or_else(
+                WindowsNamedPipeCanceller::empty,
+                WindowsNamedPipeServer::canceller,
+            ),
+            stopping: Arc::clone(&self.stopping),
+        }
+    }
+
+    /// Waits until a client authenticates, cancellation wins, or the absolute
+    /// generation deadline elapses.
+    ///
+    /// # Errors
+    ///
+    /// Returns only host-side pipe, deadline-configuration, or cleanup errors.
+    /// Peer failures are classified once through `observer`, disconnected,
+    /// and followed by another accept on the same pipe instance.
+    pub fn accept_authenticated_until(
+        &self,
+        deadline: Instant,
+        observer: &dyn BootstrapRejectionObserver,
+    ) -> io::Result<NamedPipeBootstrapAdmission> {
+        let _admission = lock_or_recover(&self.admission);
+        self.accept_loop(deadline, APP_LINK_IO_DEADLINE, observer)
+    }
+
+    fn accept_loop(
+        &self,
+        deadline: Instant,
+        handshake_deadline: Duration,
+        observer: &dyn BootstrapRejectionObserver,
+    ) -> io::Result<NamedPipeBootstrapAdmission> {
+        loop {
+            let server = lock_or_recover(&self.server)
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "named-pipe bootstrap already consumed",
+                    )
+                })?;
+            if self.stopping.load(Ordering::Acquire) {
+                server.close_terminal()?;
+                drop(lock_or_recover(&self.server).take());
+                return Ok(NamedPipeBootstrapAdmission::Cancelled);
+            }
+            match server.accept_until(Some(deadline))? {
+                WaitOutcome::Cancelled => {
+                    drop(lock_or_recover(&self.server).take());
+                    return Ok(NamedPipeBootstrapAdmission::Cancelled);
+                }
+                WaitOutcome::DeadlineElapsed => {
+                    drop(lock_or_recover(&self.server).take());
+                    return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+                }
+                WaitOutcome::PeerClosed => {
+                    observer.rejected(BootstrapRejection::Io);
+                    server.disconnect_for_retry()?;
+                    continue;
+                }
+                WaitOutcome::Ready => {}
+            }
+            if self.stopping.load(Ordering::Acquire) {
+                server.close_terminal()?;
+                drop(lock_or_recover(&self.server).take());
+                return Ok(NamedPipeBootstrapAdmission::Cancelled);
+            }
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                server.close_terminal()?;
+                drop(lock_or_recover(&self.server).take());
+                return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+            };
+            if remaining.is_zero() {
+                server.close_terminal()?;
+                drop(lock_or_recover(&self.server).take());
+                return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+            }
+            let peer_timeout = remaining.min(handshake_deadline);
+            let Some(peer_deadline) = Instant::now().checked_add(peer_timeout) else {
+                server.close_terminal()?;
+                drop(lock_or_recover(&self.server).take());
+                return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+            };
+            let mut stream = WindowsNamedPipeBootstrapStream(server.stream());
+            stream.set_app_link_read_deadline(Some(APP_LINK_READER_POLL.min(peer_timeout)))?;
+            stream.set_app_link_write_deadline(Some(peer_timeout))?;
+            stream.0.set_absolute_deadline(Some(peer_deadline));
+            match handshake_server_interruptible_until(
+                &mut stream,
+                &self.token,
+                self.stopping.as_ref(),
+                peer_deadline,
+            ) {
+                Ok(true) => {
+                    stream.0.set_absolute_deadline(None);
+                    server.consume();
+                    drop(lock_or_recover(&self.server).take());
+                    return Ok(NamedPipeBootstrapAdmission::Authenticated(stream));
+                }
+                Ok(false) => {
+                    drop(stream);
+                    server.close_terminal()?;
+                    drop(lock_or_recover(&self.server).take());
+                    return Ok(NamedPipeBootstrapAdmission::Cancelled);
+                }
+                Err(_) if self.stopping.load(Ordering::Acquire) => {
+                    drop(stream);
+                    server.close_terminal()?;
+                    drop(lock_or_recover(&self.server).take());
+                    return Ok(NamedPipeBootstrapAdmission::Cancelled);
+                }
+                Err(IpcError::Timeout) if Instant::now() >= deadline => {
+                    drop(stream);
+                    server.close_terminal()?;
+                    drop(lock_or_recover(&self.server).take());
+                    return Ok(NamedPipeBootstrapAdmission::DeadlineElapsed);
+                }
+                Err(error) => {
+                    observer.rejected(BootstrapRejection::classify(&error));
+                    drop(stream);
+                    server.disconnect_for_retry()?;
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn security_facts(&self) -> io::Result<PipeSecurityFacts> {
+        lock_or_recover(&self.server)
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "bootstrap consumed"))?
+            .security_facts()
+    }
+
+    #[cfg(test)]
+    fn is_connected(&self) -> bool {
+        lock_or_recover(&self.server)
+            .as_ref()
+            .is_some_and(WindowsNamedPipeServer::is_connected)
+    }
+
+    #[cfg(test)]
+    fn is_accept_pending(&self) -> bool {
+        lock_or_recover(&self.server)
+            .as_ref()
+            .is_some_and(WindowsNamedPipeServer::is_accept_pending)
+    }
+}
+
+/// Result of one bounded named-pipe bootstrap admission attempt.
+#[cfg(windows)]
+#[derive(Debug)]
+pub enum NamedPipeBootstrapAdmission {
+    /// A peer proved possession of the generation token.
+    Authenticated(WindowsNamedPipeBootstrapStream),
+    /// Host cancellation won.
+    Cancelled,
+    /// The absolute generation deadline elapsed.
+    DeadlineElapsed,
+}
+
+#[cfg(windows)]
+impl WindowsNamedPipeBootstrapCancellation {
+    /// Cancels pending accept or stream I/O and wakes the admission worker.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if Windows cannot signal cancellation.
+    pub fn cancel(&self) -> io::Result<()> {
+        self.stopping.store(true, Ordering::Release);
+        self.server.cancel()
+    }
+}
+
+#[cfg(windows)]
+impl io::Read for WindowsNamedPipeBootstrapStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+#[cfg(windows)]
+impl io::Write for WindowsNamedPipeBootstrapStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+#[cfg(windows)]
+impl AppLinkDeadlines for WindowsNamedPipeBootstrapStream {
+    fn set_app_link_read_deadline(&self, timeout: Option<Duration>) -> io::Result<()> {
+        self.0.set_read_timeout(timeout)
+    }
+
+    fn set_app_link_write_deadline(&self, timeout: Option<Duration>) -> io::Result<()> {
+        self.0.set_write_timeout(timeout)
+    }
+
+    fn app_link_read_deadline(&self) -> io::Result<Option<Duration>> {
+        Ok(self.0.read_timeout())
+    }
+
+    fn app_link_write_deadline(&self) -> io::Result<Option<Duration>> {
+        Ok(self.0.write_timeout())
+    }
+
+    fn shutdown_app_link(&self) -> io::Result<()> {
+        self.0.shutdown()
+    }
+}
+
+#[cfg(windows)]
+impl WindowsNamedPipeBootstrapStream {
+    /// Duplicates the Rust stream view while retaining the same owned pipe
+    /// handle. Read and write deadline settings are copied, then independent.
+    ///
+    /// # Errors
+    ///
+    /// Reserved for parity with other platform streams.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self(self.0.try_clone()))
+    }
+}
+
+#[cfg(all(test, windows))]
+mod named_pipe_tests {
+    use std::io::{Read as _, Write as _};
+    use std::sync::{Arc, Mutex, mpsc};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use crate::link::{AppLinkDeadlines, handshake_client};
+    use crate::token::{SessionToken, parse_app_link};
+    use crate::windows_named_pipe::WindowsNamedPipeServer;
+    use crate::{ChannelId, CorrelationId, FrameHeader, FrameKind, MAX_FRAME_LEN};
+
+    use super::{
+        BootstrapRejection, BootstrapRejectionObserver, NamedPipeBootstrapAdmission,
+        WindowsNamedPipeBootstrapListener, WindowsNamedPipeBootstrapStream, lock_or_recover,
+    };
+
+    #[derive(Clone)]
+    struct RecordingObserver {
+        seen: Arc<Mutex<Vec<BootstrapRejection>>>,
+        notify: Option<mpsc::Sender<BootstrapRejection>>,
+    }
+
+    impl BootstrapRejectionObserver for RecordingObserver {
+        fn rejected(&self, rejection: BootstrapRejection) {
+            lock_or_recover(&self.seen).push(rejection);
+            if let Some(notify) = &self.notify {
+                let _ = notify.send(rejection);
+            }
+        }
+    }
+
+    fn client(endpoint: &str) -> std::io::Result<WindowsNamedPipeBootstrapStream> {
+        WindowsNamedPipeServer::connect_client_until(
+            endpoint,
+            Instant::now() + Duration::from_secs(2),
+        )
+        .map(WindowsNamedPipeBootstrapStream)
+    }
+
+    fn frame(header: FrameHeader, payload: &[u8]) -> Vec<u8> {
+        let mut bytes = header.encode().to_vec();
+        bytes.extend_from_slice(payload);
+        bytes
+    }
+
+    #[expect(
+        clippy::expect_used,
+        reason = "test helper reports the exact failed boundary at each assertion"
+    )]
+    fn run_rejection_then_authenticate(hostile_bytes: Option<&[u8]>, expected: BootstrapRejection) {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (notify_tx, notify_rx) = mpsc::channel();
+        let observer = RecordingObserver {
+            seen: Arc::clone(&seen),
+            notify: Some(notify_tx),
+        };
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener
+                .accept_authenticated_until(Instant::now() + Duration::from_secs(3), &observer)
+        });
+
+        let mut hostile = client(&endpoint).expect("open hostile client");
+        hostile
+            .set_app_link_deadlines(Some(Duration::from_millis(250)))
+            .expect("hostile deadlines");
+        if let Some(bytes) = hostile_bytes {
+            hostile.write_all(bytes).expect("write hostile input");
+        } else {
+            drop(hostile);
+            assert_eq!(
+                notify_rx
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("EOF record"),
+                expected
+            );
+            let mut legitimate = client(&endpoint).expect("open legitimate client");
+            legitimate
+                .set_app_link_deadlines(Some(Duration::from_millis(500)))
+                .expect("legitimate deadlines");
+            handshake_client(&mut legitimate, &token).expect("legitimate HELLO");
+            let outcome = worker.join().expect("join").expect("admission");
+            assert!(matches!(
+                outcome,
+                NamedPipeBootstrapAdmission::Authenticated(_)
+            ));
+            assert_eq!(*lock_or_recover(&seen), vec![expected]);
+            return;
+        }
+        assert_eq!(
+            notify_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("rejection record"),
+            expected
+        );
+        let mut reply = [0_u8; 1];
+        assert!(
+            hostile.read(&mut reply).is_err(),
+            "pre-auth rejection must close without a host frame"
+        );
+        drop(hostile);
+
+        let mut legitimate = client(&endpoint).expect("open legitimate client");
+        legitimate
+            .set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("legitimate deadlines");
+        handshake_client(&mut legitimate, &token).expect("legitimate HELLO");
+        let outcome = worker.join().expect("join").expect("admission");
+        assert!(matches!(
+            outcome,
+            NamedPipeBootstrapAdmission::Authenticated(_)
+        ));
+        assert_eq!(*lock_or_recover(&seen), vec![expected]);
+    }
+
+    #[test]
+    fn pipe_name_dacl_and_non_inheritance_match_exact_contract() {
+        let listener = WindowsNamedPipeBootstrapListener::bind().expect("bind named pipe");
+        let link = listener.app_link();
+        let (endpoint, _) = parse_app_link(&link).expect("parse app link");
+        let suffix = endpoint
+            .strip_prefix(r"\\.\pipe\keld-")
+            .expect("canonical named-pipe prefix");
+        assert_eq!(suffix.len(), 64);
+        assert!(
+            suffix
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+            "pipe nonce must be lowercase hex"
+        );
+        let facts = listener.security_facts().expect("security readback");
+        assert!(facts.protected_dacl);
+        assert_eq!(facts.ace_count, 1);
+        assert!(facts.one_ace_is_current_user);
+        assert_eq!(facts.one_ace_type, 0);
+        assert_eq!(facts.one_ace_flags, 0);
+        assert_eq!(facts.one_ace_mask, 0x0012_019B);
+        assert_eq!(facts.one_ace_mask & 0x4, 0);
+        assert_eq!(facts.handle_flags & 1, 0);
+
+        let collision = WindowsNamedPipeServer::bind(endpoint)
+            .expect_err("FILE_FLAG_FIRST_PIPE_INSTANCE must reject a second server");
+        assert_eq!(collision.raw_os_error(), Some(5));
+    }
+
+    #[test]
+    fn pending_accept_cancellation_completes_and_joins() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let cancellation = listener.cancellation();
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(
+                Instant::now() + Duration::from_secs(30),
+                &super::NoopRejectionObserver,
+            )
+        });
+        let pending_deadline = Instant::now() + Duration::from_secs(1);
+        while !listener.is_accept_pending() {
+            assert!(
+                Instant::now() < pending_deadline,
+                "server never entered overlapped pending accept"
+            );
+            thread::yield_now();
+        }
+        cancellation.cancel().expect("cancel pending accept");
+        let outcome = worker
+            .join()
+            .expect("join accept worker")
+            .expect("admission");
+        assert!(matches!(outcome, NamedPipeBootstrapAdmission::Cancelled));
+    }
+
+    #[test]
+    fn active_partial_hello_cancellation_completes_and_closes_locator() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let endpoint = listener.endpoint().to_owned();
+        let cancellation = listener.cancellation();
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(
+                Instant::now() + Duration::from_secs(30),
+                &super::NoopRejectionObserver,
+            )
+        });
+        let mut partial = client(&endpoint).expect("open partial client");
+        partial.write_all(b"K").expect("start partial HELLO");
+        let connected_deadline = Instant::now() + Duration::from_secs(1);
+        while !listener.is_connected() {
+            assert!(
+                Instant::now() < connected_deadline,
+                "server never entered the connected handshake state"
+            );
+            thread::yield_now();
+        }
+        cancellation.cancel().expect("cancel active HELLO");
+        let outcome = worker.join().expect("join").expect("admission");
+        assert!(matches!(outcome, NamedPipeBootstrapAdmission::Cancelled));
+        drop(partial);
+        let stale = WindowsNamedPipeServer::connect_client(&endpoint)
+            .expect_err("cancelled generation must close its pipe handle");
+        assert_eq!(stale.raw_os_error(), Some(2));
+    }
+
+    #[test]
+    fn foreign_hello_is_redacted_then_same_instance_authenticates() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let observer = RecordingObserver {
+            seen: Arc::clone(&seen),
+            notify: None,
+        };
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener
+                .accept_authenticated_until(Instant::now() + Duration::from_secs(3), &observer)
+        });
+
+        let mut foreign_bytes = *token.as_bytes();
+        foreign_bytes[0] ^= 1;
+        let foreign = SessionToken::from_bytes(foreign_bytes);
+        let mut hostile = client(&endpoint).expect("open hostile client");
+        hostile
+            .set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("hostile deadlines");
+        let error = handshake_client(&mut hostile, &foreign).expect_err("foreign HELLO denied");
+        assert!(matches!(
+            error,
+            crate::IpcError::Io(_) | crate::IpcError::Timeout
+        ));
+        drop(hostile);
+
+        let mut legitimate = client(&endpoint).expect("open legitimate client");
+        legitimate
+            .set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("legitimate deadlines");
+        handshake_client(&mut legitimate, &token).expect("matching HELLO accepted");
+        let outcome = worker.join().expect("join").expect("admission");
+        assert!(matches!(
+            outcome,
+            NamedPipeBootstrapAdmission::Authenticated(_)
+        ));
+        let seen = lock_or_recover(&seen);
+        assert_eq!(*seen, vec![BootstrapRejection::HelloAuth]);
+        assert_eq!(seen[0].code(), "KELD-IPC-007");
+    }
+
+    #[test]
+    fn partial_hello_timeout_reaccepts_same_pipe_then_authenticates() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (notify_tx, notify_rx) = mpsc::channel();
+        let observer = RecordingObserver {
+            seen: Arc::clone(&seen),
+            notify: Some(notify_tx),
+        };
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_loop(
+                Instant::now() + Duration::from_secs(3),
+                Duration::from_millis(100),
+                &observer,
+            )
+        });
+
+        let mut silent_partial = client(&endpoint).expect("open partial client");
+        silent_partial.write_all(b"K").expect("start partial frame");
+        assert_eq!(
+            notify_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("timeout rejection"),
+            BootstrapRejection::Timeout
+        );
+        drop(silent_partial);
+
+        let mut legitimate = client(&endpoint).expect("open legitimate client");
+        legitimate
+            .set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("legitimate deadlines");
+        handshake_client(&mut legitimate, &token).expect("same pipe reaccepted");
+        let outcome = worker.join().expect("join").expect("admission");
+        assert!(matches!(
+            outcome,
+            NamedPipeBootstrapAdmission::Authenticated(_)
+        ));
+        assert_eq!(*lock_or_recover(&seen), vec![BootstrapRejection::Timeout]);
+    }
+
+    #[test]
+    fn generation_deadline_is_terminal_without_a_client() {
+        let listener = WindowsNamedPipeBootstrapListener::bind().expect("bind");
+        let outcome = listener
+            .accept_authenticated_until(
+                Instant::now() + Duration::from_millis(30),
+                &super::NoopRejectionObserver,
+            )
+            .expect("deadline admission");
+        assert!(matches!(
+            outcome,
+            NamedPipeBootstrapAdmission::DeadlineElapsed
+        ));
+        let error = WindowsNamedPipeServer::connect_client(listener.endpoint())
+            .expect_err("terminal generation must not accept a late connector");
+        assert!(matches!(error.raw_os_error(), Some(2 | 231)));
+    }
+
+    #[test]
+    fn every_pre_auth_failure_uses_shared_redacted_taxonomy_and_reaccepts() {
+        run_rejection_then_authenticate(None, BootstrapRejection::Io);
+
+        let bad_header = [0_u8; 16];
+        run_rejection_then_authenticate(Some(&bad_header), BootstrapRejection::Header);
+
+        let oversized = frame(
+            FrameHeader {
+                kind: FrameKind::Hello,
+                flags: 0,
+                channel: ChannelId(0),
+                corr: CorrelationId(0),
+                len: u32::try_from(MAX_FRAME_LEN + 1).expect("test length fits u32"),
+            },
+            &[],
+        );
+        run_rejection_then_authenticate(Some(&oversized), BootstrapRejection::PayloadTooLarge);
+
+        let non_hello = frame(
+            FrameHeader {
+                kind: FrameKind::Call,
+                flags: 0,
+                channel: ChannelId(0),
+                corr: CorrelationId(0),
+                len: 0,
+            },
+            &[],
+        );
+        run_rejection_then_authenticate(Some(&non_hello), BootstrapRejection::Protocol);
+
+        let empty_hello = frame(
+            FrameHeader {
+                kind: FrameKind::Hello,
+                flags: 0,
+                channel: ChannelId(0),
+                corr: CorrelationId(0),
+                len: 0,
+            },
+            &[],
+        );
+        run_rejection_then_authenticate(Some(&empty_hello), BootstrapRejection::HelloAuth);
+
+        let short_hello = frame(
+            FrameHeader {
+                kind: FrameKind::Hello,
+                flags: 0,
+                channel: ChannelId(0),
+                corr: CorrelationId(0),
+                len: 31,
+            },
+            &[0xA5; 31],
+        );
+        run_rejection_then_authenticate(Some(&short_hello), BootstrapRejection::HelloAuth);
+
+        let reserved_hello = frame(
+            FrameHeader {
+                kind: FrameKind::Hello,
+                flags: 0,
+                channel: ChannelId(1),
+                corr: CorrelationId(0),
+                len: 32,
+            },
+            &[0xA5; 32],
+        );
+        run_rejection_then_authenticate(Some(&reserved_hello), BootstrapRejection::Protocol);
+    }
+
+    #[test]
+    fn authenticated_session_drop_removes_locator_and_successor_is_fresh() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let first_link = listener.app_link();
+        let stale_cancellation = listener.cancellation();
+        let (endpoint, token) = parse_app_link(&first_link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(
+                Instant::now() + Duration::from_secs(2),
+                &super::NoopRejectionObserver,
+            )
+        });
+        let mut role = client(&endpoint).expect("open role");
+        role.set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("deadlines");
+        handshake_client(&mut role, &token).expect("authenticate");
+        let outcome = worker.join().expect("join").expect("admission");
+        let NamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+            panic!("expected authenticated named-pipe session")
+        };
+        stale_cancellation
+            .cancel()
+            .expect("consumed bootstrap cancellation is inert");
+        role.write_all(b"X").expect("session write after bootstrap");
+        let mut received = [0_u8; 1];
+        server_stream
+            .read_exact(&mut received)
+            .expect("session remains live after stale cancellation");
+        assert_eq!(received, *b"X");
+        drop(role);
+        drop(server_stream);
+        let stale = WindowsNamedPipeServer::connect_client(&endpoint)
+            .expect_err("dropping the session must remove its locator");
+        assert_eq!(stale.raw_os_error(), Some(2));
+
+        let successor = WindowsNamedPipeBootstrapListener::bind().expect("bind successor");
+        assert_ne!(successor.app_link(), first_link);
+        assert_ne!(successor.endpoint(), endpoint);
+    }
+
+    #[test]
+    fn overlapped_write_to_non_reading_peer_hits_configured_deadline() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(
+                Instant::now() + Duration::from_secs(2),
+                &super::NoopRejectionObserver,
+            )
+        });
+        let mut role = client(&endpoint).expect("open role");
+        role.set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("role deadlines");
+        handshake_client(&mut role, &token).expect("authenticate");
+        let outcome = worker.join().expect("join").expect("admission");
+        let NamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+            panic!("expected authenticated named-pipe session")
+        };
+        server_stream
+            .set_app_link_write_deadline(Some(Duration::from_millis(30)))
+            .expect("short write deadline");
+        let payload = vec![0_u8; 1024 * 1024];
+        let error = server_stream
+            .write_all(&payload)
+            .expect_err("non-reading peer must not wedge an overlapped write");
+        assert_eq!(error.raw_os_error(), Some(121));
+    }
+
+    #[test]
+    fn cancellation_handle_does_not_keep_dropped_listener_alive() {
+        let listener = WindowsNamedPipeBootstrapListener::bind().expect("bind");
+        let endpoint = listener.endpoint().to_owned();
+        let cancellation = listener.cancellation();
+        drop(listener);
+        cancellation
+            .cancel()
+            .expect("cancel after owner drop is inert");
+        let stale = WindowsNamedPipeServer::connect_client(&endpoint)
+            .expect_err("non-owning cancellation view must not preserve pipe handle");
+        assert_eq!(stale.raw_os_error(), Some(2));
     }
 }
 

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -887,20 +887,6 @@ impl WindowsNamedPipeBootstrapStream {
     pub fn try_clone(&self) -> io::Result<Self> {
         self.0.try_clone().map(Self)
     }
-
-    /// Waits until the peer has consumed every written byte, then disconnects.
-    ///
-    /// This is the orderly reply-before-close path. [`AppLinkDeadlines::shutdown_app_link`]
-    /// remains abortive and may discard unread pipe bytes.
-    ///
-    /// # Errors
-    ///
-    /// Returns a timeout if `deadline` wins. Timeout starts an abortive
-    /// disconnect, requests cancellation of the synchronous Windows flush,
-    /// and observes the drain worker's completion before returning.
-    pub fn shutdown_after_drain(&self, deadline: Instant) -> io::Result<()> {
-        self.0.shutdown_after_drain(deadline)
-    }
 }
 
 #[cfg(all(test, windows))]
@@ -1783,7 +1769,7 @@ socket.end();
     }
 
     #[test]
-    fn orderly_shutdown_waits_for_peer_read_then_preserves_bytes() {
+    fn stream_shutdown_disconnects_peer_even_when_cancellation_reports_error() {
         let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
         let link = listener.app_link();
         let (endpoint, token) = parse_app_link(&link).expect("parse link");
@@ -1800,145 +1786,20 @@ socket.end();
             .expect("role deadlines");
         handshake_client(&mut role, &token).expect("authenticate");
         let outcome = worker.join().expect("join admission").expect("admission");
-        let WindowsNamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
+        let WindowsNamedPipeBootstrapAdmission::Authenticated(server_stream) = outcome else {
             panic!("expected authenticated named-pipe session")
         };
-        server_stream
-            .write_all(b"reply")
-            .expect("write orderly reply");
-        let drain_stream = server_stream.try_clone().expect("clone drain stream");
-        let (drain_tx, drain_rx) = mpsc::channel();
-        let drain = thread::spawn(move || {
-            let _ = drain_tx
-                .send(drain_stream.shutdown_after_drain(Instant::now() + Duration::from_secs(2)));
-        });
-        let pending_deadline = Instant::now() + Duration::from_secs(1);
-        while !server_stream.0.is_drain_pending() {
-            assert!(
-                Instant::now() < pending_deadline,
-                "orderly drain never entered FlushFileBuffers"
-            );
-            thread::yield_now();
-        }
-        assert!(
-            matches!(drain_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
-            "drain must not complete before the peer consumes the reply"
-        );
-        let mut reply = [0_u8; 5];
-        role.read_exact(&mut reply).expect("read orderly reply");
-        assert_eq!(&reply, b"reply");
-        drain_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("drain completion")
-            .expect("orderly drain");
-        drain.join().expect("join orderly drain");
-    }
-
-    #[test]
-    fn orderly_shutdown_times_out_and_joins_for_non_reading_peer() {
-        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
-        let link = listener.app_link();
-        let (endpoint, token) = parse_app_link(&link).expect("parse link");
-        let endpoint = endpoint.to_owned();
-        let worker_listener = Arc::clone(&listener);
-        let worker = thread::spawn(move || {
-            worker_listener.accept_authenticated_until(
-                Instant::now() + Duration::from_secs(2),
-                &super::NoopRejectionObserver,
-            )
-        });
-        let mut role = client(&endpoint).expect("open role");
-        role.set_app_link_deadlines(Some(Duration::from_millis(500)))
-            .expect("role deadlines");
-        handshake_client(&mut role, &token).expect("authenticate");
-        let outcome = worker.join().expect("join admission").expect("admission");
-        let WindowsNamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
-            panic!("expected authenticated named-pipe session")
-        };
-        server_stream
-            .write_all(b"reply")
-            .expect("write orderly reply");
-        let error = server_stream
-            .shutdown_after_drain(Instant::now() + Duration::from_millis(50))
-            .expect_err("non-reading peer must not wedge orderly shutdown");
-        assert_eq!(error.raw_os_error(), Some(121));
-        assert!(
-            !server_stream.0.is_drain_pending(),
-            "timeout must observe drain-worker completion before returning"
-        );
-        if let Err(followup) =
-            server_stream.shutdown_after_drain(Instant::now() + Duration::from_millis(50))
-        {
-            assert_ne!(
-                followup.kind(),
-                std::io::ErrorKind::WouldBlock,
-                "timeout must release the single-drain claim"
-            );
-        }
-        drop(role);
-    }
-
-    #[test]
-    fn concurrent_drain_is_rejected_and_abort_breaks_active_flush() {
-        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
-        let link = listener.app_link();
-        let (endpoint, token) = parse_app_link(&link).expect("parse link");
-        let endpoint = endpoint.to_owned();
-        let worker_listener = Arc::clone(&listener);
-        let worker = thread::spawn(move || {
-            worker_listener.accept_authenticated_until(
-                Instant::now() + Duration::from_secs(2),
-                &super::NoopRejectionObserver,
-            )
-        });
-        let mut role = client(&endpoint).expect("open role");
-        role.set_app_link_deadlines(Some(Duration::from_millis(500)))
-            .expect("role deadlines");
-        handshake_client(&mut role, &token).expect("authenticate");
-        let outcome = worker.join().expect("join admission").expect("admission");
-        let WindowsNamedPipeBootstrapAdmission::Authenticated(mut server_stream) = outcome else {
-            panic!("expected authenticated named-pipe session")
-        };
-        server_stream
-            .write_all(b"reply")
-            .expect("write orderly reply");
-        let first_drain = server_stream.try_clone().expect("clone first drain");
-        let second_drain = server_stream.try_clone().expect("clone second drain");
-        let (drain_tx, drain_rx) = mpsc::channel();
-        let drain = thread::spawn(move || {
-            let _ = drain_tx
-                .send(first_drain.shutdown_after_drain(Instant::now() + Duration::from_secs(5)));
-        });
-        let pending_deadline = Instant::now() + Duration::from_secs(1);
-        while !server_stream.0.is_drain_pending() {
-            assert!(
-                Instant::now() < pending_deadline,
-                "first drain never entered FlushFileBuffers"
-            );
-            thread::yield_now();
-        }
-        let second_error = second_drain
-            .shutdown_after_drain(Instant::now() + Duration::from_millis(50))
-            .expect_err("a concurrent drain must not queue behind the first");
-        assert_eq!(second_error.kind(), std::io::ErrorKind::WouldBlock);
-
-        let abort_started = Instant::now();
-        server_stream
+        server_stream.0.force_cancel_error();
+        let shutdown_error = server_stream
             .shutdown_app_link()
-            .expect("abort active orderly drain");
-        assert!(
-            abort_started.elapsed() < Duration::from_secs(1),
-            "abortive shutdown blocked behind orderly drain"
-        );
-        assert!(
-            drain_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("active drain completion after abort")
-                .is_err(),
-            "abortive shutdown must not report the interrupted drain as orderly"
-        );
-        drain.join().expect("join aborted drain");
-        drop(role);
+            .expect_err("injected cancellation failure must be reported");
+        assert_eq!(shutdown_error.raw_os_error(), Some(5));
+
+        let mut peer_byte = [0_u8; 1];
+        let peer_error = role
+            .read(&mut peer_byte)
+            .expect_err("disconnect must still close the peer-facing connection");
+        assert!(matches!(peer_error.raw_os_error(), Some(109 | 232 | 233)));
     }
 
     #[test]

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -941,7 +941,7 @@ mod named_pipe_tests {
     fn pipe_name_dacl_and_non_inheritance_match_exact_contract() {
         let listener = WindowsNamedPipeBootstrapListener::bind().expect("bind named pipe");
         let link = listener.app_link();
-        let (endpoint, _) = parse_app_link(&link).expect("parse app link");
+        let (endpoint, token) = parse_app_link(&link).expect("parse app link");
         let suffix = endpoint
             .strip_prefix(r"\\.\pipe\keld-")
             .expect("canonical named-pipe prefix");
@@ -951,6 +951,11 @@ mod named_pipe_tests {
                 .bytes()
                 .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
             "pipe nonce must be lowercase hex"
+        );
+        assert_ne!(
+            suffix,
+            token.to_hex(),
+            "pipe namespace nonce must be minted independently from the HELLO token"
         );
         let facts = listener.security_facts().expect("security readback");
         assert!(facts.protected_dacl);

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -689,7 +689,7 @@ impl WindowsNamedPipeBootstrapListener {
                 drop(lock_or_recover(&self.server).take());
                 return Ok(BootstrapAdmission::DeadlineElapsed);
             };
-            let mut stream = WindowsNamedPipeBootstrapStream(server.stream());
+            let mut stream = WindowsNamedPipeBootstrapStream(server.stream()?);
             stream.set_app_link_read_deadline(Some(APP_LINK_READER_POLL.min(peer_timeout)))?;
             stream.set_app_link_write_deadline(Some(peer_timeout))?;
             stream.0.set_absolute_deadline(Some(peer_deadline));
@@ -818,7 +818,7 @@ impl WindowsNamedPipeBootstrapStream {
     ///
     /// Reserved for parity with other platform streams.
     pub fn try_clone(&self) -> io::Result<Self> {
-        Ok(Self(self.0.try_clone()))
+        self.0.try_clone().map(Self)
     }
 }
 

--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -1266,6 +1266,60 @@ mod named_pipe_tests {
     }
 
     #[test]
+    fn stream_shutdown_cancels_pending_read_and_joins_without_peer_input() {
+        let listener = Arc::new(WindowsNamedPipeBootstrapListener::bind().expect("bind"));
+        let link = listener.app_link();
+        let (endpoint, token) = parse_app_link(&link).expect("parse link");
+        let endpoint = endpoint.to_owned();
+        let worker_listener = Arc::clone(&listener);
+        let worker = thread::spawn(move || {
+            worker_listener.accept_authenticated_until(
+                Instant::now() + Duration::from_secs(2),
+                &super::NoopRejectionObserver,
+            )
+        });
+        let mut role = client(&endpoint).expect("open role");
+        role.set_app_link_deadlines(Some(Duration::from_millis(500)))
+            .expect("role deadlines");
+        handshake_client(&mut role, &token).expect("authenticate");
+        let outcome = worker.join().expect("join admission").expect("admission");
+        let BootstrapAdmission::Authenticated(server_stream) = outcome else {
+            panic!("expected authenticated named-pipe session")
+        };
+        let mut blocked_reader = server_stream.try_clone().expect("clone server stream");
+        blocked_reader
+            .set_app_link_read_deadline(Some(Duration::from_secs(5)))
+            .expect("reader deadline");
+        let (result_tx, result_rx) = mpsc::channel();
+        let reader = thread::spawn(move || {
+            let mut byte = [0_u8; 1];
+            let _ = result_tx.send(blocked_reader.read_exact(&mut byte));
+        });
+        let active_deadline = Instant::now() + Duration::from_secs(1);
+        while !server_stream.0.has_active_io() {
+            assert!(
+                Instant::now() < active_deadline,
+                "reader never entered overlapped I/O"
+            );
+            thread::yield_now();
+        }
+        server_stream
+            .shutdown_app_link()
+            .expect("shutdown connected pipe");
+        let error = result_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("shutdown must wake local read")
+            .expect_err("pending read must not succeed without peer bytes");
+        assert!(matches!(error.raw_os_error(), Some(995 | 109 | 233)));
+        reader.join().expect("join blocked reader");
+        let mut peer_byte = [0_u8; 1];
+        let peer_error = role
+            .read(&mut peer_byte)
+            .expect_err("shutdown must also close the peer-facing connection");
+        assert!(matches!(peer_error.raw_os_error(), Some(109 | 232 | 233)));
+    }
+
+    #[test]
     fn cancellation_handle_does_not_keep_dropped_listener_alive() {
         let listener = WindowsNamedPipeBootstrapListener::bind().expect("bind");
         let endpoint = listener.endpoint().to_owned();

--- a/crates/keld-ipc/src/lib.rs
+++ b/crates/keld-ipc/src/lib.rs
@@ -29,12 +29,13 @@ mod windows_named_pipe;
 pub use admission::{BootstrapRejection, BootstrapRejectionObserver};
 #[cfg(any(unix, windows))]
 pub use bootstrap::{
-    BootstrapAdmission, BootstrapCancellation, BootstrapListener, BootstrapStream,
+    BootstrapAdmission, BootstrapAdmissionFor, BootstrapCancellation, BootstrapListener,
+    BootstrapStream,
 };
 #[cfg(windows)]
 pub use bootstrap::{
-    WindowsNamedPipeBootstrapCancellation, WindowsNamedPipeBootstrapListener,
-    WindowsNamedPipeBootstrapStream,
+    WindowsNamedPipeBootstrapAdmission, WindowsNamedPipeBootstrapCancellation,
+    WindowsNamedPipeBootstrapListener, WindowsNamedPipeBootstrapStream,
 };
 pub use call_error::{CallError, write_call_error};
 pub use echo::{ECHO_CHANNEL, EchoRequest, EchoResponse};

--- a/crates/keld-ipc/src/lib.rs
+++ b/crates/keld-ipc/src/lib.rs
@@ -33,8 +33,8 @@ pub use bootstrap::{
 };
 #[cfg(windows)]
 pub use bootstrap::{
-    NamedPipeBootstrapAdmission, WindowsNamedPipeBootstrapCancellation,
-    WindowsNamedPipeBootstrapListener, WindowsNamedPipeBootstrapStream,
+    WindowsNamedPipeBootstrapCancellation, WindowsNamedPipeBootstrapListener,
+    WindowsNamedPipeBootstrapStream,
 };
 pub use call_error::{CallError, write_call_error};
 pub use echo::{ECHO_CHANNEL, EchoRequest, EchoResponse};

--- a/crates/keld-ipc/src/lib.rs
+++ b/crates/keld-ipc/src/lib.rs
@@ -23,11 +23,18 @@ pub mod lifecycle;
 pub mod link;
 pub mod session;
 pub mod token;
+#[cfg(windows)]
+mod windows_named_pipe;
 
 pub use admission::{BootstrapRejection, BootstrapRejectionObserver};
 #[cfg(any(unix, windows))]
 pub use bootstrap::{
     BootstrapAdmission, BootstrapCancellation, BootstrapListener, BootstrapStream,
+};
+#[cfg(windows)]
+pub use bootstrap::{
+    NamedPipeBootstrapAdmission, WindowsNamedPipeBootstrapCancellation,
+    WindowsNamedPipeBootstrapListener, WindowsNamedPipeBootstrapStream,
 };
 pub use call_error::{CallError, write_call_error};
 pub use echo::{ECHO_CHANNEL, EchoRequest, EchoResponse};

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -15,7 +15,7 @@ use std::ptr;
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, Weak, mpsc};
+use std::sync::{Arc, Mutex, MutexGuard, Weak};
 use std::time::{Duration, Instant};
 
 use windows_permissions::constants::{AceFlags, AceType, SeObjectType, SecurityInformation};
@@ -31,11 +31,9 @@ use windows_sys::Win32::Foundation::{
 use windows_sys::Win32::Storage::FileSystem::{CreateFileW, OPEN_EXISTING};
 use windows_sys::Win32::Storage::FileSystem::{
     FILE_CREATE_PIPE_INSTANCE, FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED,
-    FlushFileBuffers, PIPE_ACCESS_DUPLEX, ReadFile, WriteFile,
+    PIPE_ACCESS_DUPLEX, ReadFile, WriteFile,
 };
-use windows_sys::Win32::System::IO::{
-    CancelIoEx, CancelSynchronousIo, GetOverlappedResult, OVERLAPPED,
-};
+use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult, OVERLAPPED};
 #[cfg(test)]
 use windows_sys::Win32::System::Pipes::WaitNamedPipeW;
 use windows_sys::Win32::System::Pipes::{
@@ -67,13 +65,12 @@ struct ServerInner {
     connect_event: OwnedEvent,
     connected: AtomicBool,
     consumed: AtomicBool,
-    drain_active: AtomicBool,
     #[cfg(test)]
     accept_pending: AtomicBool,
     #[cfg(test)]
     active_stream_io: AtomicUsize,
     #[cfg(test)]
-    drain_pending: AtomicBool,
+    force_cancel_error: AtomicBool,
 }
 
 /// One host-owned named-pipe instance.
@@ -166,13 +163,12 @@ impl WindowsNamedPipeServer {
                 connect_event,
                 connected: AtomicBool::new(false),
                 consumed: AtomicBool::new(false),
-                drain_active: AtomicBool::new(false),
                 #[cfg(test)]
                 accept_pending: AtomicBool::new(false),
                 #[cfg(test)]
                 active_stream_io: AtomicUsize::new(0),
                 #[cfg(test)]
-                drain_pending: AtomicBool::new(false),
+                force_cancel_error: AtomicBool::new(false),
             }),
         };
         server.validate_security(&current_sid)?;
@@ -347,13 +343,12 @@ impl WindowsNamedPipeServer {
                 connect_event,
                 connected: AtomicBool::new(true),
                 consumed: AtomicBool::new(true),
-                drain_active: AtomicBool::new(false),
                 #[cfg(test)]
                 accept_pending: AtomicBool::new(false),
                 #[cfg(test)]
                 active_stream_io: AtomicUsize::new(0),
                 #[cfg(test)]
-                drain_pending: AtomicBool::new(false),
+                force_cancel_error: AtomicBool::new(false),
             }),
             read_event: OwnedEvent::new()?,
             write_event: OwnedEvent::new()?,
@@ -437,6 +432,10 @@ impl WindowsNamedPipeServer {
     }
 
     fn cancel_pending_io(&self) -> io::Result<()> {
+        #[cfg(test)]
+        if self.inner.force_cancel_error.load(Ordering::Acquire) {
+            return Err(io::Error::from_raw_os_error(5));
+        }
         // SAFETY: null OVERLAPPED cancels all operations issued by this
         // process on the owned pipe. Each operation owner subsequently waits
         // for and observes its own completion before freeing state.
@@ -528,105 +527,24 @@ impl WindowsNamedPipeStream {
             inner: Arc::clone(&self.inner),
         };
         let _lifecycle = lock_or_recover(&self.inner.lifecycle);
-        server.cancel_pending_io()?;
+        let cancel_error = server.cancel_pending_io().err();
         // SAFETY: this is the live server pipe handle. Cancelling does not
         // free another operation's OVERLAPPED or buffer; each operation owner
         // retains and observes its own state. Disconnect only breaks the pipe
         // connection so peer and local waiters can finish.
-        if self.inner.connected.swap(false, Ordering::AcqRel)
-            && unsafe { DisconnectNamedPipe(server.raw_pipe()?) } == 0
-        {
-            let error = io::Error::last_os_error();
-            if !matches!(error.raw_os_error(), Some(109 | 232 | 233)) {
-                return Err(error);
-            }
-        }
-        Ok(())
-    }
-
-    pub(crate) fn shutdown_after_drain(&self, deadline: Instant) -> io::Result<()> {
-        // FlushFileBuffers has no overlapped form. One terminal cold-path
-        // worker makes that synchronous OS wait cancellable; ordinary
-        // reads/writes retain their allocation-free reusable events.
-        if self
-            .inner
-            .drain_active
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return Err(io::Error::new(
-                io::ErrorKind::WouldBlock,
-                "named-pipe orderly drain already active",
-            ));
-        }
-        let _claim = ActiveDrain::new(&self.inner.drain_active);
-        let total_remaining = deadline
-            .checked_duration_since(Instant::now())
-            .filter(|remaining| !remaining.is_zero())
-            .ok_or_else(|| io::Error::from_raw_os_error(ERROR_SEM_TIMEOUT.cast_signed()))?;
-        let inner = Arc::clone(&self.inner);
-        let (result_tx, result_rx) = mpsc::sync_channel(1);
-        let worker = std::thread::Builder::new()
-            .name("keld-pipe-drain".to_owned())
-            .spawn(move || {
-                #[cfg(test)]
-                let _pending = PendingDrain::new(&inner.drain_pending);
-                let server = WindowsNamedPipeServer {
-                    inner: Arc::clone(&inner),
-                };
-                let result = (|| {
-                    let pipe = server.raw_pipe()?;
-                    // SAFETY: the worker's Arc keeps the owned connected pipe
-                    // handle live until this synchronous flush returns. The
-                    // caller observes worker completion before returning.
-                    if unsafe { FlushFileBuffers(pipe) } == 0 {
-                        return Err(io::Error::last_os_error());
-                    }
-                    Ok(())
-                })();
-                let _ = result_tx.send(result);
-            })?;
-
-        match result_rx.recv_timeout(total_remaining) {
-            Ok(flush_result) => {
-                worker
-                    .join()
-                    .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
-                let shutdown_result = self.shutdown();
-                flush_result.and(shutdown_result)
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                // Disconnect first so a peer which never reads cannot retain
-                // the pipe while cancellation targets the synchronous flush.
-                let shutdown_error = self.shutdown().err();
-                // SAFETY: AsRawHandle exposes the live worker-thread handle,
-                // which remains owned until the unconditional join below.
-                let cancel_error = if unsafe { CancelSynchronousIo(worker.as_raw_handle()) } == 0 {
+        let disconnect_error = if self.inner.connected.swap(false, Ordering::AcqRel) {
+            match server.raw_pipe() {
+                Ok(pipe) if unsafe { DisconnectNamedPipe(pipe) } == 0 => {
                     let error = io::Error::last_os_error();
-                    (error.raw_os_error() != Some(1168)).then_some(error)
-                } else {
-                    None
-                };
-                worker
-                    .join()
-                    .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
-                if let Some(error) = shutdown_error.or(cancel_error) {
-                    return Err(error);
+                    (!matches!(error.raw_os_error(), Some(109 | 232 | 233))).then_some(error)
                 }
-                Err(io::Error::from_raw_os_error(
-                    ERROR_SEM_TIMEOUT.cast_signed(),
-                ))
+                Ok(_) => None,
+                Err(error) => Some(error),
             }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                worker
-                    .join()
-                    .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
-                self.shutdown()?;
-                Err(io::Error::other(
-                    "named-pipe drain worker exited without a result",
-                ))
-            }
-        }
+        } else {
+            None
+        };
+        disconnect_error.or(cancel_error).map_or(Ok(()), Err)
     }
 
     #[cfg(test)]
@@ -635,8 +553,8 @@ impl WindowsNamedPipeStream {
     }
 
     #[cfg(test)]
-    pub(crate) fn is_drain_pending(&self) -> bool {
-        self.inner.drain_pending.load(Ordering::Acquire)
+    pub(crate) fn force_cancel_error(&self) {
+        self.inner.force_cancel_error.store(true, Ordering::Release);
     }
 
     fn raw_pipe(&self) -> io::Result<*mut core::ffi::c_void> {
@@ -846,11 +764,6 @@ struct PendingAccept<'a>(&'a AtomicBool);
 struct ActiveStreamIo<'a>(&'a AtomicUsize);
 
 #[cfg(test)]
-struct PendingDrain<'a>(&'a AtomicBool);
-
-struct ActiveDrain<'a>(&'a AtomicBool);
-
-#[cfg(test)]
 impl<'a> PendingAccept<'a> {
     fn new(pending: &'a AtomicBool) -> Self {
         pending.store(true, Ordering::Release);
@@ -877,33 +790,6 @@ impl<'a> ActiveStreamIo<'a> {
 impl Drop for ActiveStreamIo<'_> {
     fn drop(&mut self) {
         self.0.fetch_sub(1, Ordering::AcqRel);
-    }
-}
-
-#[cfg(test)]
-impl<'a> PendingDrain<'a> {
-    fn new(pending: &'a AtomicBool) -> Self {
-        pending.store(true, Ordering::Release);
-        Self(pending)
-    }
-}
-
-#[cfg(test)]
-impl Drop for PendingDrain<'_> {
-    fn drop(&mut self) {
-        self.0.store(false, Ordering::Release);
-    }
-}
-
-impl<'a> ActiveDrain<'a> {
-    fn new(active: &'a AtomicBool) -> Self {
-        Self(active)
-    }
-}
-
-impl Drop for ActiveDrain<'_> {
-    fn drop(&mut self) {
-        self.0.store(false, Ordering::Release);
     }
 }
 

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -60,6 +60,7 @@ pub(crate) enum WaitOutcome {
 #[derive(Debug)]
 struct ServerInner {
     pipe: Mutex<Option<OwnedHandle>>,
+    lifecycle: Mutex<()>,
     cancel_event: OwnedHandle,
     connect_event: OwnedEvent,
     connected: AtomicBool,
@@ -154,6 +155,7 @@ impl WindowsNamedPipeServer {
         let server = Self {
             inner: Arc::new(ServerInner {
                 pipe: Mutex::new(Some(pipe)),
+                lifecycle: Mutex::new(()),
                 cancel_event,
                 connect_event,
                 connected: AtomicBool::new(false),
@@ -219,6 +221,7 @@ impl WindowsNamedPipeServer {
     }
 
     pub(crate) fn disconnect_for_retry(&self) -> io::Result<()> {
+        let _lifecycle = lock_or_recover(&self.inner.lifecycle);
         if self.inner.consumed.load(Ordering::Acquire) {
             return Err(io::Error::new(
                 io::ErrorKind::NotConnected,
@@ -255,6 +258,7 @@ impl WindowsNamedPipeServer {
     }
 
     pub(crate) fn cancel(&self) -> io::Result<()> {
+        let _lifecycle = lock_or_recover(&self.inner.lifecycle);
         if self.inner.consumed.load(Ordering::Acquire) {
             return Ok(());
         }
@@ -278,6 +282,7 @@ impl WindowsNamedPipeServer {
     }
 
     pub(crate) fn close_terminal(&self) -> io::Result<()> {
+        let _lifecycle = lock_or_recover(&self.inner.lifecycle);
         self.inner.consumed.store(true, Ordering::Release);
         self.cancel_pending_io()?;
         // SAFETY: the server owns the live handle and all pending operations
@@ -328,6 +333,7 @@ impl WindowsNamedPipeServer {
         Ok(WindowsNamedPipeStream {
             inner: Arc::new(ServerInner {
                 pipe: Mutex::new(Some(pipe)),
+                lifecycle: Mutex::new(()),
                 cancel_event,
                 connect_event,
                 connected: AtomicBool::new(true),
@@ -499,6 +505,7 @@ impl WindowsNamedPipeStream {
         let server = WindowsNamedPipeServer {
             inner: Arc::clone(&self.inner),
         };
+        let _lifecycle = lock_or_recover(&self.inner.lifecycle);
         server.cancel_pending_io()?;
         // SAFETY: this is the live server pipe handle. Cancelling does not
         // free another operation's OVERLAPPED or buffer; each operation owner

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -15,7 +15,7 @@ use std::ptr;
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, Weak};
+use std::sync::{Arc, Mutex, MutexGuard, Weak, mpsc};
 use std::time::{Duration, Instant};
 
 use windows_permissions::constants::{AceFlags, AceType, SeObjectType, SecurityInformation};
@@ -31,13 +31,15 @@ use windows_sys::Win32::Foundation::{
 use windows_sys::Win32::Storage::FileSystem::{CreateFileW, OPEN_EXISTING};
 use windows_sys::Win32::Storage::FileSystem::{
     FILE_CREATE_PIPE_INSTANCE, FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED,
-    PIPE_ACCESS_DUPLEX, ReadFile, WriteFile,
+    FlushFileBuffers, PIPE_ACCESS_DUPLEX, ReadFile, WriteFile,
 };
-use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult, OVERLAPPED};
+use windows_sys::Win32::System::IO::{
+    CancelIoEx, CancelSynchronousIo, GetOverlappedResult, OVERLAPPED,
+};
 #[cfg(test)]
 use windows_sys::Win32::System::Pipes::WaitNamedPipeW;
 use windows_sys::Win32::System::Pipes::{
-    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PIPE_READMODE_BYTE,
+    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, GetNamedPipeInfo, PIPE_READMODE_BYTE,
     PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_BYTE, PIPE_WAIT,
 };
 use windows_sys::Win32::System::Threading::{
@@ -69,6 +71,8 @@ struct ServerInner {
     accept_pending: AtomicBool,
     #[cfg(test)]
     active_stream_io: AtomicUsize,
+    #[cfg(test)]
+    drain_pending: AtomicBool,
 }
 
 /// One host-owned named-pipe instance.
@@ -104,6 +108,7 @@ pub(crate) struct PipeSecurityFacts {
     pub(crate) one_ace_flags: u8,
     pub(crate) one_ace_mask: u32,
     pub(crate) handle_flags: u32,
+    pub(crate) pipe_flags: u32,
 }
 
 impl WindowsNamedPipeServer {
@@ -164,6 +169,8 @@ impl WindowsNamedPipeServer {
                 accept_pending: AtomicBool::new(false),
                 #[cfg(test)]
                 active_stream_io: AtomicUsize::new(0),
+                #[cfg(test)]
+                drain_pending: AtomicBool::new(false),
             }),
         };
         server.validate_security(&current_sid)?;
@@ -342,6 +349,8 @@ impl WindowsNamedPipeServer {
                 accept_pending: AtomicBool::new(false),
                 #[cfg(test)]
                 active_stream_io: AtomicUsize::new(0),
+                #[cfg(test)]
+                drain_pending: AtomicBool::new(false),
             }),
             read_event: OwnedEvent::new()?,
             write_event: OwnedEvent::new()?,
@@ -399,6 +408,7 @@ impl WindowsNamedPipeServer {
             || facts.one_ace_mask != PIPE_ACCESS_MASK
             || facts.one_ace_mask & FILE_CREATE_PIPE_INSTANCE != 0
             || facts.handle_flags & HANDLE_FLAG_INHERIT != 0
+            || facts.pipe_flags & PIPE_REJECT_REMOTE_CLIENTS == 0
         {
             return Err(io::Error::other(format!(
                 "named-pipe security readback did not match the current-user-only contract: {facts:?}"
@@ -445,6 +455,15 @@ impl WindowsNamedPipeServer {
             .as_ref()
             .map(AsRawHandle::as_raw_handle)
             .ok_or_else(closed_pipe_error)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inspect_owned_pipe<T>(
+        &self,
+        inspect: impl FnOnce(&OwnedHandle) -> io::Result<T>,
+    ) -> io::Result<T> {
+        let pipe = lock_or_recover(&self.inner.pipe);
+        inspect(pipe.as_ref().ok_or_else(closed_pipe_error)?)
     }
 
     fn raw_cancel_event(&self) -> *mut core::ffi::c_void {
@@ -522,9 +541,94 @@ impl WindowsNamedPipeStream {
         Ok(())
     }
 
+    pub(crate) fn shutdown_after_drain(&self, deadline: Instant) -> io::Result<()> {
+        // FlushFileBuffers has no overlapped form. One terminal cold-path
+        // worker makes that synchronous OS wait cancellable; ordinary
+        // reads/writes retain their allocation-free reusable events.
+        let inner = Arc::clone(&self.inner);
+        let (result_tx, result_rx) = mpsc::sync_channel(1);
+        let worker = std::thread::Builder::new()
+            .name("keld-pipe-drain".to_owned())
+            .spawn(move || {
+                let _lifecycle = lock_or_recover(&inner.lifecycle);
+                #[cfg(test)]
+                let _pending = PendingDrain::new(&inner.drain_pending);
+                let server = WindowsNamedPipeServer {
+                    inner: Arc::clone(&inner),
+                };
+                let result = (|| {
+                    let pipe = server.raw_pipe()?;
+                    // SAFETY: the owned connected server handle stays live
+                    // under the lifecycle guard until this synchronous flush
+                    // returns or CancelSynchronousIo completes it.
+                    if unsafe { FlushFileBuffers(pipe) } == 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    Ok(())
+                })();
+                let _ = result_tx.send(result);
+            })?;
+
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO);
+        match result_rx.recv_timeout(remaining) {
+            Ok(flush_result) => {
+                worker
+                    .join()
+                    .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
+                let shutdown_result = self.shutdown();
+                flush_result.and(shutdown_result)
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                loop {
+                    if worker.is_finished() {
+                        break;
+                    }
+                    // SAFETY: AsRawHandle exposes the live worker-thread
+                    // handle; the worker is joined before it can become stale.
+                    if unsafe { CancelSynchronousIo(worker.as_raw_handle()) } != 0 {
+                        break;
+                    }
+                    let error = io::Error::last_os_error();
+                    if error.raw_os_error() != Some(1168) {
+                        let _ = worker.join();
+                        let _ = self.shutdown();
+                        return Err(error);
+                    }
+                    // ERROR_NOT_FOUND can mean the worker was scheduled but
+                    // has not entered FlushFileBuffers yet. Retry until the
+                    // operation exists or the worker completed normally.
+                    std::thread::yield_now();
+                }
+                worker
+                    .join()
+                    .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
+                self.shutdown()?;
+                Err(io::Error::from_raw_os_error(
+                    ERROR_SEM_TIMEOUT.cast_signed(),
+                ))
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                worker
+                    .join()
+                    .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
+                self.shutdown()?;
+                Err(io::Error::other(
+                    "named-pipe drain worker exited without a result",
+                ))
+            }
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn has_active_io(&self) -> bool {
         self.inner.active_stream_io.load(Ordering::Acquire) != 0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_drain_pending(&self) -> bool {
+        self.inner.drain_pending.load(Ordering::Acquire)
     }
 
     fn raw_pipe(&self) -> io::Result<*mut core::ffi::c_void> {
@@ -679,9 +783,12 @@ fn wait_for_operation(
     deadline: Option<Instant>,
 ) -> io::Result<WaitOutcome> {
     let handles = [cancel_event, operation_event];
-    let timeout = deadline
-        .and_then(|deadline| deadline.checked_duration_since(Instant::now()))
-        .map_or(INFINITE, |remaining| duration_to_wait_ms(Some(remaining)));
+    let timeout = match deadline {
+        None => INFINITE,
+        Some(deadline) => deadline
+            .checked_duration_since(Instant::now())
+            .map_or(0, |remaining| duration_to_wait_ms(Some(remaining))),
+    };
     // SAFETY: both handles remain live for the wait; the array length is exact.
     let result = unsafe {
         WaitForMultipleObjects(
@@ -731,6 +838,9 @@ struct PendingAccept<'a>(&'a AtomicBool);
 struct ActiveStreamIo<'a>(&'a AtomicUsize);
 
 #[cfg(test)]
+struct PendingDrain<'a>(&'a AtomicBool);
+
+#[cfg(test)]
 impl<'a> PendingAccept<'a> {
     fn new(pending: &'a AtomicBool) -> Self {
         pending.store(true, Ordering::Release);
@@ -757,6 +867,21 @@ impl<'a> ActiveStreamIo<'a> {
 impl Drop for ActiveStreamIo<'_> {
     fn drop(&mut self) {
         self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[cfg(test)]
+impl<'a> PendingDrain<'a> {
+    fn new(pending: &'a AtomicBool) -> Self {
+        pending.store(true, Ordering::Release);
+        Self(pending)
+    }
+}
+
+#[cfg(test)]
+impl Drop for PendingDrain<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
     }
 }
 
@@ -824,6 +949,7 @@ fn read_security_facts(handle: &OwnedHandle) -> io::Result<PipeSecurityFacts> {
         one_ace_flags: ace.map_or(u8::MAX, |ace| ace.flags().bits()),
         one_ace_mask: ace.map_or(0, |ace| ace.mask().bits()),
         handle_flags: handle_flags(handle)?,
+        pipe_flags: pipe_flags(handle)?,
     })
 }
 
@@ -831,6 +957,25 @@ fn handle_flags(handle: &OwnedHandle) -> io::Result<u32> {
     let mut flags = 0;
     // SAFETY: `handle` is live and `flags` is a valid writable u32.
     if unsafe { GetHandleInformation(handle.as_raw_handle(), &raw mut flags) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(flags)
+}
+
+fn pipe_flags(handle: &OwnedHandle) -> io::Result<u32> {
+    let mut flags = 0;
+    // SAFETY: `handle` is the live server-pipe handle and `flags` is a valid
+    // writable u32; omitted size/count outputs are optional null pointers.
+    if unsafe {
+        GetNamedPipeInfo(
+            handle.as_raw_handle(),
+            &raw mut flags,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        )
+    } == 0
+    {
         return Err(io::Error::last_os_error());
     }
     Ok(flags)

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -544,10 +544,6 @@ impl WindowsNamedPipeStream {
         Ok(())
     }
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "one linear terminal state machine keeps flush cancellation and join ordering auditable"
-    )]
     pub(crate) fn shutdown_after_drain(&self, deadline: Instant) -> io::Result<()> {
         // FlushFileBuffers has no overlapped form. One terminal cold-path
         // worker makes that synchronous OS wait cancellable; ordinary
@@ -563,21 +559,16 @@ impl WindowsNamedPipeStream {
                 "named-pipe orderly drain already active",
             ));
         }
+        let _claim = ActiveDrain::new(&self.inner.drain_active);
         let total_remaining = deadline
             .checked_duration_since(Instant::now())
             .filter(|remaining| !remaining.is_zero())
-            .ok_or_else(|| {
-                self.inner.drain_active.store(false, Ordering::Release);
-                io::Error::from_raw_os_error(ERROR_SEM_TIMEOUT.cast_signed())
-            })?;
-        let cancel_reserve = Duration::from_millis(100).min(total_remaining / 2);
-        let flush_wait = total_remaining.saturating_sub(cancel_reserve);
+            .ok_or_else(|| io::Error::from_raw_os_error(ERROR_SEM_TIMEOUT.cast_signed()))?;
         let inner = Arc::clone(&self.inner);
         let (result_tx, result_rx) = mpsc::sync_channel(1);
         let worker = std::thread::Builder::new()
             .name("keld-pipe-drain".to_owned())
             .spawn(move || {
-                let _claim = ActiveDrain::new(&inner.drain_active);
                 #[cfg(test)]
                 let _pending = PendingDrain::new(&inner.drain_pending);
                 let server = WindowsNamedPipeServer {
@@ -585,21 +576,18 @@ impl WindowsNamedPipeStream {
                 };
                 let result = (|| {
                     let pipe = server.raw_pipe()?;
-                    // SAFETY: the owned connected server handle stays live
-                    // under the lifecycle guard until this synchronous flush
-                    // returns or CancelSynchronousIo completes it.
+                    // SAFETY: the worker's Arc keeps the owned connected pipe
+                    // handle live until this synchronous flush returns. The
+                    // caller observes worker completion before returning.
                     if unsafe { FlushFileBuffers(pipe) } == 0 {
                         return Err(io::Error::last_os_error());
                     }
                     Ok(())
                 })();
                 let _ = result_tx.send(result);
-            })
-            .inspect_err(|_error| {
-                self.inner.drain_active.store(false, Ordering::Release);
             })?;
 
-        match result_rx.recv_timeout(flush_wait) {
+        match result_rx.recv_timeout(total_remaining) {
             Ok(flush_result) => {
                 worker
                     .join()
@@ -608,50 +596,26 @@ impl WindowsNamedPipeStream {
                 flush_result.and(shutdown_result)
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Disconnect first so a peer which never reads cannot retain
+                // the pipe while cancellation targets the synchronous flush.
                 let shutdown_error = self.shutdown().err();
-                // SAFETY: AsRawHandle exposes the live worker-thread handle;
-                // the bounded wait below cannot outlive `worker`.
+                // SAFETY: AsRawHandle exposes the live worker-thread handle,
+                // which remains owned until the unconditional join below.
                 let cancel_error = if unsafe { CancelSynchronousIo(worker.as_raw_handle()) } == 0 {
                     let error = io::Error::last_os_error();
                     (error.raw_os_error() != Some(1168)).then_some(error)
                 } else {
                     None
                 };
-                let cleanup_wait = deadline
-                    .checked_duration_since(Instant::now())
-                    .map_or(0, |remaining| duration_to_wait_ms(Some(remaining)));
-                // SAFETY: the JoinHandle owns a live thread handle for this
-                // bounded wait and Windows retains no pointer.
-                match unsafe { WaitForSingleObject(worker.as_raw_handle(), cleanup_wait) } {
-                    WAIT_OBJECT_0 => {
-                        worker
-                            .join()
-                            .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
-                        if let Some(error) = shutdown_error.or(cancel_error) {
-                            return Err(error);
-                        }
-                        Err(io::Error::from_raw_os_error(
-                            ERROR_SEM_TIMEOUT.cast_signed(),
-                        ))
-                    }
-                    WAIT_TIMEOUT => {
-                        drop(worker);
-                        Err(io::Error::from_raw_os_error(
-                            ERROR_SEM_TIMEOUT.cast_signed(),
-                        ))
-                    }
-                    WAIT_FAILED => {
-                        let error = io::Error::last_os_error();
-                        drop(worker);
-                        Err(error)
-                    }
-                    other => {
-                        drop(worker);
-                        Err(io::Error::other(format!(
-                            "unexpected drain-worker wait result {other}"
-                        )))
-                    }
+                worker
+                    .join()
+                    .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
+                if let Some(error) = shutdown_error.or(cancel_error) {
+                    return Err(error);
                 }
+                Err(io::Error::from_raw_os_error(
+                    ERROR_SEM_TIMEOUT.cast_signed(),
+                ))
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 worker

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -67,6 +67,7 @@ struct ServerInner {
     connect_event: OwnedEvent,
     connected: AtomicBool,
     consumed: AtomicBool,
+    drain_active: AtomicBool,
     #[cfg(test)]
     accept_pending: AtomicBool,
     #[cfg(test)]
@@ -165,6 +166,7 @@ impl WindowsNamedPipeServer {
                 connect_event,
                 connected: AtomicBool::new(false),
                 consumed: AtomicBool::new(false),
+                drain_active: AtomicBool::new(false),
                 #[cfg(test)]
                 accept_pending: AtomicBool::new(false),
                 #[cfg(test)]
@@ -345,6 +347,7 @@ impl WindowsNamedPipeServer {
                 connect_event,
                 connected: AtomicBool::new(true),
                 consumed: AtomicBool::new(true),
+                drain_active: AtomicBool::new(false),
                 #[cfg(test)]
                 accept_pending: AtomicBool::new(false),
                 #[cfg(test)]
@@ -541,16 +544,40 @@ impl WindowsNamedPipeStream {
         Ok(())
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one linear terminal state machine keeps flush cancellation and join ordering auditable"
+    )]
     pub(crate) fn shutdown_after_drain(&self, deadline: Instant) -> io::Result<()> {
         // FlushFileBuffers has no overlapped form. One terminal cold-path
         // worker makes that synchronous OS wait cancellable; ordinary
         // reads/writes retain their allocation-free reusable events.
+        if self
+            .inner
+            .drain_active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "named-pipe orderly drain already active",
+            ));
+        }
+        let total_remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| {
+                self.inner.drain_active.store(false, Ordering::Release);
+                io::Error::from_raw_os_error(ERROR_SEM_TIMEOUT.cast_signed())
+            })?;
+        let cancel_reserve = Duration::from_millis(100).min(total_remaining / 2);
+        let flush_wait = total_remaining.saturating_sub(cancel_reserve);
         let inner = Arc::clone(&self.inner);
         let (result_tx, result_rx) = mpsc::sync_channel(1);
         let worker = std::thread::Builder::new()
             .name("keld-pipe-drain".to_owned())
             .spawn(move || {
-                let _lifecycle = lock_or_recover(&inner.lifecycle);
+                let _claim = ActiveDrain::new(&inner.drain_active);
                 #[cfg(test)]
                 let _pending = PendingDrain::new(&inner.drain_pending);
                 let server = WindowsNamedPipeServer {
@@ -567,12 +594,12 @@ impl WindowsNamedPipeStream {
                     Ok(())
                 })();
                 let _ = result_tx.send(result);
+            })
+            .inspect_err(|_error| {
+                self.inner.drain_active.store(false, Ordering::Release);
             })?;
 
-        let remaining = deadline
-            .checked_duration_since(Instant::now())
-            .unwrap_or(Duration::ZERO);
-        match result_rx.recv_timeout(remaining) {
+        match result_rx.recv_timeout(flush_wait) {
             Ok(flush_result) => {
                 worker
                     .join()
@@ -581,33 +608,50 @@ impl WindowsNamedPipeStream {
                 flush_result.and(shutdown_result)
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                loop {
-                    if worker.is_finished() {
-                        break;
-                    }
-                    // SAFETY: AsRawHandle exposes the live worker-thread
-                    // handle; the worker is joined before it can become stale.
-                    if unsafe { CancelSynchronousIo(worker.as_raw_handle()) } != 0 {
-                        break;
-                    }
+                let shutdown_error = self.shutdown().err();
+                // SAFETY: AsRawHandle exposes the live worker-thread handle;
+                // the bounded wait below cannot outlive `worker`.
+                let cancel_error = if unsafe { CancelSynchronousIo(worker.as_raw_handle()) } == 0 {
                     let error = io::Error::last_os_error();
-                    if error.raw_os_error() != Some(1168) {
-                        let _ = worker.join();
-                        let _ = self.shutdown();
-                        return Err(error);
+                    (error.raw_os_error() != Some(1168)).then_some(error)
+                } else {
+                    None
+                };
+                let cleanup_wait = deadline
+                    .checked_duration_since(Instant::now())
+                    .map_or(0, |remaining| duration_to_wait_ms(Some(remaining)));
+                // SAFETY: the JoinHandle owns a live thread handle for this
+                // bounded wait and Windows retains no pointer.
+                match unsafe { WaitForSingleObject(worker.as_raw_handle(), cleanup_wait) } {
+                    WAIT_OBJECT_0 => {
+                        worker
+                            .join()
+                            .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
+                        if let Some(error) = shutdown_error.or(cancel_error) {
+                            return Err(error);
+                        }
+                        Err(io::Error::from_raw_os_error(
+                            ERROR_SEM_TIMEOUT.cast_signed(),
+                        ))
                     }
-                    // ERROR_NOT_FOUND can mean the worker was scheduled but
-                    // has not entered FlushFileBuffers yet. Retry until the
-                    // operation exists or the worker completed normally.
-                    std::thread::yield_now();
+                    WAIT_TIMEOUT => {
+                        drop(worker);
+                        Err(io::Error::from_raw_os_error(
+                            ERROR_SEM_TIMEOUT.cast_signed(),
+                        ))
+                    }
+                    WAIT_FAILED => {
+                        let error = io::Error::last_os_error();
+                        drop(worker);
+                        Err(error)
+                    }
+                    other => {
+                        drop(worker);
+                        Err(io::Error::other(format!(
+                            "unexpected drain-worker wait result {other}"
+                        )))
+                    }
                 }
-                worker
-                    .join()
-                    .map_err(|_| io::Error::other("named-pipe drain worker panicked"))?;
-                self.shutdown()?;
-                Err(io::Error::from_raw_os_error(
-                    ERROR_SEM_TIMEOUT.cast_signed(),
-                ))
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 worker
@@ -840,6 +884,8 @@ struct ActiveStreamIo<'a>(&'a AtomicUsize);
 #[cfg(test)]
 struct PendingDrain<'a>(&'a AtomicBool);
 
+struct ActiveDrain<'a>(&'a AtomicBool);
+
 #[cfg(test)]
 impl<'a> PendingAccept<'a> {
     fn new(pending: &'a AtomicBool) -> Self {
@@ -880,6 +926,18 @@ impl<'a> PendingDrain<'a> {
 
 #[cfg(test)]
 impl Drop for PendingDrain<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+impl<'a> ActiveDrain<'a> {
+    fn new(active: &'a AtomicBool) -> Self {
+        Self(active)
+    }
+}
+
+impl Drop for ActiveDrain<'_> {
     fn drop(&mut self) {
         self.0.store(false, Ordering::Release);
     }

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -1,0 +1,813 @@
+//! Windows named-pipe handle and overlapped-I/O ownership.
+//!
+//! This module owns the Win32 ABI boundary only. Bootstrap token parsing,
+//! frame decoding, authentication, and rejection policy remain in safe shared
+//! modules.
+
+#![deny(unsafe_op_in_unsafe_fn)]
+#![allow(unsafe_code)] // KEL-101-sanctioned Win32 pipe/overlapped ABI owner
+
+use std::ffi::OsStr;
+use std::io::{self, Read, Write};
+use std::os::windows::ffi::OsStrExt as _;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, Weak};
+use std::time::{Duration, Instant};
+
+use windows_permissions::constants::{AceFlags, AceType, SeObjectType, SecurityInformation};
+use windows_permissions::utilities::current_process_sid;
+use windows_permissions::wrappers::{ConvertSidToStringSid, GetSecurityInfo};
+use windows_permissions::{LocalBox, SecurityDescriptor, Sid};
+use windows_sys::Win32::Foundation::{
+    ERROR_IO_PENDING, ERROR_OPERATION_ABORTED, ERROR_PIPE_CONNECTED, ERROR_SEM_TIMEOUT,
+    GetHandleInformation, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, WAIT_FAILED, WAIT_OBJECT_0,
+    WAIT_TIMEOUT,
+};
+#[cfg(test)]
+use windows_sys::Win32::Storage::FileSystem::{CreateFileW, OPEN_EXISTING};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_CREATE_PIPE_INSTANCE, FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED,
+    PIPE_ACCESS_DUPLEX, ReadFile, WriteFile,
+};
+use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult, OVERLAPPED};
+#[cfg(test)]
+use windows_sys::Win32::System::Pipes::WaitNamedPipeW;
+use windows_sys::Win32::System::Pipes::{
+    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PIPE_READMODE_BYTE,
+    PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_BYTE, PIPE_WAIT,
+};
+use windows_sys::Win32::System::Threading::{
+    CreateEventW, INFINITE, SetEvent, WaitForMultipleObjects, WaitForSingleObject,
+};
+
+const PIPE_BUFFER_BYTES: u32 = 64 * 1024;
+const PIPE_ACCESS_MASK: u32 = 0x0012_019B;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum WaitOutcome {
+    Ready,
+    PeerClosed,
+    Cancelled,
+    DeadlineElapsed,
+}
+
+#[derive(Debug)]
+struct ServerInner {
+    pipe: Mutex<Option<OwnedHandle>>,
+    cancel_event: OwnedHandle,
+    connected: AtomicBool,
+    consumed: AtomicBool,
+    #[cfg(test)]
+    accept_pending: AtomicBool,
+}
+
+/// One host-owned named-pipe instance.
+#[derive(Debug, Clone)]
+pub(crate) struct WindowsNamedPipeServer {
+    inner: Arc<ServerInner>,
+}
+
+/// Non-owning cancellation view; it cannot keep a stale pipe alive.
+#[derive(Debug, Clone)]
+pub(crate) struct WindowsNamedPipeCanceller {
+    inner: Weak<ServerInner>,
+}
+
+/// Connected server end of the named pipe.
+#[derive(Debug)]
+pub(crate) struct WindowsNamedPipeStream {
+    inner: Arc<ServerInner>,
+    read_timeout: Mutex<Option<Duration>>,
+    write_timeout: Mutex<Option<Duration>>,
+    absolute_deadline: Mutex<Option<Instant>>,
+}
+
+/// Exact security facts read back from the live pipe handle.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct PipeSecurityFacts {
+    pub(crate) protected_dacl: bool,
+    pub(crate) ace_count: usize,
+    pub(crate) one_ace_is_current_user: bool,
+    pub(crate) one_ace_type: u8,
+    pub(crate) one_ace_flags: u8,
+    pub(crate) one_ace_mask: u32,
+    pub(crate) handle_flags: u32,
+}
+
+impl WindowsNamedPipeServer {
+    pub(crate) fn bind(endpoint: &str) -> io::Result<Self> {
+        let current_sid = current_process_sid()?;
+        let descriptor = current_user_descriptor(&current_sid)?;
+        let endpoint_wide = wide(endpoint);
+        let attributes_len = u32::try_from(std::mem::size_of::<
+            windows_sys::Win32::Security::SECURITY_ATTRIBUTES,
+        >())
+        .map_err(io::Error::other)?;
+        let attributes = windows_sys::Win32::Security::SECURITY_ATTRIBUTES {
+            nLength: attributes_len,
+            lpSecurityDescriptor: descriptor.as_ptr().cast(),
+            bInheritHandle: 0,
+        };
+        // SAFETY: `endpoint_wide` is NUL terminated. `attributes` has the
+        // correct size and points to the live self-relative descriptor owned
+        // by `descriptor`; both outlive this call. Inheritance is disabled.
+        let raw_pipe = unsafe {
+            CreateNamedPipeW(
+                endpoint_wide.as_ptr(),
+                PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
+                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+                1,
+                PIPE_BUFFER_BYTES,
+                PIPE_BUFFER_BYTES,
+                0,
+                &raw const attributes,
+            )
+        };
+        if raw_pipe == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: CreateNamedPipeW returned one new owned handle, checked
+        // against INVALID_HANDLE_VALUE, and it is transferred exactly once.
+        let pipe = unsafe { OwnedHandle::from_raw_handle(raw_pipe as RawHandle) };
+
+        // SAFETY: null security/name pointers request an unnamed manual-reset
+        // event. The returned non-null handle is uniquely owned here.
+        let raw_cancel = unsafe { CreateEventW(ptr::null(), 1, 0, ptr::null()) };
+        if raw_cancel.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: CreateEventW returned one valid owned handle, transferred once.
+        let cancel_event = unsafe { OwnedHandle::from_raw_handle(raw_cancel as RawHandle) };
+
+        let server = Self {
+            inner: Arc::new(ServerInner {
+                pipe: Mutex::new(Some(pipe)),
+                cancel_event,
+                connected: AtomicBool::new(false),
+                consumed: AtomicBool::new(false),
+                #[cfg(test)]
+                accept_pending: AtomicBool::new(false),
+            }),
+        };
+        server.validate_security(&current_sid)?;
+        Ok(server)
+    }
+
+    pub(crate) fn accept_until(&self, deadline: Option<Instant>) -> io::Result<WaitOutcome> {
+        if self.inner.consumed.load(Ordering::Acquire) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "named-pipe bootstrap already consumed",
+            ));
+        }
+        let operation_event = OwnedEvent::new()?;
+        let mut overlapped = operation_event.overlapped();
+        // SAFETY: the pipe was created for overlapped I/O; `overlapped` and
+        // its event remain live until completion is observed below.
+        let connected_now = unsafe { ConnectNamedPipe(self.raw_pipe()?, &raw mut overlapped) } != 0;
+        if connected_now {
+            self.inner.connected.store(true, Ordering::Release);
+            return Ok(WaitOutcome::Ready);
+        }
+        match io::Error::last_os_error().raw_os_error() {
+            Some(code) if code == ERROR_PIPE_CONNECTED.cast_signed() => {
+                self.inner.connected.store(true, Ordering::Release);
+                Ok(WaitOutcome::Ready)
+            }
+            Some(code) if code == ERROR_IO_PENDING.cast_signed() => {
+                #[cfg(test)]
+                let _pending = PendingAccept::new(&self.inner.accept_pending);
+                let outcome = wait_for_operation(
+                    self.raw_pipe()?,
+                    &mut overlapped,
+                    operation_event.raw(),
+                    self.raw_cancel_event(),
+                    deadline,
+                )?;
+                match outcome {
+                    WaitOutcome::Ready | WaitOutcome::PeerClosed => {
+                        self.inner.connected.store(true, Ordering::Release);
+                    }
+                    WaitOutcome::Cancelled | WaitOutcome::DeadlineElapsed => {
+                        self.close_terminal()?;
+                    }
+                }
+                Ok(outcome)
+            }
+            Some(232 | 233) => {
+                self.inner.connected.store(true, Ordering::Release);
+                Ok(WaitOutcome::PeerClosed)
+            }
+            _ => Err(io::Error::last_os_error()),
+        }
+    }
+
+    pub(crate) fn disconnect_for_retry(&self) -> io::Result<()> {
+        if self.inner.consumed.load(Ordering::Acquire) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "consumed named-pipe bootstrap cannot re-listen",
+            ));
+        }
+        self.cancel_pending_io()?;
+        if self.inner.connected.swap(false, Ordering::AcqRel) {
+            // SAFETY: this object owns the live server pipe handle; no
+            // OVERLAPPED state is reused until cancellation was observed.
+            if unsafe { DisconnectNamedPipe(self.raw_pipe()?) } == 0 {
+                let error = io::Error::last_os_error();
+                if !matches!(error.raw_os_error(), Some(109 | 232 | 233)) {
+                    return Err(error);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn stream(&self) -> WindowsNamedPipeStream {
+        WindowsNamedPipeStream {
+            inner: Arc::clone(&self.inner),
+            read_timeout: Mutex::new(None),
+            write_timeout: Mutex::new(None),
+            absolute_deadline: Mutex::new(None),
+        }
+    }
+
+    pub(crate) fn consume(&self) {
+        self.inner.consumed.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn cancel(&self) -> io::Result<()> {
+        if self.inner.consumed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        // SAFETY: the cancellation event handle remains live in `inner`.
+        if unsafe { SetEvent(self.raw_cancel_event()) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        self.cancel_pending_io()
+    }
+
+    pub(crate) fn canceller(&self) -> WindowsNamedPipeCanceller {
+        WindowsNamedPipeCanceller {
+            inner: Arc::downgrade(&self.inner),
+        }
+    }
+
+    pub(crate) fn security_facts(&self) -> io::Result<PipeSecurityFacts> {
+        let pipe = lock_or_recover(&self.inner.pipe);
+        let pipe = pipe.as_ref().ok_or_else(closed_pipe_error)?;
+        read_security_facts(pipe)
+    }
+
+    pub(crate) fn close_terminal(&self) -> io::Result<()> {
+        self.inner.consumed.store(true, Ordering::Release);
+        self.cancel_pending_io()?;
+        if self.inner.connected.swap(false, Ordering::AcqRel)
+            && unsafe { DisconnectNamedPipe(self.raw_pipe()?) } == 0
+        {
+            let error = io::Error::last_os_error();
+            if !matches!(error.raw_os_error(), Some(109 | 233)) {
+                return Err(error);
+            }
+        }
+        drop(lock_or_recover(&self.inner.pipe).take());
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn connect_client(endpoint: &str) -> io::Result<WindowsNamedPipeStream> {
+        let endpoint_wide = wide(endpoint);
+        // SAFETY: endpoint_wide is NUL terminated; no security template is
+        // supplied; the returned handle is checked and transferred once.
+        let raw = unsafe {
+            CreateFileW(
+                endpoint_wide.as_ptr(),
+                PIPE_ACCESS_MASK,
+                0,
+                ptr::null(),
+                OPEN_EXISTING,
+                FILE_FLAG_OVERLAPPED,
+                ptr::null_mut(),
+            )
+        };
+        if raw == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: CreateFileW returned a valid newly owned handle.
+        let pipe = unsafe { OwnedHandle::from_raw_handle(raw as RawHandle) };
+        // SAFETY: null security/name pointers request an unnamed manual-reset
+        // event. The returned non-null handle is transferred once below.
+        let raw_cancel = unsafe { CreateEventW(ptr::null(), 1, 0, ptr::null()) };
+        if raw_cancel.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: CreateEventW returned a valid newly owned handle.
+        let cancel_event = unsafe { OwnedHandle::from_raw_handle(raw_cancel as RawHandle) };
+        Ok(WindowsNamedPipeStream {
+            inner: Arc::new(ServerInner {
+                pipe: Mutex::new(Some(pipe)),
+                cancel_event,
+                connected: AtomicBool::new(true),
+                consumed: AtomicBool::new(true),
+                #[cfg(test)]
+                accept_pending: AtomicBool::new(false),
+            }),
+            read_timeout: Mutex::new(None),
+            write_timeout: Mutex::new(None),
+            absolute_deadline: Mutex::new(None),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_connected(&self) -> bool {
+        self.inner.connected.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_accept_pending(&self) -> bool {
+        self.inner.accept_pending.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn connect_client_until(
+        endpoint: &str,
+        deadline: Instant,
+    ) -> io::Result<WindowsNamedPipeStream> {
+        let endpoint_wide = wide(endpoint);
+        loop {
+            match Self::connect_client(endpoint) {
+                Ok(stream) => return Ok(stream),
+                Err(error) if error.raw_os_error() == Some(231) => {
+                    let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                        return Err(io::Error::from_raw_os_error(231));
+                    };
+                    let wait_ms = duration_to_wait_ms(Some(remaining));
+                    // SAFETY: `endpoint_wide` is a live NUL-terminated path;
+                    // the bounded wait does not retain its pointer.
+                    if unsafe { WaitNamedPipeW(endpoint_wide.as_ptr(), wait_ms) } == 0 {
+                        let wait_error = io::Error::last_os_error();
+                        if wait_error.raw_os_error() != Some(ERROR_SEM_TIMEOUT.cast_signed()) {
+                            return Err(wait_error);
+                        }
+                    }
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn validate_security(&self, current_sid: &Sid) -> io::Result<()> {
+        let facts = self.security_facts()?;
+        if !facts.protected_dacl
+            || facts.ace_count != 1
+            || !facts.one_ace_is_current_user
+            || facts.one_ace_type != AceType::ACCESS_ALLOWED_ACE_TYPE as u8
+            || facts.one_ace_flags != AceFlags::empty().bits()
+            || facts.one_ace_mask != PIPE_ACCESS_MASK
+            || facts.one_ace_mask & FILE_CREATE_PIPE_INSTANCE != 0
+            || facts.handle_flags & HANDLE_FLAG_INHERIT != 0
+        {
+            return Err(io::Error::other(format!(
+                "named-pipe security readback did not match the current-user-only contract: {facts:?}"
+            )));
+        }
+        let descriptor = GetSecurityInfo(
+            lock_or_recover(&self.inner.pipe)
+                .as_ref()
+                .ok_or_else(closed_pipe_error)?,
+            SeObjectType::SE_KERNEL_OBJECT,
+            SecurityInformation::Dacl,
+        )?;
+        let ace_sid = descriptor
+            .dacl()
+            .and_then(|dacl| dacl.get_ace(0))
+            .and_then(|ace| ace.sid());
+        if ace_sid != Some(current_sid) {
+            return Err(io::Error::other(
+                "named-pipe DACL ACE does not equal current TokenUser SID",
+            ));
+        }
+        Ok(())
+    }
+
+    fn cancel_pending_io(&self) -> io::Result<()> {
+        // SAFETY: null OVERLAPPED cancels all operations issued by this
+        // process on the owned pipe. Each operation owner subsequently waits
+        // for and observes its own completion before freeing state.
+        let Ok(pipe) = self.raw_pipe() else {
+            return Ok(());
+        };
+        if unsafe { CancelIoEx(pipe, ptr::null()) } == 0 {
+            let error = io::Error::last_os_error();
+            // ERROR_NOT_FOUND means no matching operation remained pending.
+            if error.raw_os_error() != Some(1168) {
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    fn raw_pipe(&self) -> io::Result<*mut core::ffi::c_void> {
+        lock_or_recover(&self.inner.pipe)
+            .as_ref()
+            .map(AsRawHandle::as_raw_handle)
+            .ok_or_else(closed_pipe_error)
+    }
+
+    fn raw_cancel_event(&self) -> *mut core::ffi::c_void {
+        self.inner.cancel_event.as_raw_handle()
+    }
+}
+
+impl WindowsNamedPipeCanceller {
+    pub(crate) fn empty() -> Self {
+        Self { inner: Weak::new() }
+    }
+
+    pub(crate) fn cancel(&self) -> io::Result<()> {
+        let Some(inner) = self.inner.upgrade() else {
+            return Ok(());
+        };
+        WindowsNamedPipeServer { inner }.cancel()
+    }
+}
+
+impl WindowsNamedPipeStream {
+    pub(crate) fn try_clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            read_timeout: Mutex::new(*lock_or_recover(&self.read_timeout)),
+            write_timeout: Mutex::new(*lock_or_recover(&self.write_timeout)),
+            absolute_deadline: Mutex::new(*lock_or_recover(&self.absolute_deadline)),
+        }
+    }
+
+    pub(crate) fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+        validate_timeout(timeout)?;
+        *lock_or_recover(&self.read_timeout) = timeout;
+        Ok(())
+    }
+
+    pub(crate) fn set_write_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+        validate_timeout(timeout)?;
+        *lock_or_recover(&self.write_timeout) = timeout;
+        Ok(())
+    }
+
+    pub(crate) fn read_timeout(&self) -> Option<Duration> {
+        *lock_or_recover(&self.read_timeout)
+    }
+
+    pub(crate) fn write_timeout(&self) -> Option<Duration> {
+        *lock_or_recover(&self.write_timeout)
+    }
+
+    pub(crate) fn set_absolute_deadline(&self, deadline: Option<Instant>) {
+        *lock_or_recover(&self.absolute_deadline) = deadline;
+    }
+
+    pub(crate) fn shutdown(&self) -> io::Result<()> {
+        let server = WindowsNamedPipeServer {
+            inner: Arc::clone(&self.inner),
+        };
+        server.cancel_pending_io()?;
+        // SAFETY: this is the live server pipe handle. Cancelling does not
+        // free another operation's OVERLAPPED or buffer; each operation owner
+        // retains and observes its own state. Disconnect only breaks the pipe
+        // connection so peer and local waiters can finish.
+        if self.inner.connected.swap(false, Ordering::AcqRel)
+            && unsafe { DisconnectNamedPipe(server.raw_pipe()?) } == 0
+        {
+            let error = io::Error::last_os_error();
+            if !matches!(error.raw_os_error(), Some(109 | 232 | 233)) {
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    fn raw_pipe(&self) -> io::Result<*mut core::ffi::c_void> {
+        lock_or_recover(&self.inner.pipe)
+            .as_ref()
+            .map(AsRawHandle::as_raw_handle)
+            .ok_or_else(closed_pipe_error)
+    }
+}
+
+impl Read for WindowsNamedPipeStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let timeout = effective_timeout(
+            *lock_or_recover(&self.read_timeout),
+            *lock_or_recover(&self.absolute_deadline),
+        )?;
+        overlapped_io(
+            self.raw_pipe()?,
+            timeout,
+            buf.len(),
+            |handle, bytes, len, overlapped| {
+                // SAFETY: `bytes` points to `len` writable bytes owned by `buf` and
+                // remains live until this overlapped operation is observed.
+                unsafe { ReadFile(handle, bytes, len, ptr::null_mut(), overlapped) }
+            },
+            buf.as_mut_ptr().cast(),
+        )
+    }
+}
+
+impl Write for WindowsNamedPipeStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let timeout = effective_timeout(
+            *lock_or_recover(&self.write_timeout),
+            *lock_or_recover(&self.absolute_deadline),
+        )?;
+        overlapped_io(
+            self.raw_pipe()?,
+            timeout,
+            buf.len(),
+            |handle, bytes, len, overlapped| {
+                // SAFETY: `bytes` points to `len` readable bytes owned by `buf` and
+                // remains live until this overlapped operation is observed.
+                unsafe { WriteFile(handle, bytes, len, ptr::null_mut(), overlapped) }
+            },
+            buf.as_ptr().cast_mut().cast(),
+        )
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn overlapped_io(
+    handle: *mut core::ffi::c_void,
+    timeout: Option<Duration>,
+    buffer_len: usize,
+    start: impl FnOnce(*mut core::ffi::c_void, *mut u8, u32, *mut OVERLAPPED) -> i32,
+    bytes: *mut u8,
+) -> io::Result<usize> {
+    let event = OwnedEvent::new()?;
+    let mut overlapped = event.overlapped();
+    let len = u32::try_from(buffer_len.min(u32::MAX as usize)).map_err(io::Error::other)?;
+    let started = start(handle, bytes, len, &raw mut overlapped);
+    if started != 0 {
+        return observed_bytes(handle, &mut overlapped);
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() != Some(ERROR_IO_PENDING.cast_signed()) {
+        return Err(error);
+    }
+    let wait_ms = duration_to_wait_ms(timeout);
+    // SAFETY: event remains live and belongs to the live OVERLAPPED above.
+    match unsafe { WaitForSingleObject(event.raw(), wait_ms) } {
+        WAIT_OBJECT_0 => observed_bytes(handle, &mut overlapped),
+        WAIT_TIMEOUT => {
+            cancel_one_and_observe(handle, &mut overlapped)?;
+            Err(io::Error::from_raw_os_error(
+                ERROR_SEM_TIMEOUT.cast_signed(),
+            ))
+        }
+        WAIT_FAILED => {
+            let error = io::Error::last_os_error();
+            cancel_one_and_observe(handle, &mut overlapped)?;
+            Err(error)
+        }
+        other => {
+            cancel_one_and_observe(handle, &mut overlapped)?;
+            Err(io::Error::other(format!(
+                "unexpected overlapped wait result {other}"
+            )))
+        }
+    }
+}
+
+fn observed_bytes(
+    handle: *mut core::ffi::c_void,
+    overlapped: &mut OVERLAPPED,
+) -> io::Result<usize> {
+    let mut transferred = 0;
+    // SAFETY: this OVERLAPPED belongs to an operation on `handle`; its event
+    // signalled, and both remain live through this completion observation.
+    if unsafe { GetOverlappedResult(handle, overlapped, &raw mut transferred, 0) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    usize::try_from(transferred).map_err(io::Error::other)
+}
+
+fn cancel_one_and_observe(
+    handle: *mut core::ffi::c_void,
+    overlapped: &mut OVERLAPPED,
+) -> io::Result<()> {
+    // SAFETY: `overlapped` is the live state for this operation and will not
+    // be freed until GetOverlappedResult observes completion below.
+    if unsafe { CancelIoEx(handle, overlapped) } == 0 {
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() != Some(1168) {
+            return Err(error);
+        }
+    }
+    let mut transferred = 0;
+    // SAFETY: bWait=TRUE keeps the state live until cancellation or the racing
+    // normal completion is observed.
+    if unsafe { GetOverlappedResult(handle, overlapped, &raw mut transferred, 1) } == 0 {
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() != Some(ERROR_OPERATION_ABORTED.cast_signed()) {
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+fn wait_for_operation(
+    handle: *mut core::ffi::c_void,
+    overlapped: &mut OVERLAPPED,
+    operation_event: *mut core::ffi::c_void,
+    cancel_event: *mut core::ffi::c_void,
+    deadline: Option<Instant>,
+) -> io::Result<WaitOutcome> {
+    let handles = [cancel_event, operation_event];
+    let timeout = deadline
+        .and_then(|deadline| deadline.checked_duration_since(Instant::now()))
+        .map_or(INFINITE, |remaining| duration_to_wait_ms(Some(remaining)));
+    // SAFETY: both handles remain live for the wait; the array length is exact.
+    let result = unsafe {
+        WaitForMultipleObjects(
+            u32::try_from(handles.len()).map_err(io::Error::other)?,
+            handles.as_ptr(),
+            0,
+            timeout,
+        )
+    };
+    match result {
+        WAIT_OBJECT_0 => {
+            cancel_one_and_observe(handle, overlapped)?;
+            Ok(WaitOutcome::Cancelled)
+        }
+        value if value == WAIT_OBJECT_0 + 1 => match observed_bytes(handle, overlapped) {
+            Ok(_) => Ok(WaitOutcome::Ready),
+            Err(error) if matches!(error.raw_os_error(), Some(232 | 233)) => {
+                Ok(WaitOutcome::PeerClosed)
+            }
+            Err(error) => Err(error),
+        },
+        WAIT_TIMEOUT => {
+            cancel_one_and_observe(handle, overlapped)?;
+            Ok(WaitOutcome::DeadlineElapsed)
+        }
+        WAIT_FAILED => {
+            let error = io::Error::last_os_error();
+            cancel_one_and_observe(handle, overlapped)?;
+            Err(error)
+        }
+        other => {
+            cancel_one_and_observe(handle, overlapped)?;
+            Err(io::Error::other(format!(
+                "unexpected connect wait result {other}"
+            )))
+        }
+    }
+}
+
+struct OwnedEvent(OwnedHandle);
+
+#[cfg(test)]
+struct PendingAccept<'a>(&'a AtomicBool);
+
+#[cfg(test)]
+impl<'a> PendingAccept<'a> {
+    fn new(pending: &'a AtomicBool) -> Self {
+        pending.store(true, Ordering::Release);
+        Self(pending)
+    }
+}
+
+#[cfg(test)]
+impl Drop for PendingAccept<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+impl OwnedEvent {
+    fn new() -> io::Result<Self> {
+        // SAFETY: null security/name pointers request an unnamed manual-reset
+        // event. The returned non-null handle is transferred once below.
+        let raw = unsafe { CreateEventW(ptr::null(), 1, 0, ptr::null()) };
+        if raw.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: CreateEventW returned one valid uniquely owned handle.
+        Ok(Self(unsafe {
+            OwnedHandle::from_raw_handle(raw as RawHandle)
+        }))
+    }
+
+    fn raw(&self) -> *mut core::ffi::c_void {
+        self.0.as_raw_handle()
+    }
+
+    fn overlapped(&self) -> OVERLAPPED {
+        OVERLAPPED {
+            hEvent: self.raw(),
+            ..OVERLAPPED::default()
+        }
+    }
+}
+
+fn current_user_descriptor(sid: &Sid) -> io::Result<LocalBox<SecurityDescriptor>> {
+    let sid = ConvertSidToStringSid(sid)?;
+    format!(
+        "D:P(A;;0x{PIPE_ACCESS_MASK:08x};;;{})",
+        sid.to_string_lossy()
+    )
+    .parse()
+}
+
+fn read_security_facts(handle: &OwnedHandle) -> io::Result<PipeSecurityFacts> {
+    let descriptor = GetSecurityInfo(
+        handle,
+        SeObjectType::SE_KERNEL_OBJECT,
+        SecurityInformation::Dacl,
+    )?;
+    let current_sid = current_process_sid()?;
+    let sddl = descriptor.as_sddl()?;
+    let protected_dacl = sddl.to_string_lossy().contains("D:P");
+    let dacl = descriptor
+        .dacl()
+        .ok_or_else(|| io::Error::other("named-pipe descriptor contains no DACL"))?;
+    let ace = dacl.get_ace(0);
+    Ok(PipeSecurityFacts {
+        protected_dacl,
+        ace_count: usize::try_from(dacl.len()).map_err(io::Error::other)?,
+        one_ace_is_current_user: ace.and_then(|ace| ace.sid()) == Some(&current_sid),
+        one_ace_type: ace.map_or(u8::MAX, |ace| ace.ace_type() as u8),
+        one_ace_flags: ace.map_or(u8::MAX, |ace| ace.flags().bits()),
+        one_ace_mask: ace.map_or(0, |ace| ace.mask().bits()),
+        handle_flags: handle_flags(handle)?,
+    })
+}
+
+fn handle_flags(handle: &OwnedHandle) -> io::Result<u32> {
+    let mut flags = 0;
+    // SAFETY: `handle` is live and `flags` is a valid writable u32.
+    if unsafe { GetHandleInformation(handle.as_raw_handle(), &raw mut flags) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(flags)
+}
+
+fn duration_to_wait_ms(timeout: Option<Duration>) -> u32 {
+    let Some(timeout) = timeout else {
+        return INFINITE;
+    };
+    let millis = timeout.as_millis().max(1).min(u128::from(INFINITE - 1));
+    u32::try_from(millis).unwrap_or(INFINITE - 1)
+}
+
+fn validate_timeout(timeout: Option<Duration>) -> io::Result<()> {
+    if timeout == Some(Duration::ZERO) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "zero named-pipe I/O timeout is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn effective_timeout(
+    configured: Option<Duration>,
+    absolute_deadline: Option<Instant>,
+) -> io::Result<Option<Duration>> {
+    let Some(deadline) = absolute_deadline else {
+        return Ok(configured);
+    };
+    let remaining = deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| io::Error::from_raw_os_error(ERROR_SEM_TIMEOUT.cast_signed()))?;
+    Ok(Some(
+        configured.map_or(remaining, |timeout| timeout.min(remaining)),
+    ))
+}
+
+fn wide(value: &str) -> Vec<u16> {
+    OsStr::new(value).encode_wide().chain(Some(0)).collect()
+}
+
+fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn closed_pipe_error() -> io::Error {
+    io::Error::new(io::ErrorKind::NotConnected, "named-pipe handle is closed")
+}

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -41,6 +41,8 @@ use windows_sys::Win32::System::Pipes::{
 use windows_sys::Win32::System::Threading::{
     CreateEventW, INFINITE, SetEvent, WaitForMultipleObjects, WaitForSingleObject,
 };
+#[cfg(test)]
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, GetProcessHandleCount};
 
 const PIPE_BUFFER_BYTES: u32 = 64 * 1024;
 const PIPE_ACCESS_MASK: u32 = 0x0012_019B;
@@ -813,4 +815,15 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 
 fn closed_pipe_error() -> io::Error {
     io::Error::new(io::ErrorKind::NotConnected, "named-pipe handle is closed")
+}
+
+#[cfg(test)]
+pub(crate) fn process_handle_count() -> io::Result<u32> {
+    let mut count = 0;
+    // SAFETY: GetCurrentProcess returns the caller's valid pseudo-handle and
+    // `count` is a live writable u32 for the duration of the query.
+    if unsafe { GetProcessHandleCount(GetCurrentProcess(), &raw mut count) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(count)
 }

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -12,6 +12,8 @@ use std::io::{self, Read, Write};
 use std::os::windows::ffi::OsStrExt as _;
 use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
 use std::ptr;
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
 use std::time::{Duration, Instant};
@@ -63,6 +65,8 @@ struct ServerInner {
     consumed: AtomicBool,
     #[cfg(test)]
     accept_pending: AtomicBool,
+    #[cfg(test)]
+    active_stream_io: AtomicUsize,
 }
 
 /// One host-owned named-pipe instance.
@@ -151,6 +155,8 @@ impl WindowsNamedPipeServer {
                 consumed: AtomicBool::new(false),
                 #[cfg(test)]
                 accept_pending: AtomicBool::new(false),
+                #[cfg(test)]
+                active_stream_io: AtomicUsize::new(0),
             }),
         };
         server.validate_security(&current_sid)?;
@@ -318,6 +324,8 @@ impl WindowsNamedPipeServer {
                 consumed: AtomicBool::new(true),
                 #[cfg(test)]
                 accept_pending: AtomicBool::new(false),
+                #[cfg(test)]
+                active_stream_io: AtomicUsize::new(0),
             }),
             read_timeout: Mutex::new(None),
             write_timeout: Mutex::new(None),
@@ -493,6 +501,11 @@ impl WindowsNamedPipeStream {
         Ok(())
     }
 
+    #[cfg(test)]
+    pub(crate) fn has_active_io(&self) -> bool {
+        self.inner.active_stream_io.load(Ordering::Acquire) != 0
+    }
+
     fn raw_pipe(&self) -> io::Result<*mut core::ffi::c_void> {
         lock_or_recover(&self.inner.pipe)
             .as_ref()
@@ -510,6 +523,8 @@ impl Read for WindowsNamedPipeStream {
             *lock_or_recover(&self.read_timeout),
             *lock_or_recover(&self.absolute_deadline),
         )?;
+        #[cfg(test)]
+        let _active = ActiveStreamIo::new(&self.inner.active_stream_io);
         overlapped_io(
             self.raw_pipe()?,
             timeout,
@@ -533,6 +548,8 @@ impl Write for WindowsNamedPipeStream {
             *lock_or_recover(&self.write_timeout),
             *lock_or_recover(&self.absolute_deadline),
         )?;
+        #[cfg(test)]
+        let _active = ActiveStreamIo::new(&self.inner.active_stream_io);
         overlapped_io(
             self.raw_pipe()?,
             timeout,
@@ -686,6 +703,9 @@ struct OwnedEvent(OwnedHandle);
 struct PendingAccept<'a>(&'a AtomicBool);
 
 #[cfg(test)]
+struct ActiveStreamIo<'a>(&'a AtomicUsize);
+
+#[cfg(test)]
 impl<'a> PendingAccept<'a> {
     fn new(pending: &'a AtomicBool) -> Self {
         pending.store(true, Ordering::Release);
@@ -697,6 +717,21 @@ impl<'a> PendingAccept<'a> {
 impl Drop for PendingAccept<'_> {
     fn drop(&mut self) {
         self.0.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+impl<'a> ActiveStreamIo<'a> {
+    fn new(active: &'a AtomicUsize) -> Self {
+        active.fetch_add(1, Ordering::AcqRel);
+        Self(active)
+    }
+}
+
+#[cfg(test)]
+impl Drop for ActiveStreamIo<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
     }
 }
 

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -264,6 +264,9 @@ impl WindowsNamedPipeServer {
     pub(crate) fn close_terminal(&self) -> io::Result<()> {
         self.inner.consumed.store(true, Ordering::Release);
         self.cancel_pending_io()?;
+        // SAFETY: the server owns the live handle and all pending operations
+        // were cancelled; their owners retain state until they observe
+        // completion. Disconnect does not free an OVERLAPPED or its buffer.
         if self.inner.connected.swap(false, Ordering::AcqRel)
             && unsafe { DisconnectNamedPipe(self.raw_pipe()?) } == 0
         {

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -297,7 +297,7 @@ impl WindowsNamedPipeServer {
             && unsafe { DisconnectNamedPipe(self.raw_pipe()?) } == 0
         {
             let error = io::Error::last_os_error();
-            if !matches!(error.raw_os_error(), Some(109 | 233)) {
+            if !matches!(error.raw_os_error(), Some(109 | 232 | 233)) {
                 return Err(error);
             }
         }
@@ -644,12 +644,7 @@ fn overlapped_io(
     // SAFETY: event remains live and belongs to the live OVERLAPPED above.
     match unsafe { WaitForSingleObject(event.raw(), wait_ms) } {
         WAIT_OBJECT_0 => observed_bytes(handle, &mut overlapped),
-        WAIT_TIMEOUT => {
-            cancel_one_and_observe(handle, &mut overlapped)?;
-            Err(io::Error::from_raw_os_error(
-                ERROR_SEM_TIMEOUT.cast_signed(),
-            ))
-        }
+        WAIT_TIMEOUT => timeout_io_result(cancel_one_and_observe(handle, &mut overlapped)?),
         WAIT_FAILED => {
             let error = io::Error::last_os_error();
             cancel_one_and_observe(handle, &mut overlapped)?;
@@ -677,28 +672,51 @@ fn observed_bytes(
     usize::try_from(transferred).map_err(io::Error::other)
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum CancelledOperation {
+    Aborted,
+    Completed(usize),
+}
+
+fn timeout_io_result(observation: CancelledOperation) -> io::Result<usize> {
+    match observation {
+        CancelledOperation::Aborted => Err(io::Error::from_raw_os_error(
+            ERROR_SEM_TIMEOUT.cast_signed(),
+        )),
+        CancelledOperation::Completed(transferred) => Ok(transferred),
+    }
+}
+
 fn cancel_one_and_observe(
     handle: *mut core::ffi::c_void,
     overlapped: &mut OVERLAPPED,
-) -> io::Result<()> {
+) -> io::Result<CancelledOperation> {
     // SAFETY: `overlapped` is the live state for this operation and will not
     // be freed until GetOverlappedResult observes completion below.
-    if unsafe { CancelIoEx(handle, overlapped) } == 0 {
+    let cancel_error = if unsafe { CancelIoEx(handle, overlapped) } == 0 {
         let error = io::Error::last_os_error();
-        if error.raw_os_error() != Some(1168) {
-            return Err(error);
+        if error.raw_os_error() == Some(1168) {
+            None
+        } else {
+            Some(error)
         }
-    }
+    } else {
+        None
+    };
     let mut transferred = 0;
     // SAFETY: bWait=TRUE keeps the state live until cancellation or the racing
     // normal completion is observed.
-    if unsafe { GetOverlappedResult(handle, overlapped, &raw mut transferred, 1) } == 0 {
-        let error = io::Error::last_os_error();
-        if error.raw_os_error() != Some(ERROR_OPERATION_ABORTED.cast_signed()) {
-            return Err(error);
-        }
-    }
-    Ok(())
+    let observation =
+        if unsafe { GetOverlappedResult(handle, overlapped, &raw mut transferred, 1) } == 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() != Some(ERROR_OPERATION_ABORTED.cast_signed()) {
+                return Err(error);
+            }
+            CancelledOperation::Aborted
+        } else {
+            CancelledOperation::Completed(usize::try_from(transferred).map_err(io::Error::other)?)
+        };
+    cancel_error.map_or(Ok(observation), Err)
 }
 
 fn wait_for_operation(
@@ -947,4 +965,23 @@ pub(crate) fn process_handle_count() -> io::Result<u32> {
         return Err(io::Error::last_os_error());
     }
     Ok(count)
+}
+
+#[cfg(test)]
+mod cancellation_tests {
+    use super::{CancelledOperation, timeout_io_result};
+
+    #[test]
+    fn timeout_preserves_bytes_from_a_racing_normal_completion() {
+        assert_eq!(
+            timeout_io_result(CancelledOperation::Completed(7)).expect("completed transfer"),
+            7
+        );
+        assert_eq!(
+            timeout_io_result(CancelledOperation::Aborted)
+                .expect_err("aborted transfer remains a timeout")
+                .raw_os_error(),
+            Some(121)
+        );
+    }
 }

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -41,7 +41,7 @@ use windows_sys::Win32::System::Pipes::{
     PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_BYTE, PIPE_WAIT,
 };
 use windows_sys::Win32::System::Threading::{
-    CreateEventW, INFINITE, SetEvent, WaitForMultipleObjects, WaitForSingleObject,
+    CreateEventW, INFINITE, ResetEvent, SetEvent, WaitForMultipleObjects, WaitForSingleObject,
 };
 #[cfg(test)]
 use windows_sys::Win32::System::Threading::{GetCurrentProcess, GetProcessHandleCount};
@@ -61,6 +61,7 @@ pub(crate) enum WaitOutcome {
 struct ServerInner {
     pipe: Mutex<Option<OwnedHandle>>,
     cancel_event: OwnedHandle,
+    connect_event: OwnedEvent,
     connected: AtomicBool,
     consumed: AtomicBool,
     #[cfg(test)]
@@ -85,6 +86,8 @@ pub(crate) struct WindowsNamedPipeCanceller {
 #[derive(Debug)]
 pub(crate) struct WindowsNamedPipeStream {
     inner: Arc<ServerInner>,
+    read_event: OwnedEvent,
+    write_event: OwnedEvent,
     read_timeout: Mutex<Option<Duration>>,
     write_timeout: Mutex<Option<Duration>>,
     absolute_deadline: Mutex<Option<Instant>>,
@@ -146,11 +149,13 @@ impl WindowsNamedPipeServer {
         }
         // SAFETY: CreateEventW returned one valid owned handle, transferred once.
         let cancel_event = unsafe { OwnedHandle::from_raw_handle(raw_cancel as RawHandle) };
+        let connect_event = OwnedEvent::new()?;
 
         let server = Self {
             inner: Arc::new(ServerInner {
                 pipe: Mutex::new(Some(pipe)),
                 cancel_event,
+                connect_event,
                 connected: AtomicBool::new(false),
                 consumed: AtomicBool::new(false),
                 #[cfg(test)]
@@ -170,7 +175,8 @@ impl WindowsNamedPipeServer {
                 "named-pipe bootstrap already consumed",
             ));
         }
-        let operation_event = OwnedEvent::new()?;
+        let operation_event = &self.inner.connect_event;
+        operation_event.reset()?;
         let mut overlapped = operation_event.overlapped();
         // SAFETY: the pipe was created for overlapped I/O; `overlapped` and
         // its event remain live until completion is observed below.
@@ -233,13 +239,15 @@ impl WindowsNamedPipeServer {
         Ok(())
     }
 
-    pub(crate) fn stream(&self) -> WindowsNamedPipeStream {
-        WindowsNamedPipeStream {
+    pub(crate) fn stream(&self) -> io::Result<WindowsNamedPipeStream> {
+        Ok(WindowsNamedPipeStream {
             inner: Arc::clone(&self.inner),
+            read_event: OwnedEvent::new()?,
+            write_event: OwnedEvent::new()?,
             read_timeout: Mutex::new(None),
             write_timeout: Mutex::new(None),
             absolute_deadline: Mutex::new(None),
-        }
+        })
     }
 
     pub(crate) fn consume(&self) {
@@ -316,10 +324,12 @@ impl WindowsNamedPipeServer {
         }
         // SAFETY: CreateEventW returned a valid newly owned handle.
         let cancel_event = unsafe { OwnedHandle::from_raw_handle(raw_cancel as RawHandle) };
+        let connect_event = OwnedEvent::new()?;
         Ok(WindowsNamedPipeStream {
             inner: Arc::new(ServerInner {
                 pipe: Mutex::new(Some(pipe)),
                 cancel_event,
+                connect_event,
                 connected: AtomicBool::new(true),
                 consumed: AtomicBool::new(true),
                 #[cfg(test)]
@@ -327,6 +337,8 @@ impl WindowsNamedPipeServer {
                 #[cfg(test)]
                 active_stream_io: AtomicUsize::new(0),
             }),
+            read_event: OwnedEvent::new()?,
+            write_event: OwnedEvent::new()?,
             read_timeout: Mutex::new(None),
             write_timeout: Mutex::new(None),
             absolute_deadline: Mutex::new(None),
@@ -448,13 +460,15 @@ impl WindowsNamedPipeCanceller {
 }
 
 impl WindowsNamedPipeStream {
-    pub(crate) fn try_clone(&self) -> Self {
-        Self {
+    pub(crate) fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
             inner: Arc::clone(&self.inner),
+            read_event: OwnedEvent::new()?,
+            write_event: OwnedEvent::new()?,
             read_timeout: Mutex::new(*lock_or_recover(&self.read_timeout)),
             write_timeout: Mutex::new(*lock_or_recover(&self.write_timeout)),
             absolute_deadline: Mutex::new(*lock_or_recover(&self.absolute_deadline)),
-        }
+        })
     }
 
     pub(crate) fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
@@ -526,6 +540,7 @@ impl Read for WindowsNamedPipeStream {
         #[cfg(test)]
         let _active = ActiveStreamIo::new(&self.inner.active_stream_io);
         overlapped_io(
+            &self.read_event,
             self.raw_pipe()?,
             timeout,
             buf.len(),
@@ -551,6 +566,7 @@ impl Write for WindowsNamedPipeStream {
         #[cfg(test)]
         let _active = ActiveStreamIo::new(&self.inner.active_stream_io);
         overlapped_io(
+            &self.write_event,
             self.raw_pipe()?,
             timeout,
             buf.len(),
@@ -569,13 +585,14 @@ impl Write for WindowsNamedPipeStream {
 }
 
 fn overlapped_io(
+    event: &OwnedEvent,
     handle: *mut core::ffi::c_void,
     timeout: Option<Duration>,
     buffer_len: usize,
     start: impl FnOnce(*mut core::ffi::c_void, *mut u8, u32, *mut OVERLAPPED) -> i32,
     bytes: *mut u8,
 ) -> io::Result<usize> {
-    let event = OwnedEvent::new()?;
+    event.reset()?;
     let mut overlapped = event.overlapped();
     let len = u32::try_from(buffer_len.min(u32::MAX as usize)).map_err(io::Error::other)?;
     let started = start(handle, bytes, len, &raw mut overlapped);
@@ -697,6 +714,7 @@ fn wait_for_operation(
     }
 }
 
+#[derive(Debug)]
 struct OwnedEvent(OwnedHandle);
 
 #[cfg(test)]
@@ -751,6 +769,14 @@ impl OwnedEvent {
 
     fn raw(&self) -> *mut core::ffi::c_void {
         self.0.as_raw_handle()
+    }
+
+    fn reset(&self) -> io::Result<()> {
+        // SAFETY: this object owns the live manual-reset event handle.
+        if unsafe { ResetEvent(self.raw()) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
     }
 
     fn overlapped(&self) -> OVERLAPPED {

--- a/docs/specs/kel101-windows-named-pipe-dacl.md
+++ b/docs/specs/kel101-windows-named-pipe-dacl.md
@@ -340,7 +340,7 @@ remains Done for token possession only; KEL-101 closes the OS-object divergence.
 
 - [x] T1: approve the reused safe DACL wrapper plus narrow raw pipe/overlapped
   ABI owner, foreign-user fixture, review gates, and rollback boundary.
-- [ ] T2: add Windows shared bootstrap, exact DACL, overlapped state machine,
+- [x] T2: add Windows shared bootstrap, exact DACL, overlapped state machine,
   cancellation, redacted rejection, and inheritance proof with focused tests.
 - [ ] T3: atomically migrate echo server, diagnostics, and Bun template/client;
   retain only explicit decimal-port diagnostic consumption and prove bad-then-good HELLO.


### PR DESCRIPTION
## Summary
Adds the opt-in KEL-101/T2 Windows named-pipe bootstrap in `keld-ipc` without migrating shipping consumers. The host-owned first instance uses a protected one-ACE current-TokenUser DACL, remote-client rejection, non-inheritable handles, overlapped accept/read/write, cancellation with observed completion, absolute deadlines, unchanged v2 HELLO authentication, and the shared redacted rejection taxonomy. `BootstrapListener::bind()` remains TCP until T3.

The out-of-scope synchronous orderly-drain experiment was removed because Windows does not guarantee bounded completion after `CancelSynchronousIo`. T3 owns product-consumer close semantics.

## Spec refs
`docs/specs/kel101-windows-named-pipe-dacl.md` T2. No T3 product migration or architecture LIVE claim is included.

## Review gates
- unsafe: applicable; only `windows_named_pipe.rs` owns the Win32 ABI, denies `unsafe_op_in_unsafe_fn`, and has local safety proofs.
- public API: applicable; adds opt-in Windows listener/cancellation/stream types while preserving the concrete default `BootstrapAdmission` API.
- permission model: applicable; exact protected current-user DACL mask `0x0012019B`, first/one instance, remote rejection, and OS readback.
- dependency addition: applicable; target-only use of existing workspace-pinned `windows-permissions 0.2.4` and `windows-sys 0.61.2`.
- wire protocol: none; frame bytes, v2, token, and HELLO remain unchanged.

## Tests
Exact head `bf07257`: local `just ci` passed with 520/520 tests, workspace clippy `-D warnings`, rustfmt, rustdoc, Mermaid render, hygiene, and cargo-deny. GitHub CI run 33391643745 passed Windows/macOS/Ubuntu clippy+test, Linux GUI, MSRV, cargo-deny, rustfmt, gitleaks, CODEOWNERS, and required result. Focused real-Windows named-pipe tests passed 17/17 and the cancellation-race test passed 1/1. All five CodeRabbit threads are resolved; exact-tip isolated unsafe/lifecycle, cross-scope, and final reviews found no blockers.

## Platforms
Windows 11 real-OS DACL/ACE/SID, handle inheritance, remote-mode, overlapped cancellation/deadline, Bun `node:net` HELLO+echo, and process handle-census evidence passed. GitHub Windows, macOS, and Ubuntu lanes passed. T4 retains the different-user Windows product fixture.

## Perf impact
None claimed. This is a cold-path security transport implementation.

T3 product-consumer migration, T4 foreign-user Windows evidence/LIVE docs, and T5 decimal compatibility cleanup remain separate. KEL-101 remains In Progress after T2.