### PR TITLE
fix(ipc): wait for busy named-pipe instance

### DIFF
--- a/crates/keld-ipc/src/bootstrap.rs
+++ b/crates/keld-ipc/src/bootstrap.rs
@@ -943,7 +943,10 @@ impl WindowsNamedPipeBootstrapStream {
                 "Windows app-link endpoint is not an exact Keld named pipe",
             ));
         }
-        WindowsNamedPipeServer::connect_client(endpoint).map(Self)
+        let deadline = Instant::now()
+            .checked_add(APP_LINK_IO_DEADLINE)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "deadline overflow"))?;
+        WindowsNamedPipeServer::connect_client_until(endpoint, deadline).map(Self)
     }
 
     /// Duplicates the Rust stream view while retaining the same owned pipe
@@ -962,7 +965,7 @@ impl WindowsNamedPipeBootstrapStream {
 mod named_pipe_tests {
     #![allow(unsafe_code)] // test-only independent Win32 descriptor/handle oracle
 
-    use std::io::{Read as _, Write as _};
+    use std::io::{self, Read as _, Write as _};
     use std::os::windows::io::AsRawHandle as _;
     use std::process::{Child, Command, Output, Stdio};
     use std::sync::{Arc, Mutex, mpsc};
@@ -978,7 +981,7 @@ mod named_pipe_tests {
     use crate::link::{AppLinkDeadlines, handshake_client};
     use crate::serve_echo_requests;
     use crate::token::{SessionToken, parse_app_link};
-    use crate::windows_named_pipe::{WindowsNamedPipeServer, process_handle_count};
+    use crate::windows_named_pipe::{WaitOutcome, WindowsNamedPipeServer, process_handle_count};
     use crate::{ChannelId, CorrelationId, FrameHeader, FrameKind, MAX_FRAME_LEN};
 
     use super::{
@@ -1289,6 +1292,106 @@ socket.end();
         let collision = WindowsNamedPipeServer::bind(endpoint)
             .expect_err("FILE_FLAG_FIRST_PIPE_INSTANCE must reject a second server");
         assert_eq!(collision.raw_os_error(), Some(5));
+    }
+
+    #[test]
+    fn shipping_client_waits_for_busy_instance_then_connects() {
+        let listener = WindowsNamedPipeBootstrapListener::bind().expect("bind");
+        let endpoint = listener.endpoint().to_owned();
+        let server = lock_or_recover(&listener.server)
+            .as_ref()
+            .cloned()
+            .expect("live server");
+        let first = WindowsNamedPipeServer::connect_client(&endpoint).expect("first client");
+        assert!(matches!(
+            server
+                .accept_until(Some(Instant::now() + Duration::from_secs(1)))
+                .expect("accept first client"),
+            WaitOutcome::Ready
+        ));
+        let busy = WindowsNamedPipeServer::connect_client(&endpoint)
+            .expect_err("one-shot open must expose the busy-instance control");
+        assert_eq!(busy.raw_os_error(), Some(231));
+
+        let (busy_tx, busy_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+        let connector = thread::spawn(move || {
+            WindowsNamedPipeServer::install_connect_busy_witness(busy_tx);
+            let _ = result_tx.send(WindowsNamedPipeBootstrapStream::connect(&endpoint));
+        });
+        busy_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("shipping client must causally observe ERROR_PIPE_BUSY");
+
+        server.disconnect_for_retry().expect("release first client");
+        assert!(matches!(
+            server
+                .accept_until(Some(Instant::now() + Duration::from_secs(1)))
+                .expect("rearm server for shipping client"),
+            WaitOutcome::Ready
+        ));
+        let second = result_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("shipping client must finish after rearm")
+            .expect("shipping client must connect after rearm");
+        connector.join().expect("join shipping connector");
+        drop(first);
+        drop(second);
+        server.close_terminal().expect("close test server");
+    }
+
+    #[test]
+    fn busy_client_deadline_is_timeout_and_past_deadline_never_connects() {
+        let listener = WindowsNamedPipeBootstrapListener::bind().expect("bind busy listener");
+        let endpoint = listener.endpoint().to_owned();
+        let server = lock_or_recover(&listener.server)
+            .as_ref()
+            .cloned()
+            .expect("live busy server");
+        let first = WindowsNamedPipeServer::connect_client(&endpoint).expect("first client");
+        assert!(matches!(
+            server
+                .accept_until(Some(Instant::now() + Duration::from_secs(1)))
+                .expect("accept first client"),
+            WaitOutcome::Ready
+        ));
+        let started = Instant::now();
+        let timeout = WindowsNamedPipeServer::connect_client_until(
+            &endpoint,
+            started + Duration::from_millis(40),
+        )
+        .expect_err("permanently busy instance must hit its deadline");
+        assert_eq!(timeout.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(timeout.raw_os_error(), Some(121));
+        assert!(
+            started.elapsed() >= Duration::from_millis(30),
+            "busy-instance wait returned materially before its 40 ms deadline"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "busy-instance deadline exceeded its kill bound"
+        );
+        drop(first);
+        server.close_terminal().expect("close busy server");
+
+        let available = WindowsNamedPipeBootstrapListener::bind().expect("bind available listener");
+        let past = Instant::now()
+            .checked_sub(Duration::from_millis(1))
+            .expect("representable past deadline");
+        let timeout = WindowsNamedPipeServer::connect_client_until(available.endpoint(), past)
+            .expect_err("past deadline must not open an available instance");
+        assert_eq!(timeout.kind(), io::ErrorKind::TimedOut);
+        let available_server = lock_or_recover(&available.server)
+            .as_ref()
+            .cloned()
+            .expect("live available server");
+        assert!(matches!(
+            available_server
+                .accept_until(Some(Instant::now() + Duration::from_millis(40)))
+                .expect("observe available server after past-deadline call"),
+            WaitOutcome::DeadlineElapsed
+        ));
+        available.shutdown().expect("close available listener");
     }
 
     #[test]

--- a/crates/keld-ipc/src/windows_named_pipe.rs
+++ b/crates/keld-ipc/src/windows_named_pipe.rs
@@ -17,6 +17,8 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
 use std::time::{Duration, Instant};
+#[cfg(test)]
+use std::{cell::RefCell, sync::mpsc};
 
 use windows_permissions::constants::{AceFlags, AceType, SeObjectType, SecurityInformation};
 use windows_permissions::utilities::current_process_sid;
@@ -33,7 +35,6 @@ use windows_sys::Win32::Storage::FileSystem::{
     PIPE_ACCESS_DUPLEX, ReadFile, WriteFile,
 };
 use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult, OVERLAPPED};
-#[cfg(test)]
 use windows_sys::Win32::System::Pipes::WaitNamedPipeW;
 use windows_sys::Win32::System::Pipes::{
     ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, GetNamedPipeInfo, PIPE_READMODE_BYTE,
@@ -47,6 +48,11 @@ use windows_sys::Win32::System::Threading::{GetCurrentProcess, GetProcessHandleC
 
 const PIPE_BUFFER_BYTES: u32 = 64 * 1024;
 const PIPE_ACCESS_MASK: u32 = 0x0012_019B;
+
+#[cfg(test)]
+thread_local! {
+    static CONNECT_BUSY_WITNESS: RefCell<Option<mpsc::Sender<()>>> = const { RefCell::new(None) };
+}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum WaitOutcome {
@@ -366,32 +372,55 @@ impl WindowsNamedPipeServer {
         self.inner.accept_pending.load(Ordering::Acquire)
     }
 
-    #[cfg(test)]
     pub(crate) fn connect_client_until(
         endpoint: &str,
         deadline: Instant,
     ) -> io::Result<WindowsNamedPipeStream> {
         let endpoint_wide = wide(endpoint);
         loop {
+            if Instant::now() >= deadline {
+                return Err(connect_deadline_error());
+            }
             match Self::connect_client(endpoint) {
-                Ok(stream) => return Ok(stream),
+                Ok(stream) => {
+                    if Instant::now() >= deadline {
+                        drop(stream);
+                        return Err(connect_deadline_error());
+                    }
+                    return Ok(stream);
+                }
                 Err(error) if error.raw_os_error() == Some(231) => {
+                    #[cfg(test)]
+                    CONNECT_BUSY_WITNESS.with(|witness| {
+                        if let Some(witness) = witness.borrow_mut().take() {
+                            let _ = witness.send(());
+                        }
+                    });
                     let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
-                        return Err(io::Error::from_raw_os_error(231));
+                        return Err(connect_deadline_error());
                     };
                     let wait_ms = duration_to_wait_ms(Some(remaining));
                     // SAFETY: `endpoint_wide` is a live NUL-terminated path;
                     // the bounded wait does not retain its pointer.
                     if unsafe { WaitNamedPipeW(endpoint_wide.as_ptr(), wait_ms) } == 0 {
                         let wait_error = io::Error::last_os_error();
-                        if wait_error.raw_os_error() != Some(ERROR_SEM_TIMEOUT.cast_signed()) {
-                            return Err(wait_error);
+                        if wait_error.raw_os_error() == Some(ERROR_SEM_TIMEOUT.cast_signed()) {
+                            if Instant::now() < deadline {
+                                continue;
+                            }
+                            return Err(connect_deadline_error());
                         }
+                        return Err(wait_error);
                     }
                 }
                 Err(error) => return Err(error),
             }
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_connect_busy_witness(witness: mpsc::Sender<()>) {
+        CONNECT_BUSY_WITNESS.with(|slot| *slot.borrow_mut() = Some(witness));
     }
 
     fn validate_security(&self, current_sid: &Sid) -> io::Result<()> {
@@ -915,6 +944,10 @@ fn duration_to_wait_ms(timeout: Option<Duration>) -> u32 {
     };
     let millis = timeout.as_millis().max(1).min(u128::from(INFINITE - 1));
     u32::try_from(millis).unwrap_or(INFINITE - 1)
+}
+
+fn connect_deadline_error() -> io::Error {
+    io::Error::from_raw_os_error(ERROR_SEM_TIMEOUT.cast_signed())
 }
 
 fn validate_timeout(timeout: Option<Duration>) -> io::Result<()> {


### PR DESCRIPTION
## Summary

- Bound shipping Windows named-pipe client opens by the existing app-link deadline.
- Treat transient `ERROR_PIPE_BUSY` with `WaitNamedPipeW`, preserving timeout and non-timeout error classes.
- Add causal real-Windows busy/rearm, permanent-busy deadline, and past-deadline no-connection regressions.

## Spec refs

KEL-101 §4 admission/deadline contract. No ownership, principal, permission, or wire boundary change.

## Review gates

- unsafe: yes — existing `WaitNamedPipeW` call promoted inside sanctioned `windows_named_pipe`; exact-tip independent review clean.
- public API: yes — connect now waits only within the existing app-link deadline; exact-tip independent review clean.
- permission model: none
- dependency addition: none
- wire protocol: none

## Tests

- Focused Windows busy/rearm and deadline tests pass; one-shot negative control fails and was restored.
- 20/20 repetitions of the original core wrong-token/legitimate-client regression passed.
- Exact final-tip local `just ci` passed: 526/526 tests (2 known leaky, 2 skipped), format, workspace Clippy with warnings denied, rustdoc, hygiene/instruction/atomic/router gates, Mermaid render, llms, and cargo-deny. Two independent exact-tip reviewers reported no actionable findings.

## Platforms

Real Windows 11 evidence. Cross-platform code paths are unchanged; GitHub matrix remains required.

## Perf impact

No performance claim. The cold connection path may wait up to the existing app-link deadline only after `ERROR_PIPE_BUSY`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows connection handling when the communication channel is busy, allowing clients to wait briefly for availability instead of failing unexpectedly.
  - Added consistent connection deadlines so attempts stop promptly when the configured limit is reached.
  - Expired connection requests now return a clear input error rather than hanging or reporting an unrelated failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
