### PR TITLE
fix(host): harden Windows renderer beacon framing (KEL-163)

### DIFF
--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -31,6 +31,7 @@ const PRODUCT_TITLE: &str = "KEL96 T4 Windows Fixture";
 const PRODUCT_DEADLINE: Duration = Duration::from_secs(20);
 const RENDERER_ACCEPT_POLL: Duration = Duration::from_millis(10);
 const RENDERER_CONNECTION_LIMIT: usize = 16;
+const RENDERER_REQUEST_LINE_LIMIT: usize = 2048;
 const SYSTEM_EXTENDED_HANDLE_INFORMATION: u32 = 64;
 const STATUS_INFO_LENGTH_MISMATCH: i32 = -1_073_741_820;
 const OBJ_INHERIT: u32 = 0x0000_0002;
@@ -1378,15 +1379,14 @@ fn read_renderer_request_line(
     request: &mut Vec<u8>,
     mut read_chunk: impl FnMut(&mut [u8]) -> std::io::Result<usize>,
 ) -> Result<RendererRequestRead, String> {
-    const REQUEST_LINE_LIMIT: usize = 2048;
     loop {
-        if request.len() == REQUEST_LINE_LIMIT {
+        if request.len() == RENDERER_REQUEST_LINE_LIMIT {
             return Err(format!(
-                "renderer beacon request line exceeded {REQUEST_LINE_LIMIT} bytes"
+                "renderer beacon request line exceeded {RENDERER_REQUEST_LINE_LIMIT} bytes"
             ));
         }
         let mut chunk = [0_u8; 256];
-        let available = (REQUEST_LINE_LIMIT - request.len()).min(chunk.len());
+        let available = (RENDERER_REQUEST_LINE_LIMIT - request.len()).min(chunk.len());
         let read = match read_chunk(&mut chunk[..available]) {
             Ok(read) => read,
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
@@ -1459,6 +1459,29 @@ fn renderer_beacon_accumulates_a_fragmented_request_line() {
 }
 
 #[test]
+fn renderer_beacon_request_line_enforces_exact_maximum_and_maximum_plus_one() {
+    let exact = vec![b'a'; RENDERER_REQUEST_LINE_LIMIT - 2];
+    let mut exact_wire = exact.clone();
+    exact_wire.extend_from_slice(b"\r\n");
+    let mut exact_cursor = std::io::Cursor::new(exact_wire);
+    let mut request = Vec::new();
+    let result = read_renderer_request_line(&mut request, |buffer| exact_cursor.read(buffer))
+        .expect("exact-limit request line");
+    assert_eq!(result, RendererRequestRead::Complete(exact));
+
+    let mut oversized_wire = vec![b'b'; RENDERER_REQUEST_LINE_LIMIT - 1];
+    oversized_wire.extend_from_slice(b"\r\n");
+    let mut oversized_cursor = std::io::Cursor::new(oversized_wire);
+    let mut request = Vec::new();
+    let error = read_renderer_request_line(&mut request, |buffer| oversized_cursor.read(buffer))
+        .expect_err("maximum-plus-one request line must fail");
+    assert_eq!(
+        error,
+        format!("renderer beacon request line exceeded {RENDERER_REQUEST_LINE_LIMIT} bytes")
+    );
+}
+
+#[test]
 fn renderer_beacon_ignores_an_empty_preconnect_before_the_exact_request() {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind beacon regression listener");
     let address = listener.local_addr().expect("beacon regression address");
@@ -1505,7 +1528,7 @@ fn renderer_beacon_serves_before_the_parent_activates_its_wait_deadline() {
 fn renderer_beacon_does_not_serialize_idle_preconnects_before_the_exact_request() {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind idle-preconnect listener");
     let address = listener.local_addr().expect("idle-preconnect address");
-    let idle = (0..5)
+    let idle = (0..(RENDERER_CONNECTION_LIMIT - 1))
         .map(|_| TcpStream::connect(address).expect("queue idle preconnect"))
         .collect::<Vec<_>>();
     let deadline = Instant::now() + Duration::from_secs(2);
@@ -1525,6 +1548,24 @@ fn renderer_beacon_does_not_serialize_idle_preconnects_before_the_exact_request(
     beacon.join().expect("idle-preconnect beacon thread");
     let result = observed.expect("idle peers serialized ahead of the exact request");
     assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn renderer_beacon_rejects_maximum_plus_one_pending_connections() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind connection-limit listener");
+    let address = listener.local_addr().expect("connection-limit address");
+    let pending = (0..=RENDERER_CONNECTION_LIMIT)
+        .map(|_| TcpStream::connect(address).expect("queue pending connection"))
+        .collect::<Vec<_>>();
+    let result = serve_renderer_beacon_until(&listener, Instant::now() + Duration::from_secs(1));
+    drop(pending);
+
+    assert_eq!(
+        result,
+        Err(format!(
+            "renderer beacon exceeded {RENDERER_CONNECTION_LIMIT} pending connections"
+        ))
+    );
 }
 
 #[test]

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -1309,26 +1309,6 @@ fn serve_renderer_beacon_loop(
             })
             .transpose()?;
 
-        loop {
-            let (stream, _) = match listener.accept() {
-                Ok(accepted) => accepted,
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
-                Err(error) => return Err(format!("accept renderer beacon: {error}")),
-            };
-            if pending.len() == RENDERER_CONNECTION_LIMIT {
-                return Err(format!(
-                    "renderer beacon exceeded {RENDERER_CONNECTION_LIMIT} pending connections"
-                ));
-            }
-            stream
-                .set_nonblocking(true)
-                .map_err(|error| format!("set renderer beacon stream nonblocking: {error}"))?;
-            pending.push(PendingRendererRequest {
-                stream,
-                request: Vec::new(),
-            });
-        }
-
         let mut index = 0;
         while index < pending.len() {
             let request = {
@@ -1365,6 +1345,26 @@ fn serve_renderer_beacon_loop(
                     return Ok(());
                 }
             }
+        }
+
+        match listener.accept() {
+            Ok((stream, _)) => {
+                if pending.len() == RENDERER_CONNECTION_LIMIT {
+                    return Err(format!(
+                        "renderer beacon exceeded {RENDERER_CONNECTION_LIMIT} pending connections"
+                    ));
+                }
+                stream
+                    .set_nonblocking(true)
+                    .map_err(|error| format!("set renderer beacon stream nonblocking: {error}"))?;
+                pending.push(PendingRendererRequest {
+                    stream,
+                    request: Vec::new(),
+                });
+                continue;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(error) => return Err(format!("accept renderer beacon: {error}")),
         }
 
         // This only backs off the nonblocking kernel poll; socket readiness
@@ -1548,6 +1548,35 @@ fn renderer_beacon_does_not_serialize_idle_preconnects_before_the_exact_request(
     beacon.join().expect("idle-preconnect beacon thread");
     let result = observed.expect("idle peers serialized ahead of the exact request");
     assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn renderer_beacon_reaps_closed_pending_connections_before_applying_the_live_cap() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind stale-pending listener");
+    let address = listener.local_addr().expect("stale-pending address");
+    let stale = (0..RENDERER_CONNECTION_LIMIT)
+        .map(|_| TcpStream::connect(address).expect("queue stale pending connection"))
+        .collect::<Vec<_>>();
+    drop(stale);
+
+    let mut target = TcpStream::connect(address).expect("connect behind stale pending peers");
+    target
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("stale-pending response kill switch");
+    target
+        .write_all(b"GET /ready.png HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .expect("write exact request behind stale pending peers");
+
+    let result = serve_renderer_beacon_until(&listener, Instant::now() + Duration::from_secs(1));
+    assert_eq!(result, Ok(()));
+    let mut response = Vec::new();
+    target
+        .read_to_end(&mut response)
+        .expect("read exact response behind stale pending peers");
+    assert_eq!(
+        response,
+        b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    );
 }
 
 #[test]

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -466,9 +466,7 @@ fn run_same_window_recovery(failure_command: &str) {
 
     let (mut g1_reader, mut g1_writer, g1_pid, g1_link) =
         accept_ready_generation(&control_listener, &mut child);
-    beacon_rx
-        .recv_timeout(PRODUCT_DEADLINE)
-        .expect("initial renderer beacon");
+    expect_renderer_beacon(&beacon_rx, "initial renderer beacon");
     let g1_window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
     writeln!(g1_writer, "{failure_command}").expect("fail g1 app link or process");
     g1_writer.flush().expect("flush g1 failure command");
@@ -596,9 +594,7 @@ fn shipping_windows_keld_dev_delegates_and_cleans_the_orderly_stage() {
     let host_pid =
         wait_for_child_process(cli_pid, "keld-host.exe", Instant::now() + PRODUCT_DEADLINE);
     let (mut reader, mut writer, bun_pid, _) = accept_ready_generation(&control_listener, &mut cli);
-    beacon_rx
-        .recv_timeout(PRODUCT_DEADLINE)
-        .expect("shipping renderer beacon");
+    expect_renderer_beacon(&beacon_rx, "shipping renderer beacon");
     let window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
     assert_eq!(window["title"], PRODUCT_TITLE);
     writer.write_all(b"QUIT\n").expect("shipping Quit");
@@ -670,9 +666,7 @@ fn shipping_windows_cli_death_reaps_the_delegated_host_and_bun() {
     let cleanup_pid = wait_for_cleanup_sentinel(cli_pid, Instant::now() + PRODUCT_DEADLINE);
     let (mut reader, _writer, bun_pid, _, lease_handle) =
         accept_ready_generation_with_lease(&control_listener, &mut cli);
-    beacon_rx
-        .recv_timeout(PRODUCT_DEADLINE)
-        .expect("lease renderer beacon");
+    expect_renderer_beacon(&beacon_rx, "lease renderer beacon");
     let _window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
     let controller_pipe = cli
         .stdout
@@ -749,9 +743,7 @@ fn shipping_windows_host_death_reaps_bun_descendant_deletes_stage_and_relaunches
     let cleanup_pid = wait_for_cleanup_sentinel(cli_pid, Instant::now() + PRODUCT_DEADLINE);
     let (reader, _writer, bun_pid, _, descendant_pid) =
         accept_ready_generation_with_descendant(&control_listener, &mut cli);
-    beacon_rx
-        .recv_timeout(PRODUCT_DEADLINE)
-        .expect("host-death renderer beacon");
+    expect_renderer_beacon(&beacon_rx, "host-death renderer beacon");
     let _window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
 
     let host = open_process_for_wait(host_pid, true);
@@ -1206,9 +1198,7 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
     let descendant_record = read_control_line(&mut reader);
     assert_eq!(parse_descendant_pid(&descendant_record), 0);
 
-    beacon_rx
-        .recv_timeout(PRODUCT_DEADLINE)
-        .expect("WebView2 renderer requested the exact beacon");
+    expect_renderer_beacon(&beacon_rx, "WebView2 renderer requested the exact beacon");
     assert_eq!(read_control_line(&mut reader), "READY");
     assert_eq!(read_control_line(&mut reader), "ECHO1");
     assert_eq!(read_control_line(&mut reader), "ECHO2");
@@ -1235,31 +1225,132 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
     }
 }
 
-fn serve_renderer_beacon(listener: &TcpListener, observed: &mpsc::Sender<()>) {
-    let (mut stream, _) = listener.accept().expect("accept renderer beacon");
-    stream
-        .set_read_timeout(Some(PRODUCT_DEADLINE))
-        .expect("beacon read deadline");
-    let request = read_renderer_request_line(|buffer| stream.read(buffer))
-        .expect("read renderer beacon")
-        .unwrap_or_default();
-    let request = String::from_utf8_lossy(&request);
-    assert!(request.starts_with("GET /ready.png "), "{request}");
-    stream
-        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-        .expect("reply renderer beacon");
-    observed.send(()).expect("publish renderer beacon");
+fn expect_renderer_beacon(observed: &mpsc::Receiver<Result<(), String>>, context: &str) {
+    let result = observed
+        .recv_timeout(PRODUCT_DEADLINE)
+        .unwrap_or_else(|error| panic!("{context}: beacon worker did not report: {error}"));
+    result.unwrap_or_else(|error| panic!("{context}: {error}"));
+}
+
+fn serve_renderer_beacon(listener: &TcpListener, observed: &mpsc::Sender<Result<(), String>>) {
+    let result = serve_renderer_beacon_until(listener, Instant::now() + PRODUCT_DEADLINE);
+    let _ = observed.send(result);
+}
+
+fn serve_renderer_beacon_until(listener: &TcpListener, deadline: Instant) -> Result<(), String> {
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| format!("set renderer beacon listener nonblocking: {error}"))?;
+
+    loop {
+        if Instant::now() >= deadline {
+            return Err("renderer beacon deadline elapsed before the exact request".to_owned());
+        }
+        let (mut stream, _) = match listener.accept() {
+            Ok(accepted) => accepted,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::yield_now();
+                continue;
+            }
+            Err(error) => return Err(format!("accept renderer beacon: {error}")),
+        };
+        stream
+            .set_nonblocking(false)
+            .map_err(|error| format!("set renderer beacon stream blocking: {error}"))?;
+
+        let Some(request) = read_renderer_request_line(|buffer| {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .filter(|remaining| !remaining.is_zero())
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "renderer beacon absolute deadline elapsed",
+                    )
+                })?;
+            stream.set_read_timeout(Some(remaining))?;
+            stream.read(buffer)
+        })?
+        else {
+            // WebView2 may preconnect and close without an HTTP request. That
+            // connection carries no renderer evidence, so keep the same
+            // absolute deadline and await the actual request.
+            continue;
+        };
+
+        if !request.starts_with(b"GET /ready.png ") {
+            return Err(format!(
+                "renderer requested an unexpected beacon: {}",
+                String::from_utf8_lossy(&request)
+            ));
+        }
+
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| "renderer beacon deadline elapsed before the HTTP reply".to_owned())?;
+        stream
+            .set_write_timeout(Some(remaining))
+            .map_err(|error| format!("set renderer beacon write deadline: {error}"))?;
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .map_err(|error| format!("reply renderer beacon: {error}"))?;
+        return Ok(());
+    }
 }
 
 fn read_renderer_request_line(
     mut read_chunk: impl FnMut(&mut [u8]) -> std::io::Result<usize>,
 ) -> Result<Option<Vec<u8>>, String> {
-    let mut request = [0_u8; 2048];
-    let read = read_chunk(&mut request).map_err(|error| error.to_string())?;
-    if read == 0 {
-        Ok(None)
-    } else {
-        Ok(Some(request[..read].to_vec()))
+    const REQUEST_LINE_LIMIT: usize = 2048;
+    let mut request = Vec::new();
+    loop {
+        if request.len() == REQUEST_LINE_LIMIT {
+            return Err(format!(
+                "renderer beacon request line exceeded {REQUEST_LINE_LIMIT} bytes"
+            ));
+        }
+        let mut chunk = [0_u8; 256];
+        let available = (REQUEST_LINE_LIMIT - request.len()).min(chunk.len());
+        let read = match read_chunk(&mut chunk[..available]) {
+            Ok(read) => read,
+            Err(error)
+                if request.is_empty()
+                    && matches!(
+                        error.kind(),
+                        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
+                    ) =>
+            {
+                return Ok(None);
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
+                ) =>
+            {
+                return Err(format!(
+                    "renderer beacon request reset after {} bytes: {error}",
+                    request.len()
+                ));
+            }
+            Err(error) => return Err(format!("read renderer beacon request: {error}")),
+        };
+        if read == 0 {
+            return if request.is_empty() {
+                Ok(None)
+            } else {
+                Err(format!(
+                    "renderer beacon request ended before CRLF: {}",
+                    String::from_utf8_lossy(&request)
+                ))
+            };
+        }
+        request.extend_from_slice(&chunk[..read]);
+        if let Some(line_end) = request.windows(2).position(|bytes| bytes == b"\r\n") {
+            request.truncate(line_end);
+            return Ok(Some(request));
+        }
     }
 }
 
@@ -1295,10 +1386,85 @@ fn renderer_beacon_ignores_an_empty_preconnect_before_the_exact_request() {
         .write_all(b"GET /ready.png HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
         .expect("write target renderer request");
 
-    observed_rx
-        .recv_timeout(PRODUCT_DEADLINE)
-        .expect("exact renderer request observed after empty preconnect");
+    expect_renderer_beacon(
+        &observed_rx,
+        "exact renderer request observed after empty preconnect",
+    );
     beacon.join().expect("beacon regression thread");
+}
+
+#[test]
+fn renderer_beacon_reports_its_absolute_deadline_instead_of_disconnect() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind beacon deadline listener");
+    let deadline = Instant::now() + Duration::from_millis(50);
+    let (observed_tx, observed_rx) = mpsc::channel();
+    let beacon = thread::spawn(move || {
+        let result = serve_renderer_beacon_until(&listener, deadline);
+        observed_tx
+            .send(result)
+            .expect("publish beacon deadline result");
+    });
+
+    let result = observed_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("beacon worker honored its absolute deadline");
+    assert_eq!(
+        result,
+        Err("renderer beacon deadline elapsed before the exact request".to_owned())
+    );
+    beacon.join().expect("beacon deadline thread");
+}
+
+#[test]
+fn renderer_beacon_ignores_only_a_reset_before_request_bytes() {
+    let empty = read_renderer_request_line(|_| {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "empty preconnect reset",
+        ))
+    })
+    .expect("pre-request reset is an empty preconnect");
+    assert_eq!(empty, None);
+
+    let mut first = true;
+    let partial = read_renderer_request_line(|buffer| {
+        if first {
+            first = false;
+            buffer[..3].copy_from_slice(b"GET");
+            Ok(3)
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "partial request reset",
+            ))
+        }
+    })
+    .expect_err("a reset after request bytes must remain a failure");
+    assert!(
+        partial.starts_with("renderer beacon request reset after 3 bytes:"),
+        "{partial}"
+    );
+}
+
+#[test]
+fn renderer_beacon_preserves_the_unexpected_path_failure() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind wrong-path listener");
+    let address = listener.local_addr().expect("wrong-path address");
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let beacon = thread::spawn(move || serve_renderer_beacon_until(&listener, deadline));
+    let mut request = TcpStream::connect(address).expect("connect wrong-path request");
+    request
+        .write_all(b"GET /leaked.png HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .expect("write wrong-path request");
+
+    let error = beacon
+        .join()
+        .expect("wrong-path beacon thread")
+        .expect_err("wrong renderer path must fail");
+    assert_eq!(
+        error,
+        "renderer requested an unexpected beacon: GET /leaked.png HTTP/1.1"
+    );
 }
 
 fn accept_control_or_host_failure(

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -30,7 +30,7 @@ use windows_sys::Win32::System::Threading::{
 const PRODUCT_TITLE: &str = "KEL96 T4 Windows Fixture";
 const PRODUCT_DEADLINE: Duration = Duration::from_secs(20);
 const RENDERER_ACCEPT_POLL: Duration = Duration::from_millis(10);
-const RENDERER_PRECONNECT_IDLE_LIMIT: Duration = Duration::from_millis(250);
+const RENDERER_CONNECTION_LIMIT: usize = 16;
 const SYSTEM_EXTENDED_HANDLE_INFORMATION: u32 = 64;
 const STATUS_INFO_LENGTH_MISMATCH: i32 = -1_073_741_820;
 const OBJ_INHERIT: u32 = 0x0000_0002;
@@ -1239,10 +1239,23 @@ fn serve_renderer_beacon(listener: &TcpListener, observed: &mpsc::Sender<Result<
     let _ = observed.send(result);
 }
 
+struct PendingRendererRequest {
+    stream: TcpStream,
+    request: Vec<u8>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RendererRequestRead {
+    Pending,
+    Empty,
+    Complete(Vec<u8>),
+}
+
 fn serve_renderer_beacon_until(listener: &TcpListener, deadline: Instant) -> Result<(), String> {
     listener
         .set_nonblocking(true)
         .map_err(|error| format!("set renderer beacon listener nonblocking: {error}"))?;
+    let mut pending = Vec::<PendingRendererRequest>::new();
 
     loop {
         let remaining = deadline
@@ -1251,66 +1264,81 @@ fn serve_renderer_beacon_until(listener: &TcpListener, deadline: Instant) -> Res
             .ok_or_else(|| {
                 "renderer beacon deadline elapsed before the exact request".to_owned()
             })?;
-        let (mut stream, _) = match listener.accept() {
-            Ok(accepted) => accepted,
-            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                // This only backs off the nonblocking kernel poll; the socket
-                // readiness and absolute deadline remain the observables.
-                thread::park_timeout(remaining.min(RENDERER_ACCEPT_POLL));
-                continue;
+
+        loop {
+            let (stream, _) = match listener.accept() {
+                Ok(accepted) => accepted,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(error) => return Err(format!("accept renderer beacon: {error}")),
+            };
+            if pending.len() == RENDERER_CONNECTION_LIMIT {
+                return Err(format!(
+                    "renderer beacon exceeded {RENDERER_CONNECTION_LIMIT} pending connections"
+                ));
             }
-            Err(error) => return Err(format!("accept renderer beacon: {error}")),
-        };
-        stream
-            .set_nonblocking(false)
-            .map_err(|error| format!("set renderer beacon stream blocking: {error}"))?;
-
-        let Some(request) = read_renderer_request_line(|buffer| {
-            let remaining = deadline
-                .checked_duration_since(Instant::now())
-                .filter(|remaining| !remaining.is_zero())
-                .ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::TimedOut,
-                        "renderer beacon absolute deadline elapsed",
-                    )
-                })?;
-            stream.set_read_timeout(Some(remaining.min(RENDERER_PRECONNECT_IDLE_LIMIT)))?;
-            stream.read(buffer)
-        })?
-        else {
-            // WebView2 may preconnect and close without an HTTP request. That
-            // connection carries no renderer evidence, so keep the same
-            // absolute deadline and await the actual request.
-            continue;
-        };
-
-        if !request.starts_with(b"GET /ready.png ") {
-            return Err(format!(
-                "renderer requested an unexpected beacon: {}",
-                String::from_utf8_lossy(&request)
-            ));
+            stream
+                .set_nonblocking(true)
+                .map_err(|error| format!("set renderer beacon stream nonblocking: {error}"))?;
+            pending.push(PendingRendererRequest {
+                stream,
+                request: Vec::new(),
+            });
         }
 
-        let remaining = deadline
-            .checked_duration_since(Instant::now())
-            .filter(|remaining| !remaining.is_zero())
-            .ok_or_else(|| "renderer beacon deadline elapsed before the HTTP reply".to_owned())?;
-        stream
-            .set_write_timeout(Some(remaining))
-            .map_err(|error| format!("set renderer beacon write deadline: {error}"))?;
-        stream
-            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-            .map_err(|error| format!("reply renderer beacon: {error}"))?;
-        return Ok(());
+        let mut index = 0;
+        while index < pending.len() {
+            let request = {
+                let PendingRendererRequest { stream, request } = &mut pending[index];
+                read_renderer_request_line(request, |buffer| stream.read(buffer))
+            }?;
+            match request {
+                RendererRequestRead::Pending => index += 1,
+                RendererRequestRead::Empty => {
+                    pending.swap_remove(index);
+                }
+                RendererRequestRead::Complete(request) => {
+                    let mut matched = pending.swap_remove(index);
+                    if !request.starts_with(b"GET /ready.png ") {
+                        return Err(format!(
+                            "renderer requested an unexpected beacon: {}",
+                            String::from_utf8_lossy(&request)
+                        ));
+                    }
+                    let remaining = deadline
+                        .checked_duration_since(Instant::now())
+                        .filter(|remaining| !remaining.is_zero())
+                        .ok_or_else(|| {
+                            "renderer beacon deadline elapsed before the HTTP reply".to_owned()
+                        })?;
+                    matched.stream.set_nonblocking(false).map_err(|error| {
+                        format!("set renderer beacon reply stream blocking: {error}")
+                    })?;
+                    matched
+                        .stream
+                        .set_write_timeout(Some(remaining))
+                        .map_err(|error| format!("set renderer beacon write deadline: {error}"))?;
+                    matched
+                        .stream
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        )
+                        .map_err(|error| format!("reply renderer beacon: {error}"))?;
+                    return Ok(());
+                }
+            }
+        }
+
+        // This only backs off the nonblocking kernel poll; socket readiness
+        // and the single absolute deadline remain the observables.
+        thread::park_timeout(remaining.min(RENDERER_ACCEPT_POLL));
     }
 }
 
 fn read_renderer_request_line(
+    request: &mut Vec<u8>,
     mut read_chunk: impl FnMut(&mut [u8]) -> std::io::Result<usize>,
-) -> Result<Option<Vec<u8>>, String> {
+) -> Result<RendererRequestRead, String> {
     const REQUEST_LINE_LIMIT: usize = 2048;
-    let mut request = Vec::new();
     loop {
         if request.len() == REQUEST_LINE_LIMIT {
             return Err(format!(
@@ -1321,17 +1349,20 @@ fn read_renderer_request_line(
         let available = (REQUEST_LINE_LIMIT - request.len()).min(chunk.len());
         let read = match read_chunk(&mut chunk[..available]) {
             Ok(read) => read,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                return Ok(RendererRequestRead::Pending);
+            }
+            Err(error) if request.is_empty() && error.kind() == std::io::ErrorKind::TimedOut => {
+                return Ok(RendererRequestRead::Pending);
+            }
             Err(error)
                 if request.is_empty()
                     && matches!(
                         error.kind(),
-                        std::io::ErrorKind::ConnectionReset
-                            | std::io::ErrorKind::ConnectionAborted
-                            | std::io::ErrorKind::TimedOut
-                            | std::io::ErrorKind::WouldBlock
+                        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
                     ) =>
             {
-                return Ok(None);
+                return Ok(RendererRequestRead::Empty);
             }
             Err(error)
                 if matches!(
@@ -1348,18 +1379,19 @@ fn read_renderer_request_line(
         };
         if read == 0 {
             return if request.is_empty() {
-                Ok(None)
+                Ok(RendererRequestRead::Empty)
             } else {
                 Err(format!(
                     "renderer beacon request ended before CRLF: {}",
-                    String::from_utf8_lossy(&request)
+                    String::from_utf8_lossy(request)
                 ))
             };
         }
         request.extend_from_slice(&chunk[..read]);
         if let Some(line_end) = request.windows(2).position(|bytes| bytes == b"\r\n") {
-            request.truncate(line_end);
-            return Ok(Some(request));
+            let mut complete = std::mem::take(request);
+            complete.truncate(line_end);
+            return Ok(RendererRequestRead::Complete(complete));
         }
     }
 }
@@ -1372,15 +1404,18 @@ fn renderer_beacon_accumulates_a_fragmented_request_line() {
         b"\nHost: 127.0.0.1\r\n\r\n".as_slice(),
     ]
     .into_iter();
-    let request = read_renderer_request_line(|buffer| {
+    let mut request = Vec::new();
+    let result = read_renderer_request_line(&mut request, |buffer| {
         let chunk = chunks.next().unwrap_or_default();
         buffer[..chunk.len()].copy_from_slice(chunk);
         Ok(chunk.len())
     })
-    .expect("read fragmented renderer request")
-    .expect("fragmented request is not empty");
+    .expect("read fragmented renderer request");
 
-    assert_eq!(request, b"GET /ready.png HTTP/1.1");
+    assert_eq!(
+        result,
+        RendererRequestRead::Complete(b"GET /ready.png HTTP/1.1".to_vec())
+    );
 }
 
 #[test]
@@ -1404,20 +1439,28 @@ fn renderer_beacon_ignores_an_empty_preconnect_before_the_exact_request() {
 }
 
 #[test]
-fn renderer_beacon_does_not_let_an_idle_preconnect_block_the_exact_request() {
+fn renderer_beacon_does_not_serialize_idle_preconnects_before_the_exact_request() {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind idle-preconnect listener");
     let address = listener.local_addr().expect("idle-preconnect address");
-    let idle = TcpStream::connect(address).expect("queue idle preconnect");
-    let deadline = Instant::now() + Duration::from_secs(1);
-    let beacon = thread::spawn(move || serve_renderer_beacon_until(&listener, deadline));
+    let idle = (0..5)
+        .map(|_| TcpStream::connect(address).expect("queue idle preconnect"))
+        .collect::<Vec<_>>();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let (observed_tx, observed_rx) = mpsc::channel();
+    let beacon = thread::spawn(move || {
+        let result = serve_renderer_beacon_until(&listener, deadline);
+        let _ = observed_tx.send(result);
+    });
 
     let mut target = TcpStream::connect(address).expect("connect exact request behind idle peer");
     target
         .write_all(b"GET /ready.png HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
         .expect("write exact request behind idle peer");
 
-    let result = beacon.join().expect("idle-preconnect beacon thread");
+    let observed = observed_rx.recv_timeout(Duration::from_secs(1));
     drop(idle);
+    beacon.join().expect("idle-preconnect beacon thread");
+    let result = observed.expect("idle peers serialized ahead of the exact request");
     assert_eq!(result, Ok(()));
 }
 
@@ -1473,18 +1516,26 @@ fn renderer_beacon_ignores_only_idle_or_reset_before_request_bytes() {
     for kind in [
         std::io::ErrorKind::ConnectionReset,
         std::io::ErrorKind::ConnectionAborted,
-        std::io::ErrorKind::TimedOut,
-        std::io::ErrorKind::WouldBlock,
     ] {
-        let empty = read_renderer_request_line(|_| {
+        let mut request = Vec::new();
+        let empty = read_renderer_request_line(&mut request, |_| {
             Err(std::io::Error::new(kind, "empty preconnect ended"))
         })
-        .expect("pre-request close or idle is an empty preconnect");
-        assert_eq!(empty, None);
+        .expect("pre-request close is an empty preconnect");
+        assert_eq!(empty, RendererRequestRead::Empty);
+    }
+    for kind in [std::io::ErrorKind::TimedOut, std::io::ErrorKind::WouldBlock] {
+        let mut request = Vec::new();
+        let idle = read_renderer_request_line(&mut request, |_| {
+            Err(std::io::Error::new(kind, "empty preconnect ended"))
+        })
+        .expect("pre-request idle remains pending");
+        assert_eq!(idle, RendererRequestRead::Pending);
     }
 
     let mut first = true;
-    let partial = read_renderer_request_line(|buffer| {
+    let mut request = Vec::new();
+    let partial = read_renderer_request_line(&mut request, |buffer| {
         if first {
             first = false;
             buffer[..3].copy_from_slice(b"GET");

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -1416,6 +1416,31 @@ fn renderer_beacon_reports_its_absolute_deadline_instead_of_disconnect() {
 }
 
 #[test]
+fn renderer_beacon_empty_preconnect_does_not_renew_the_deadline() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind preconnect deadline listener");
+    let address = listener.local_addr().expect("preconnect deadline address");
+    drop(TcpStream::connect(address).expect("queue empty preconnect before deadline"));
+
+    let deadline = Instant::now() + Duration::from_millis(50);
+    let (observed_tx, observed_rx) = mpsc::channel();
+    let beacon = thread::spawn(move || {
+        let result = serve_renderer_beacon_until(&listener, deadline);
+        observed_tx
+            .send(result)
+            .expect("publish preconnect deadline result");
+    });
+
+    let result = observed_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("empty preconnect retained the original absolute deadline");
+    assert_eq!(
+        result,
+        Err("renderer beacon deadline elapsed before the exact request".to_owned())
+    );
+    beacon.join().expect("preconnect deadline thread");
+}
+
+#[test]
 fn renderer_beacon_ignores_only_a_reset_before_request_bytes() {
     let empty = read_renderer_request_line(|_| {
         Err(std::io::Error::new(

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -1240,14 +1240,65 @@ fn serve_renderer_beacon(listener: &TcpListener, observed: &mpsc::Sender<()>) {
     stream
         .set_read_timeout(Some(PRODUCT_DEADLINE))
         .expect("beacon read deadline");
-    let mut request = [0_u8; 2048];
-    let read = stream.read(&mut request).expect("read renderer beacon");
-    let request = String::from_utf8_lossy(&request[..read]);
+    let request = read_renderer_request_line(|buffer| stream.read(buffer))
+        .expect("read renderer beacon")
+        .unwrap_or_default();
+    let request = String::from_utf8_lossy(&request);
     assert!(request.starts_with("GET /ready.png "), "{request}");
     stream
         .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
         .expect("reply renderer beacon");
     observed.send(()).expect("publish renderer beacon");
+}
+
+fn read_renderer_request_line(
+    mut read_chunk: impl FnMut(&mut [u8]) -> std::io::Result<usize>,
+) -> Result<Option<Vec<u8>>, String> {
+    let mut request = [0_u8; 2048];
+    let read = read_chunk(&mut request).map_err(|error| error.to_string())?;
+    if read == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(request[..read].to_vec()))
+    }
+}
+
+#[test]
+fn renderer_beacon_accumulates_a_fragmented_request_line() {
+    let mut chunks = [
+        b"G".as_slice(),
+        b"ET /ready.png HTTP/1.1\r".as_slice(),
+        b"\nHost: 127.0.0.1\r\n\r\n".as_slice(),
+    ]
+    .into_iter();
+    let request = read_renderer_request_line(|buffer| {
+        let chunk = chunks.next().unwrap_or_default();
+        buffer[..chunk.len()].copy_from_slice(chunk);
+        Ok(chunk.len())
+    })
+    .expect("read fragmented renderer request")
+    .expect("fragmented request is not empty");
+
+    assert_eq!(request, b"GET /ready.png HTTP/1.1");
+}
+
+#[test]
+fn renderer_beacon_ignores_an_empty_preconnect_before_the_exact_request() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind beacon regression listener");
+    let address = listener.local_addr().expect("beacon regression address");
+    let (observed_tx, observed_rx) = mpsc::channel();
+    let beacon = thread::spawn(move || serve_renderer_beacon(&listener, &observed_tx));
+
+    drop(TcpStream::connect(address).expect("connect empty preconnect"));
+    let mut target = TcpStream::connect(address).expect("connect target renderer request");
+    target
+        .write_all(b"GET /ready.png HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .expect("write target renderer request");
+
+    observed_rx
+        .recv_timeout(PRODUCT_DEADLINE)
+        .expect("exact renderer request observed after empty preconnect");
+    beacon.join().expect("beacon regression thread");
 }
 
 fn accept_control_or_host_failure(

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -29,6 +29,8 @@ use windows_sys::Win32::System::Threading::{
 
 const PRODUCT_TITLE: &str = "KEL96 T4 Windows Fixture";
 const PRODUCT_DEADLINE: Duration = Duration::from_secs(20);
+const RENDERER_ACCEPT_POLL: Duration = Duration::from_millis(10);
+const RENDERER_PRECONNECT_IDLE_LIMIT: Duration = Duration::from_millis(250);
 const SYSTEM_EXTENDED_HANDLE_INFORMATION: u32 = 64;
 const STATUS_INFO_LENGTH_MISMATCH: i32 = -1_073_741_820;
 const OBJ_INHERIT: u32 = 0x0000_0002;
@@ -1243,13 +1245,18 @@ fn serve_renderer_beacon_until(listener: &TcpListener, deadline: Instant) -> Res
         .map_err(|error| format!("set renderer beacon listener nonblocking: {error}"))?;
 
     loop {
-        if Instant::now() >= deadline {
-            return Err("renderer beacon deadline elapsed before the exact request".to_owned());
-        }
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| {
+                "renderer beacon deadline elapsed before the exact request".to_owned()
+            })?;
         let (mut stream, _) = match listener.accept() {
             Ok(accepted) => accepted,
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                thread::yield_now();
+                // This only backs off the nonblocking kernel poll; the socket
+                // readiness and absolute deadline remain the observables.
+                thread::park_timeout(remaining.min(RENDERER_ACCEPT_POLL));
                 continue;
             }
             Err(error) => return Err(format!("accept renderer beacon: {error}")),
@@ -1268,7 +1275,7 @@ fn serve_renderer_beacon_until(listener: &TcpListener, deadline: Instant) -> Res
                         "renderer beacon absolute deadline elapsed",
                     )
                 })?;
-            stream.set_read_timeout(Some(remaining))?;
+            stream.set_read_timeout(Some(remaining.min(RENDERER_PRECONNECT_IDLE_LIMIT)))?;
             stream.read(buffer)
         })?
         else {
@@ -1318,7 +1325,10 @@ fn read_renderer_request_line(
                 if request.is_empty()
                     && matches!(
                         error.kind(),
-                        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
+                        std::io::ErrorKind::ConnectionReset
+                            | std::io::ErrorKind::ConnectionAborted
+                            | std::io::ErrorKind::TimedOut
+                            | std::io::ErrorKind::WouldBlock
                     ) =>
             {
                 return Ok(None);
@@ -1394,6 +1404,24 @@ fn renderer_beacon_ignores_an_empty_preconnect_before_the_exact_request() {
 }
 
 #[test]
+fn renderer_beacon_does_not_let_an_idle_preconnect_block_the_exact_request() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind idle-preconnect listener");
+    let address = listener.local_addr().expect("idle-preconnect address");
+    let idle = TcpStream::connect(address).expect("queue idle preconnect");
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let beacon = thread::spawn(move || serve_renderer_beacon_until(&listener, deadline));
+
+    let mut target = TcpStream::connect(address).expect("connect exact request behind idle peer");
+    target
+        .write_all(b"GET /ready.png HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .expect("write exact request behind idle peer");
+
+    let result = beacon.join().expect("idle-preconnect beacon thread");
+    drop(idle);
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
 fn renderer_beacon_reports_its_absolute_deadline_instead_of_disconnect() {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind beacon deadline listener");
     let deadline = Instant::now() + Duration::from_millis(50);
@@ -1441,15 +1469,19 @@ fn renderer_beacon_empty_preconnect_does_not_renew_the_deadline() {
 }
 
 #[test]
-fn renderer_beacon_ignores_only_a_reset_before_request_bytes() {
-    let empty = read_renderer_request_line(|_| {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::ConnectionReset,
-            "empty preconnect reset",
-        ))
-    })
-    .expect("pre-request reset is an empty preconnect");
-    assert_eq!(empty, None);
+fn renderer_beacon_ignores_only_idle_or_reset_before_request_bytes() {
+    for kind in [
+        std::io::ErrorKind::ConnectionReset,
+        std::io::ErrorKind::ConnectionAborted,
+        std::io::ErrorKind::TimedOut,
+        std::io::ErrorKind::WouldBlock,
+    ] {
+        let empty = read_renderer_request_line(|_| {
+            Err(std::io::Error::new(kind, "empty preconnect ended"))
+        })
+        .expect("pre-request close or idle is an empty preconnect");
+        assert_eq!(empty, None);
+    }
 
     let mut first = true;
     let partial = read_renderer_request_line(|buffer| {

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -1266,8 +1266,8 @@ fn finish_renderer_beacon(
     let result = match initial_result {
         Ok(result) => result,
         Err(receive_error) => match observed.try_recv() {
-            Ok(result) => result,
-            Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => {
+            Ok(Err(error)) => Err(error),
+            Ok(Ok(())) | Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => {
                 return Err(format!(
                     "{context}: beacon worker did not report: {receive_error}"
                 ));
@@ -1301,6 +1301,14 @@ fn serve_renderer_beacon_loop(
     listener: &TcpListener,
     deadline_rx: &mpsc::Receiver<Instant>,
 ) -> Result<(), String> {
+    serve_renderer_beacon_loop_with_clock(listener, deadline_rx, Instant::now)
+}
+
+fn serve_renderer_beacon_loop_with_clock(
+    listener: &TcpListener,
+    deadline_rx: &mpsc::Receiver<Instant>,
+    mut now: impl FnMut() -> Instant,
+) -> Result<(), String> {
     listener
         .set_nonblocking(true)
         .map_err(|error| format!("set renderer beacon listener nonblocking: {error}"))?;
@@ -1318,14 +1326,7 @@ fn serve_renderer_beacon_loop(
             }
         }
         let remaining = deadline
-            .map(|deadline| {
-                deadline
-                    .checked_duration_since(Instant::now())
-                    .filter(|remaining| !remaining.is_zero())
-                    .ok_or_else(|| {
-                        "renderer beacon deadline elapsed before the exact request".to_owned()
-                    })
-            })
+            .map(|deadline| renderer_beacon_remaining(deadline, now()))
             .transpose()?;
 
         let mut index = 0;
@@ -1347,10 +1348,13 @@ fn serve_renderer_beacon_loop(
                             String::from_utf8_lossy(&request)
                         ));
                     }
-                    let write_timeout = remaining.unwrap_or(PRODUCT_DEADLINE);
                     matched.stream.set_nonblocking(false).map_err(|error| {
                         format!("set renderer beacon reply stream blocking: {error}")
                     })?;
+                    let write_timeout = deadline
+                        .map(|deadline| renderer_beacon_remaining(deadline, now()))
+                        .transpose()?
+                        .unwrap_or(PRODUCT_DEADLINE);
                     matched
                         .stream
                         .set_write_timeout(Some(write_timeout))
@@ -1392,6 +1396,13 @@ fn serve_renderer_beacon_loop(
             remaining.min(RENDERER_ACCEPT_POLL)
         }));
     }
+}
+
+fn renderer_beacon_remaining(deadline: Instant, now: Instant) -> Result<Duration, String> {
+    deadline
+        .checked_duration_since(now)
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| "renderer beacon deadline elapsed before the exact request".to_owned())
 }
 
 fn read_renderer_request_line(
@@ -1503,6 +1514,31 @@ fn renderer_beacon_prefers_worker_error_published_after_initial_receive_timeout(
 }
 
 #[test]
+fn renderer_beacon_rejects_worker_success_published_after_initial_receive_timeout() {
+    let (observed_tx, observed) = mpsc::channel();
+    let (publish_tx, publish_rx) = mpsc::channel();
+    let worker = thread::spawn(move || {
+        publish_rx
+            .recv()
+            .expect("release late renderer beacon success");
+        observed_tx
+            .send(Ok(()))
+            .expect("publish late renderer beacon success");
+    });
+    let initial_result = observed.recv_timeout(Duration::from_millis(1));
+    assert_eq!(initial_result, Err(mpsc::RecvTimeoutError::Timeout));
+    publish_tx
+        .send(())
+        .expect("release success after initial receive timeout");
+
+    let result = finish_renderer_beacon(&observed, worker, initial_result, "late success");
+    assert_eq!(
+        result,
+        Err("late success: beacon worker did not report: timed out waiting on channel".to_owned())
+    );
+}
+
+#[test]
 fn renderer_beacon_preserves_initial_timeout_when_worker_publishes_nothing() {
     let (observed_tx, observed) = mpsc::channel::<Result<(), String>>();
     let (release_tx, release_rx) = mpsc::channel();
@@ -1548,6 +1584,47 @@ fn renderer_beacon_request_line_enforces_exact_maximum_and_maximum_plus_one() {
         error,
         format!("renderer beacon request line exceeded {RENDERER_REQUEST_LINE_LIMIT} bytes")
     );
+}
+
+#[test]
+fn renderer_beacon_rechecks_the_absolute_deadline_before_replying() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind reply-deadline listener");
+    let address = listener.local_addr().expect("reply-deadline address");
+    let mut target = TcpStream::connect(address).expect("connect reply-deadline request");
+    target
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("reply-deadline response kill switch");
+    target
+        .write_all(b"GET /ready.png HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .expect("write reply-deadline request");
+
+    let before = Instant::now();
+    let deadline = before + Duration::from_secs(1);
+    let after = deadline + Duration::from_nanos(1);
+    let (deadline_tx, deadline_rx) = mpsc::channel();
+    deadline_tx
+        .send(deadline)
+        .expect("activate injected reply deadline");
+    let mut observations = [before, before, after].into_iter();
+    let result = serve_renderer_beacon_loop_with_clock(&listener, &deadline_rx, || {
+        observations
+            .next()
+            .expect("renderer beacon sampled the clock beyond the reply boundary")
+    });
+
+    assert_eq!(
+        result,
+        Err("renderer beacon deadline elapsed before the exact request".to_owned())
+    );
+    assert!(
+        observations.next().is_none(),
+        "the reply boundary did not consume its fresh clock observation"
+    );
+    let mut response = Vec::new();
+    target
+        .read_to_end(&mut response)
+        .expect("read reply-deadline response");
+    assert!(response.is_empty(), "late response escaped: {response:?}");
 }
 
 #[test]

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -443,8 +443,6 @@ fn run_same_window_recovery(failure_command: &str) {
         .port();
     let beacon_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind recovery beacon");
     let beacon_port = beacon_listener.local_addr().expect("beacon address").port();
-    let (beacon_tx, beacon_rx) = mpsc::channel();
-    let beacon = thread::spawn(move || serve_renderer_beacon(&beacon_listener, &beacon_tx));
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -468,7 +466,10 @@ fn run_same_window_recovery(failure_command: &str) {
 
     let (mut g1_reader, mut g1_writer, g1_pid, g1_link) =
         accept_ready_generation(&control_listener, &mut child);
-    expect_renderer_beacon(&beacon_rx, "initial renderer beacon");
+    expect_renderer_beacon(
+        spawn_renderer_beacon(beacon_listener),
+        "initial renderer beacon",
+    );
     let g1_window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
     writeln!(g1_writer, "{failure_command}").expect("fail g1 app link or process");
     g1_writer.flush().expect("flush g1 failure command");
@@ -494,7 +495,6 @@ fn run_same_window_recovery(failure_command: &str) {
     assert!(status.success(), "recovery host exited with {status}");
     assert!(!process_exists(g1_pid), "retired g1 Bun survived");
     assert!(!process_exists(g2_pid), "g2 Bun survived Quit");
-    beacon.join().expect("recovery beacon thread");
 }
 
 #[test]
@@ -568,8 +568,6 @@ fn shipping_windows_keld_dev_delegates_and_cleans_the_orderly_stage() {
         .port();
     let beacon_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind shipping beacon");
     let beacon_port = beacon_listener.local_addr().expect("beacon address").port();
-    let (beacon_tx, beacon_rx) = mpsc::channel();
-    let beacon = thread::spawn(move || serve_renderer_beacon(&beacon_listener, &beacon_tx));
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -596,7 +594,10 @@ fn shipping_windows_keld_dev_delegates_and_cleans_the_orderly_stage() {
     let host_pid =
         wait_for_child_process(cli_pid, "keld-host.exe", Instant::now() + PRODUCT_DEADLINE);
     let (mut reader, mut writer, bun_pid, _) = accept_ready_generation(&control_listener, &mut cli);
-    expect_renderer_beacon(&beacon_rx, "shipping renderer beacon");
+    expect_renderer_beacon(
+        spawn_renderer_beacon(beacon_listener),
+        "shipping renderer beacon",
+    );
     let window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
     assert_eq!(window["title"], PRODUCT_TITLE);
     writer.write_all(b"QUIT\n").expect("shipping Quit");
@@ -628,7 +629,6 @@ fn shipping_windows_keld_dev_delegates_and_cleans_the_orderly_stage() {
         "delegated Bun survived orderly exit"
     );
     assert_eq!(dev_stage_count(&fixture.project), 0, "orderly stage leaked");
-    beacon.join().expect("shipping beacon thread");
 }
 
 #[test]
@@ -641,8 +641,6 @@ fn shipping_windows_cli_death_reaps_the_delegated_host_and_bun() {
         .port();
     let beacon_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind lease beacon");
     let beacon_port = beacon_listener.local_addr().expect("beacon address").port();
-    let (beacon_tx, beacon_rx) = mpsc::channel();
-    let beacon = thread::spawn(move || serve_renderer_beacon(&beacon_listener, &beacon_tx));
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -668,7 +666,10 @@ fn shipping_windows_cli_death_reaps_the_delegated_host_and_bun() {
     let cleanup_pid = wait_for_cleanup_sentinel(cli_pid, Instant::now() + PRODUCT_DEADLINE);
     let (mut reader, _writer, bun_pid, _, lease_handle) =
         accept_ready_generation_with_lease(&control_listener, &mut cli);
-    expect_renderer_beacon(&beacon_rx, "lease renderer beacon");
+    expect_renderer_beacon(
+        spawn_renderer_beacon(beacon_listener),
+        "lease renderer beacon",
+    );
     let _window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
     let controller_pipe = cli
         .stdout
@@ -702,7 +703,6 @@ fn shipping_windows_cli_death_reaps_the_delegated_host_and_bun() {
         handle_census.bun_count,
         handle_census.lease_host_handle,
     );
-    beacon.join().expect("lease beacon thread");
 }
 
 #[test]
@@ -718,8 +718,6 @@ fn shipping_windows_host_death_reaps_bun_descendant_deletes_stage_and_relaunches
         .local_addr()
         .expect("host-death beacon address")
         .port();
-    let (beacon_tx, beacon_rx) = mpsc::channel();
-    let beacon = thread::spawn(move || serve_renderer_beacon(&beacon_listener, &beacon_tx));
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -745,7 +743,10 @@ fn shipping_windows_host_death_reaps_bun_descendant_deletes_stage_and_relaunches
     let cleanup_pid = wait_for_cleanup_sentinel(cli_pid, Instant::now() + PRODUCT_DEADLINE);
     let (reader, _writer, bun_pid, _, descendant_pid) =
         accept_ready_generation_with_descendant(&control_listener, &mut cli);
-    expect_renderer_beacon(&beacon_rx, "host-death renderer beacon");
+    expect_renderer_beacon(
+        spawn_renderer_beacon(beacon_listener),
+        "host-death renderer beacon",
+    );
     let _window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
 
     let host = open_process_for_wait(host_pid, true);
@@ -762,7 +763,6 @@ fn shipping_windows_host_death_reaps_bun_descendant_deletes_stage_and_relaunches
     assert!(!cli_status.success(), "host death became CLI success");
     wait_for_dev_stage_count(&fixture.project, 0, Instant::now() + PRODUCT_DEADLINE);
     wait_process_gone(cleanup_pid, Instant::now() + PRODUCT_DEADLINE);
-    beacon.join().expect("host-death beacon thread");
 
     let relaunched = run_product_cycle(&fixture, "post-host-death");
     println!(
@@ -1154,8 +1154,6 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
         .port();
     let beacon_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind beacon listener");
     let beacon_port = beacon_listener.local_addr().expect("beacon address").port();
-    let (beacon_tx, beacon_rx) = mpsc::channel();
-    let beacon = thread::spawn(move || serve_renderer_beacon(&beacon_listener, &beacon_tx));
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -1200,7 +1198,10 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
     let descendant_record = read_control_line(&mut reader);
     assert_eq!(parse_descendant_pid(&descendant_record), 0);
 
-    expect_renderer_beacon(&beacon_rx, "WebView2 renderer requested the exact beacon");
+    expect_renderer_beacon(
+        spawn_renderer_beacon(beacon_listener),
+        "WebView2 renderer requested the exact beacon",
+    );
     assert_eq!(read_control_line(&mut reader), "READY");
     assert_eq!(read_control_line(&mut reader), "ECHO1");
     assert_eq!(read_control_line(&mut reader), "ECHO2");
@@ -1218,7 +1219,6 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
         !process_exists(bun_pid),
         "Bun {bun_pid} survived orderly host exit"
     );
-    beacon.join().expect("beacon thread");
 
     ProductEvidence {
         host_pid,
@@ -1227,16 +1227,42 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
     }
 }
 
-fn expect_renderer_beacon(observed: &mpsc::Receiver<Result<(), String>>, context: &str) {
-    let result = observed
-        .recv_timeout(PRODUCT_DEADLINE)
-        .unwrap_or_else(|error| panic!("{context}: beacon worker did not report: {error}"));
-    result.unwrap_or_else(|error| panic!("{context}: {error}"));
+struct RendererBeacon {
+    observed: mpsc::Receiver<Result<(), String>>,
+    worker: thread::JoinHandle<()>,
+    deadline: Instant,
 }
 
-fn serve_renderer_beacon(listener: &TcpListener, observed: &mpsc::Sender<Result<(), String>>) {
-    let result = serve_renderer_beacon_until(listener, Instant::now() + PRODUCT_DEADLINE);
-    let _ = observed.send(result);
+fn spawn_renderer_beacon(listener: TcpListener) -> RendererBeacon {
+    let deadline = Instant::now() + PRODUCT_DEADLINE;
+    let (observed_tx, observed) = mpsc::channel();
+    let worker = thread::spawn(move || {
+        let result = serve_renderer_beacon_until(&listener, deadline);
+        let _ = observed_tx.send(result);
+    });
+    RendererBeacon {
+        observed,
+        worker,
+        deadline,
+    }
+}
+
+fn expect_renderer_beacon(beacon: RendererBeacon, context: &str) {
+    let RendererBeacon {
+        observed,
+        worker,
+        deadline,
+    } = beacon;
+    let remaining = deadline
+        .checked_duration_since(Instant::now())
+        .unwrap_or_default();
+    let result = observed.recv_timeout(remaining);
+    worker
+        .join()
+        .unwrap_or_else(|_| panic!("{context}: beacon worker panicked"));
+    let result =
+        result.unwrap_or_else(|error| panic!("{context}: beacon worker did not report: {error}"));
+    result.unwrap_or_else(|error| panic!("{context}: {error}"));
 }
 
 struct PendingRendererRequest {
@@ -1422,8 +1448,7 @@ fn renderer_beacon_accumulates_a_fragmented_request_line() {
 fn renderer_beacon_ignores_an_empty_preconnect_before_the_exact_request() {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind beacon regression listener");
     let address = listener.local_addr().expect("beacon regression address");
-    let (observed_tx, observed_rx) = mpsc::channel();
-    let beacon = thread::spawn(move || serve_renderer_beacon(&listener, &observed_tx));
+    let beacon = spawn_renderer_beacon(listener);
 
     drop(TcpStream::connect(address).expect("connect empty preconnect"));
     let mut target = TcpStream::connect(address).expect("connect target renderer request");
@@ -1432,10 +1457,9 @@ fn renderer_beacon_ignores_an_empty_preconnect_before_the_exact_request() {
         .expect("write target renderer request");
 
     expect_renderer_beacon(
-        &observed_rx,
+        beacon,
         "exact renderer request observed after empty preconnect",
     );
-    beacon.join().expect("beacon regression thread");
 }
 
 #[test]

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -1249,13 +1249,32 @@ fn expect_renderer_beacon(beacon: RendererBeacon, context: &str) {
     let remaining = deadline
         .checked_duration_since(Instant::now())
         .unwrap_or_default();
-    let result = observed.recv_timeout(remaining);
+    let initial_result = observed.recv_timeout(remaining);
+    finish_renderer_beacon(&observed, worker, initial_result, context)
+        .unwrap_or_else(|error| panic!("{error}"));
+}
+
+fn finish_renderer_beacon(
+    observed: &mpsc::Receiver<Result<(), String>>,
+    worker: thread::JoinHandle<()>,
+    initial_result: Result<Result<(), String>, mpsc::RecvTimeoutError>,
+    context: &str,
+) -> Result<(), String> {
     worker
         .join()
-        .unwrap_or_else(|_| panic!("{context}: beacon worker panicked"));
-    let result =
-        result.unwrap_or_else(|error| panic!("{context}: beacon worker did not report: {error}"));
-    result.unwrap_or_else(|error| panic!("{context}: {error}"));
+        .map_err(|_| format!("{context}: beacon worker panicked"))?;
+    let result = match initial_result {
+        Ok(result) => result,
+        Err(receive_error) => match observed.try_recv() {
+            Ok(result) => result,
+            Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => {
+                return Err(format!(
+                    "{context}: beacon worker did not report: {receive_error}"
+                ));
+            }
+        },
+    };
+    result.map_err(|error| format!("{context}: {error}"))
 }
 
 struct PendingRendererRequest {
@@ -1455,6 +1474,56 @@ fn renderer_beacon_accumulates_a_fragmented_request_line() {
     assert_eq!(
         result,
         RendererRequestRead::Complete(b"GET /ready.png HTTP/1.1".to_vec())
+    );
+}
+
+#[test]
+fn renderer_beacon_prefers_worker_error_published_after_initial_receive_timeout() {
+    let (observed_tx, observed) = mpsc::channel();
+    let (publish_tx, publish_rx) = mpsc::channel();
+    let worker = thread::spawn(move || {
+        publish_rx
+            .recv()
+            .expect("release late renderer beacon publication");
+        observed_tx
+            .send(Err("precise worker failure".to_owned()))
+            .expect("publish precise renderer beacon failure");
+    });
+    let initial_result = observed.recv_timeout(Duration::from_millis(1));
+    assert_eq!(initial_result, Err(mpsc::RecvTimeoutError::Timeout));
+    publish_tx
+        .send(())
+        .expect("release worker after initial receive timeout");
+
+    let result = finish_renderer_beacon(&observed, worker, initial_result, "late publication");
+    assert_eq!(
+        result,
+        Err("late publication: precise worker failure".to_owned())
+    );
+}
+
+#[test]
+fn renderer_beacon_preserves_initial_timeout_when_worker_publishes_nothing() {
+    let (observed_tx, observed) = mpsc::channel::<Result<(), String>>();
+    let (release_tx, release_rx) = mpsc::channel();
+    let worker = thread::spawn(move || {
+        release_rx
+            .recv()
+            .expect("release renderer beacon worker without publication");
+        drop(observed_tx);
+    });
+    let initial_result = observed.recv_timeout(Duration::from_millis(1));
+    assert_eq!(initial_result, Err(mpsc::RecvTimeoutError::Timeout));
+    release_tx
+        .send(())
+        .expect("release non-publishing worker after initial timeout");
+
+    let result = finish_renderer_beacon(&observed, worker, initial_result, "no publication");
+    assert_eq!(
+        result,
+        Err(
+            "no publication: beacon worker did not report: timed out waiting on channel".to_owned()
+        )
     );
 }
 

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -443,6 +443,7 @@ fn run_same_window_recovery(failure_command: &str) {
         .port();
     let beacon_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind recovery beacon");
     let beacon_port = beacon_listener.local_addr().expect("beacon address").port();
+    let beacon = spawn_renderer_beacon(beacon_listener);
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -466,10 +467,7 @@ fn run_same_window_recovery(failure_command: &str) {
 
     let (mut g1_reader, mut g1_writer, g1_pid, g1_link) =
         accept_ready_generation(&control_listener, &mut child);
-    expect_renderer_beacon(
-        spawn_renderer_beacon(beacon_listener),
-        "initial renderer beacon",
-    );
+    expect_renderer_beacon(beacon, "initial renderer beacon");
     let g1_window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
     writeln!(g1_writer, "{failure_command}").expect("fail g1 app link or process");
     g1_writer.flush().expect("flush g1 failure command");
@@ -568,6 +566,7 @@ fn shipping_windows_keld_dev_delegates_and_cleans_the_orderly_stage() {
         .port();
     let beacon_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind shipping beacon");
     let beacon_port = beacon_listener.local_addr().expect("beacon address").port();
+    let beacon = spawn_renderer_beacon(beacon_listener);
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -594,10 +593,7 @@ fn shipping_windows_keld_dev_delegates_and_cleans_the_orderly_stage() {
     let host_pid =
         wait_for_child_process(cli_pid, "keld-host.exe", Instant::now() + PRODUCT_DEADLINE);
     let (mut reader, mut writer, bun_pid, _) = accept_ready_generation(&control_listener, &mut cli);
-    expect_renderer_beacon(
-        spawn_renderer_beacon(beacon_listener),
-        "shipping renderer beacon",
-    );
+    expect_renderer_beacon(beacon, "shipping renderer beacon");
     let window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
     assert_eq!(window["title"], PRODUCT_TITLE);
     writer.write_all(b"QUIT\n").expect("shipping Quit");
@@ -641,6 +637,7 @@ fn shipping_windows_cli_death_reaps_the_delegated_host_and_bun() {
         .port();
     let beacon_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind lease beacon");
     let beacon_port = beacon_listener.local_addr().expect("beacon address").port();
+    let beacon = spawn_renderer_beacon(beacon_listener);
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -666,10 +663,7 @@ fn shipping_windows_cli_death_reaps_the_delegated_host_and_bun() {
     let cleanup_pid = wait_for_cleanup_sentinel(cli_pid, Instant::now() + PRODUCT_DEADLINE);
     let (mut reader, _writer, bun_pid, _, lease_handle) =
         accept_ready_generation_with_lease(&control_listener, &mut cli);
-    expect_renderer_beacon(
-        spawn_renderer_beacon(beacon_listener),
-        "lease renderer beacon",
-    );
+    expect_renderer_beacon(beacon, "lease renderer beacon");
     let _window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
     let controller_pipe = cli
         .stdout
@@ -718,6 +712,7 @@ fn shipping_windows_host_death_reaps_bun_descendant_deletes_stage_and_relaunches
         .local_addr()
         .expect("host-death beacon address")
         .port();
+    let beacon = spawn_renderer_beacon(beacon_listener);
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -743,10 +738,7 @@ fn shipping_windows_host_death_reaps_bun_descendant_deletes_stage_and_relaunches
     let cleanup_pid = wait_for_cleanup_sentinel(cli_pid, Instant::now() + PRODUCT_DEADLINE);
     let (reader, _writer, bun_pid, _, descendant_pid) =
         accept_ready_generation_with_descendant(&control_listener, &mut cli);
-    expect_renderer_beacon(
-        spawn_renderer_beacon(beacon_listener),
-        "host-death renderer beacon",
-    );
+    expect_renderer_beacon(beacon, "host-death renderer beacon");
     let _window = wait_for_host_window(host_pid, Instant::now() + PRODUCT_DEADLINE);
 
     let host = open_process_for_wait(host_pid, true);
@@ -1154,6 +1146,7 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
         .port();
     let beacon_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind beacon listener");
     let beacon_port = beacon_listener.local_addr().expect("beacon address").port();
+    let beacon = spawn_renderer_beacon(beacon_listener);
     fs::write(
         fixture.project.join("index.html"),
         format!(
@@ -1198,10 +1191,7 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
     let descendant_record = read_control_line(&mut reader);
     assert_eq!(parse_descendant_pid(&descendant_record), 0);
 
-    expect_renderer_beacon(
-        spawn_renderer_beacon(beacon_listener),
-        "WebView2 renderer requested the exact beacon",
-    );
+    expect_renderer_beacon(beacon, "WebView2 renderer requested the exact beacon");
     assert_eq!(read_control_line(&mut reader), "READY");
     assert_eq!(read_control_line(&mut reader), "ECHO1");
     assert_eq!(read_control_line(&mut reader), "ECHO2");
@@ -1230,20 +1220,20 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
 struct RendererBeacon {
     observed: mpsc::Receiver<Result<(), String>>,
     worker: thread::JoinHandle<()>,
-    deadline: Instant,
+    activate_deadline: mpsc::Sender<Instant>,
 }
 
 fn spawn_renderer_beacon(listener: TcpListener) -> RendererBeacon {
-    let deadline = Instant::now() + PRODUCT_DEADLINE;
     let (observed_tx, observed) = mpsc::channel();
+    let (activate_deadline, deadline_rx) = mpsc::channel();
     let worker = thread::spawn(move || {
-        let result = serve_renderer_beacon_until(&listener, deadline);
+        let result = serve_renderer_beacon_loop(&listener, &deadline_rx);
         let _ = observed_tx.send(result);
     });
     RendererBeacon {
         observed,
         worker,
-        deadline,
+        activate_deadline,
     }
 }
 
@@ -1251,8 +1241,10 @@ fn expect_renderer_beacon(beacon: RendererBeacon, context: &str) {
     let RendererBeacon {
         observed,
         worker,
-        deadline,
+        activate_deadline,
     } = beacon;
+    let deadline = Instant::now() + PRODUCT_DEADLINE;
+    let _ = activate_deadline.send(deadline);
     let remaining = deadline
         .checked_duration_since(Instant::now())
         .unwrap_or_default();
@@ -1278,18 +1270,43 @@ enum RendererRequestRead {
 }
 
 fn serve_renderer_beacon_until(listener: &TcpListener, deadline: Instant) -> Result<(), String> {
+    let (deadline_tx, deadline_rx) = mpsc::channel();
+    deadline_tx
+        .send(deadline)
+        .expect("activate fixed renderer beacon deadline");
+    serve_renderer_beacon_loop(listener, &deadline_rx)
+}
+
+fn serve_renderer_beacon_loop(
+    listener: &TcpListener,
+    deadline_rx: &mpsc::Receiver<Instant>,
+) -> Result<(), String> {
     listener
         .set_nonblocking(true)
         .map_err(|error| format!("set renderer beacon listener nonblocking: {error}"))?;
     let mut pending = Vec::<PendingRendererRequest>::new();
+    let mut deadline = None;
 
     loop {
+        if deadline.is_none() {
+            match deadline_rx.try_recv() {
+                Ok(activated) => deadline = Some(activated),
+                Err(mpsc::TryRecvError::Empty) => {}
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    return Err("renderer beacon deadline owner ended before awaiting".to_owned());
+                }
+            }
+        }
         let remaining = deadline
-            .checked_duration_since(Instant::now())
-            .filter(|remaining| !remaining.is_zero())
-            .ok_or_else(|| {
-                "renderer beacon deadline elapsed before the exact request".to_owned()
-            })?;
+            .map(|deadline| {
+                deadline
+                    .checked_duration_since(Instant::now())
+                    .filter(|remaining| !remaining.is_zero())
+                    .ok_or_else(|| {
+                        "renderer beacon deadline elapsed before the exact request".to_owned()
+                    })
+            })
+            .transpose()?;
 
         loop {
             let (stream, _) = match listener.accept() {
@@ -1330,18 +1347,13 @@ fn serve_renderer_beacon_until(listener: &TcpListener, deadline: Instant) -> Res
                             String::from_utf8_lossy(&request)
                         ));
                     }
-                    let remaining = deadline
-                        .checked_duration_since(Instant::now())
-                        .filter(|remaining| !remaining.is_zero())
-                        .ok_or_else(|| {
-                            "renderer beacon deadline elapsed before the HTTP reply".to_owned()
-                        })?;
+                    let write_timeout = remaining.unwrap_or(PRODUCT_DEADLINE);
                     matched.stream.set_nonblocking(false).map_err(|error| {
                         format!("set renderer beacon reply stream blocking: {error}")
                     })?;
                     matched
                         .stream
-                        .set_write_timeout(Some(remaining))
+                        .set_write_timeout(Some(write_timeout))
                         .map_err(|error| format!("set renderer beacon write deadline: {error}"))?;
                     matched
                         .stream
@@ -1355,8 +1367,10 @@ fn serve_renderer_beacon_until(listener: &TcpListener, deadline: Instant) -> Res
         }
 
         // This only backs off the nonblocking kernel poll; socket readiness
-        // and the single absolute deadline remain the observables.
-        thread::park_timeout(remaining.min(RENDERER_ACCEPT_POLL));
+        // and the parent-activated absolute deadline remain the observables.
+        thread::park_timeout(remaining.map_or(RENDERER_ACCEPT_POLL, |remaining| {
+            remaining.min(RENDERER_ACCEPT_POLL)
+        }));
     }
 }
 
@@ -1460,6 +1474,31 @@ fn renderer_beacon_ignores_an_empty_preconnect_before_the_exact_request() {
         beacon,
         "exact renderer request observed after empty preconnect",
     );
+}
+
+#[test]
+fn renderer_beacon_serves_before_the_parent_activates_its_wait_deadline() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind early beacon listener");
+    let address = listener.local_addr().expect("early beacon address");
+    let beacon = spawn_renderer_beacon(listener);
+    let mut target = TcpStream::connect(address).expect("connect early renderer request");
+    target
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("early response kill switch");
+    target
+        .write_all(b"GET /ready.png HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .expect("write early renderer request");
+    let mut response = [0_u8; 128];
+    let read = target
+        .read(&mut response)
+        .expect("worker replied before parent await");
+    assert!(
+        response[..read].starts_with(b"HTTP/1.1 200 OK\r\n"),
+        "{}",
+        String::from_utf8_lossy(&response[..read])
+    );
+
+    expect_renderer_beacon(beacon, "early renderer request");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes KEL-163's Windows test-only renderer beacon helper: bounded fragmented request accumulation, empty/idle/reset preconnect handling, one parent-activated absolute deadline, live pending-socket accounting, precise worker-result provenance, and a fresh reply write budget.
- Current frozen head: `cb60882aaf603d7ed547bd5531ee592f6d208684`, linearly rebased onto `dcc4676af16146c887e03e5dcbdd824032c10055`.
- One changed file and no production code. KEL-164's accepted current-definition Defender qualification is Done.
- Merge: `merge-when-complete` after the required independent post-push CODEOWNER approval; every other merge predicate currently passes.

## Spec refs

- KEL-163
- KEL-164 accepted operational disposition
- `docs/specs/kel96-no-flag-host-boot.md`
- `crates/keld-host/AGENTS.md`

No boundary change and no architecture/spec text change.

## Review gates

- `unsafe`: none
- Public API: none
- Permission model: none
- Dependency addition: none
- Wire protocol: none

Independent adversarial review: 24 findings/refuters; 0 blockers, 2 optional minor hardening items, 3 nits, 19 rejected. The final tree/patch is identical to the reviewed rebased tree. Current-head CodeRabbit coverage binds source/covered commit to `cb60882`, reports minimal merge risk, and generated no actionable comments. The sole historical review thread is resolved and outdated.

## Tests

- Failure-first controls at the original unfixed states proved zero-byte-first, fragmented read, stale backlog, receive/publication, and reply-deadline defects before their fixes.
- Exact final head, real RAMANI Windows:
  - Named shipping host-death/descendant cleanup/stage deletion/relaunch: 1 passed, 30 filtered.
  - Full `no_flag_windows`: 31 passed, 0 failed.
  - `bash -lc 'just ci'`: exit 0.
  - Bun: 32 passed, 10 Windows-inapplicable Unix-socket cases skipped.
  - Workspace nextest: 581 passed, 2 leaky, 3 skipped.
  - Format, workspace clippy with `-D warnings`, rustdoc with `-D warnings`, generated docs/status, pinned Mermaid render, CI hygiene, and cargo-deny passed.
- Defender remained enabled: engine `1.1.26080.3`, signature `1.459.105.0`; zero new ThreatID `2147731250` records or Operational events 1116/1117/2050. Exact candidate host SHA-256: `8937A16059D9AD48BD96EAF9AF6E19A31439EBAD5DCBB283FD59BA1192E533CB`.
- Exact-head hosted run `34189665221`: `CI required`, Windows/Ubuntu/macOS clippy+test, Linux GUI, MSRV, rustfmt, gitleaks, and change router passed; routed non-applicable jobs skipped. KeldBot gatekeeper/title-lint passed.

## Platforms

- Real Windows RAMANI: exact-final product/process/stage/relaunch and full local-gate evidence passed with Defender enabled.
- Hosted Windows: exact-final CI passed.
- Linux/macOS: changed test is `#![cfg(windows)]`; exact-final hosted CI passed and no product behavior changed.

## Perf impact

None in product binaries. Test-only polling is bounded to 16 connections, a 2048-byte request line, one absolute deadline, and a 10 ms park interval.