### PR TITLE
ci(ci): route IPC fixtures and check fuzz workspace (KEL-153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: Check keld-ipc fuzz workspace
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.rust == 'true'
+        run: |
+          cargo check --manifest-path crates/keld-ipc/fuzz/Cargo.toml
       - name: Product status Windows path contracts
         if: matrix.os == 'windows-latest'
         shell: bash

--- a/tools/ci_changes.sh
+++ b/tools/ci_changes.sh
@@ -269,9 +269,9 @@ ts_package_consumer_packages() {
     done < <(grep -rlF --exclude-dir=target -- "$package_dir" "$repo_root/crates" 2>/dev/null || true)
 }
 
-# A Bun suite root is a package.json directory that owns at least one file
-# `bun test` would actually run. The fixtures package owns none: it is spawned
-# by the Rust conformance test, not by `bun test`.
+# Print every file below a package directory that `bun test` would actually
+# run. Keeping this discovery in one helper lets both suite selection and
+# cross-tree fixture consumers follow the same pinned Bun contract.
 #
 # The shapes below mirror bun 1.4.0's own discovery, measured rather than read
 # off its error text (which understates the set). Of 21 planted filenames it
@@ -286,17 +286,10 @@ ts_package_consumer_packages() {
 # Bun's side cannot fail it — re-measure when the pinned version moves. KEL-115's
 # receipt — the lane reporting which suites it actually ran — removes the
 # duplication entirely and is the real fix.
-ts_test_package_dirs() {
-    local repo_root
-    repo_root="$(git rev-parse --show-toplevel)"
-    [[ -d "$repo_root/packages" ]] || return 0
-    local manifest
-    local dir
-    while IFS= read -r manifest; do
-        [[ -z "$manifest" ]] && continue
-        dir="${manifest%/package.json}"
-        if [[ -n "$(find "$dir" -name node_modules -prune -o \
-            \( -iname '*.test.ts' -o -iname '*.test.tsx' -o -iname '*.test.js' \
+ts_test_files_in_dir() {
+    local dir="$1"
+    find "$dir" -name node_modules -prune -o \
+        \( -iname '*.test.ts' -o -iname '*.test.tsx' -o -iname '*.test.js' \
             -o -iname '*.test.jsx' -o -iname '*.test.mts' -o -iname '*.test.cts' \
             -o -iname '*.test.mjs' -o -iname '*.test.cjs' \
             -o -iname '*.spec.ts' -o -iname '*.spec.tsx' -o -iname '*.spec.js' \
@@ -307,10 +300,67 @@ ts_test_package_dirs() {
             -o -iname '*_test.mjs' -o -iname '*_test.cjs' \
             -o -iname '*_spec.ts' -o -iname '*_spec.tsx' -o -iname '*_spec.js' \
             -o -iname '*_spec.jsx' -o -iname '*_spec.mts' -o -iname '*_spec.cts' \
-            -o -iname '*_spec.mjs' -o -iname '*_spec.cjs' \) -print -quit)" ]]; then
+            -o -iname '*_spec.mjs' -o -iname '*_spec.cjs' \) -print0
+}
+
+# A Bun suite root is a package.json directory that owns at least one test
+# file. The fixtures package owns none: it is spawned by the Rust conformance
+# test, not by `bun test`.
+ts_test_package_dirs() {
+    local repo_root
+    repo_root="$(git rev-parse --show-toplevel)"
+    [[ -d "$repo_root/packages" ]] || return 0
+    local manifest
+    local dir
+    local test_file
+    while IFS= read -r manifest; do
+        [[ -z "$manifest" ]] && continue
+        dir="${manifest%/package.json}"
+        if IFS= read -r -d '' test_file < <(ts_test_files_in_dir "$dir"); then
             printf '%s\n' "${dir#"$repo_root"/}"
         fi
     done < <(find "$repo_root/packages" -name package.json -not -path '*/node_modules/*' -print)
+}
+
+# A crate fixture can also be an input to Bun tests. Cargo metadata cannot
+# express this crate-fixture -> npm-package edge, so derive it from actual Bun
+# test files that name the changed path. Searching only suite roots preserves
+# the existing no-empty-selection contract and excludes source-only mentions.
+ts_fixture_consumer_package_dirs() {
+    local changed_file="$1"
+    local repo_root
+    repo_root="$(git rev-parse --show-toplevel)"
+    local package_dir
+    local test_file
+    local grep_status
+    while IFS= read -r package_dir; do
+        [[ -z "$package_dir" ]] && continue
+        while IFS= read -r -d '' test_file; do
+            if grep -Fq -- "$changed_file" "$test_file"; then
+                printf '%s\n' "$package_dir"
+                break
+            else
+                grep_status=$?
+                if [[ "$grep_status" -gt 1 ]]; then
+                    return 1
+                fi
+            fi
+        done < <(ts_test_files_in_dir "$repo_root/$package_dir")
+    done < <(ts_test_package_dirs)
+}
+
+resolve_crate_fixture_consumers() {
+    local changed_file="$1"
+    local consumers
+    local package_dir
+    if ! consumers="$(ts_fixture_consumer_package_dirs "$changed_file")"; then
+        mark_unknown
+        return
+    fi
+    for package_dir in $consumers; do
+        ts="$TRUE"
+        add_changed_ts_package_dir "$package_dir"
+    done
 }
 
 # Runs before the Rust selection so a derived crate consumer joins the same
@@ -469,6 +519,9 @@ classify_path() {
 
         crates/*)
             rust="$TRUE"
+            case "$changed_file" in
+                crates/*/tests/fixtures/*) resolve_crate_fixture_consumers "$changed_file" ;;
+            esac
             local package_name
             if ! package_name="$(package_for_path "$changed_file")"; then
                 mark_unknown

--- a/tools/ci_changes_test.sh
+++ b/tools/ci_changes_test.sh
@@ -95,6 +95,7 @@ hygiene_only=$'rust=false\ndocs=false\nhygiene=true\ngui=false\nmsrv=false\ndeny
 docs_hygiene=$'rust=false\ndocs=true\nhygiene=true\ngui=false\nmsrv=false\ndeny=false\nts=false\nwebkitgtk=false'
 host_dependency=$'rust=true\ndocs=false\nhygiene=false\ngui=true\nmsrv=true\ndeny=false\nts=false\nwebkitgtk=true'
 compat_flags=$'rust=true\ndocs=false\nhygiene=false\ngui=false\nmsrv=true\ndeny=false\nts=false\nwebkitgtk=true'
+ipc_fixture_flags=$'rust=true\ndocs=false\nhygiene=false\ngui=true\nmsrv=true\ndeny=false\nts=true\nwebkitgtk=true'
 # A TypeScript package change owns the Bun lane and the crates that read that
 # package directory (keld-compat spawns the @keld/electron fixtures). It cannot
 # change rustc, the workspace dependency policy, or the host window, so MSRV,
@@ -152,6 +153,10 @@ expect_package_token "compat-only change includes its owner package" keld-compat
 compat_test_classification="$(result_for_paths crates/keld-compat/tests/electron_lifecycle.rs)"
 expect_flags "Rust-only change does not select the TypeScript lane" "$compat_flags" "$compat_test_classification"
 expect_empty_output "Rust-only change selects no Bun suite" ts_packages "$compat_test_classification"
+
+ipc_fixture_classification="$(result_for_paths crates/keld-ipc/tests/fixtures/receiver-semantics-v0.tsv)"
+expect_flags "shared IPC fixture change runs the Bun lane" "$ipc_fixture_flags" "$ipc_fixture_classification"
+expect_output_package_token "shared IPC fixture change selects its consuming Bun suite" ts_packages packages/@keld/electron "$ipc_fixture_classification"
 
 ts_classification="$(result_for_paths packages/@keld/electron/src/link.ts)"
 expect_flags "TypeScript package change runs the Bun lane and its Rust consumer only" "$ts_flags" "$ts_classification"
@@ -404,11 +409,20 @@ for shape in plain.ts test.ts tests.ts; do
 done
 echo "ok: router suite discovery matches bun 1.4.0 across all 32 patterns, 4 case variants and 3 skipped shapes"
 
+# A crate fixture with no Bun test consumer must not select the TypeScript
+# lane merely because it lives under tests/fixtures. The matching case below
+# then proves the edge is derived from the checked-out test reference.
+fixture_path='crates/keld-ipc/tests/fixtures/shared.tsv'
+fixture_without_consumer="$(cd "$temp_dir" && printf '%s\0' "$fixture_path" | PATH="$temp_dir/fake-bin:$PATH" "$router" classify)"
+fake_fixture_without_consumer=$'rust=true\ndocs=false\nhygiene=false\ngui=true\nmsrv=true\ndeny=false\nts=false\nwebkitgtk=false'
+expect_flags "unreferenced crate fixture does not invent a Bun consumer" "$fake_fixture_without_consumer" "$fixture_without_consumer"
+expect_empty_output "unreferenced crate fixture selects no Bun suite" ts_packages "$fixture_without_consumer"
+
 # A Bun suite the Keld workspace does not own: this fixture proves the lane is
 # derived from the checked-out packages/ tree, not from a hard-coded path.
 mkdir -p "$temp_dir/packages/@fake/pkg/src"
 printf '{"name":"@fake/pkg","type":"module"}\n' >"$temp_dir/packages/@fake/pkg/package.json"
-printf 'import { test } from "bun:test";\n' >"$temp_dir/packages/@fake/pkg/src/unit.test.ts"
+printf 'import { test } from "bun:test"; // %s\n' "$fixture_path" >"$temp_dir/packages/@fake/pkg/src/unit.test.ts"
 git -C "$temp_dir" add packages
 git -C "$temp_dir" commit -qm packages
 ts_sha="$(git -C "$temp_dir" rev-parse HEAD)"
@@ -417,6 +431,11 @@ fake_ts_flags=$'rust=false\ndocs=false\nhygiene=false\ngui=false\nmsrv=false\nde
 expect_flags "pull-request TypeScript-only diff runs the Bun lane with no Rust consumer" "$fake_ts_flags" "$ts_pr_result"
 expect_output_package_token "pull-request TypeScript-only diff selects the changed Bun suite" ts_packages 'packages/@fake/pkg' "$ts_pr_result"
 expect_empty_packages "pull-request TypeScript-only diff selects no workspace package" "$ts_pr_result"
+
+fixture_with_consumer="$(cd "$temp_dir" && printf '%s\0' "$fixture_path" | PATH="$temp_dir/fake-bin:$PATH" "$router" classify)"
+fake_fixture_with_consumer=$'rust=true\ndocs=false\nhygiene=false\ngui=true\nmsrv=true\ndeny=false\nts=true\nwebkitgtk=false'
+expect_flags "crate fixture discovers a checked-out Bun test consumer" "$fake_fixture_with_consumer" "$fixture_with_consumer"
+expect_output_package_token "crate fixture selects the discovered Bun suite" ts_packages 'packages/@fake/pkg' "$fixture_with_consumer"
 
 ts_push_result="$(cd "$temp_dir" && PATH="$temp_dir/fake-bin:$PATH" KELD_CI_EVENT_NAME=push KELD_CI_BEFORE_SHA="$untested_sha" GITHUB_SHA="$ts_sha" "$router" github)"
 expect_flags "push TypeScript-only diff runs the Bun lane" "$fake_ts_flags" "$ts_push_result"

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -103,6 +103,9 @@ const PRODUCT_STATUS_WINDOWS_COMMANDS: &[&str] = &[
     "target/product-status/product-status-test",
 ];
 
+const FUZZ_WORKSPACE_COMMANDS: &[&str] =
+    &["cargo check --manifest-path crates/keld-ipc/fuzz/Cargo.toml"];
+
 fn read(root: &Path, relative: &str) -> Result<String, String> {
     let path = root.join(relative);
     fs::read_to_string(&path).map_err(|error| {
@@ -796,6 +799,49 @@ fn check_check_job_if_avoids_matrix(text: &str) -> Result<(), String> {
     if if_text.contains("matrix.") {
         return Err(format!(
             "CI-HYGIENE: `{WORKFLOW}` `check` job-level `if` must not use `matrix`. GitHub evaluates `jobs.<job_id>.if` before matrix expansion (contexts: github, needs, vars, inputs only). Referencing `matrix.os` invalidates the workflow so rustc never starts on any OS. Keep OS filters on steps, which do have `matrix`."
+        ));
+    }
+    Ok(())
+}
+
+fn check_fuzz_workspace_step(text: &str) -> Result<(), String> {
+    let Some(check_job) = workflow_job_block(text, "check") else {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` has no cross-platform `check` job for the keld-ipc fuzz workspace."
+        ));
+    };
+    let step = "Check keld-ipc fuzz workspace";
+    let count = workflow_direct_named_step_count(&check_job, step);
+    if count != 1 {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `check` must contain exactly one `{step}` step; found {count}."
+        ));
+    }
+    let block = workflow_direct_named_step_block(&check_job, step).ok_or_else(|| {
+        format!("CI-HYGIENE: `{WORKFLOW}` `{step}` must be a direct child of `check.steps`.")
+    })?;
+    let expected_keys = ["if".to_owned(), "run".to_owned()];
+    if workflow_named_step_direct_keys(&block, step).as_deref() != Some(expected_keys.as_slice()) {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `{step}` must contain only its exact Ubuntu/router condition and direct run command."
+        ));
+    }
+    let condition = "matrix.os == 'ubuntu-latest' && needs.changes.outputs.rust == 'true'";
+    if workflow_named_step_direct_value(&block, step, "if").as_deref() != Some(condition) {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `{step}` must use the exact condition `{condition}` so the stable fuzz build runs only on the rust-routed Ubuntu row."
+        ));
+    }
+    let commands = workflow_named_step_shell_commands(&block, step).ok_or_else(|| {
+        format!("CI-HYGIENE: `{WORKFLOW}` `{step}` has no executable multiline run block.")
+    })?;
+    if commands
+        .iter()
+        .map(String::as_str)
+        .ne(FUZZ_WORKSPACE_COMMANDS.iter().copied())
+    {
+        return Err(format!(
+            "CI-HYGIENE: `{WORKFLOW}` `{step}` must directly run the stable fuzz-workspace cargo check without a wrapper, campaign, retry, or exit suppression."
         ));
     }
     Ok(())
@@ -1560,6 +1606,7 @@ fn check_workflow(root: &Path) -> Result<(), String> {
     check_change_router_job(&text)?;
     check_package_loop_shell(&text)?;
     check_check_job_if_avoids_matrix(&text)?;
+    check_fuzz_workspace_step(&text)?;
     check_msrv_avoids_apt(&text)?;
     check_bun_test_job(&text)?;
     check_required_job(&text)?;
@@ -1736,6 +1783,10 @@ mod tests {
             "          target/product-status/product-status check .",
             "  check:",
             "    steps:",
+            "      - name: Check keld-ipc fuzz workspace",
+            "        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.rust == 'true'",
+            "        run: |",
+            "          cargo check --manifest-path crates/keld-ipc/fuzz/Cargo.toml",
             "      - name: clippy (warnings deny)",
             "        shell: bash",
             "        run: cargo clippy -p fixture --all-targets -- -D warnings",
@@ -2584,6 +2635,46 @@ mod tests {
         let error = check(temp.path()).expect_err("job-level matrix.os must fail hygiene");
         assert!(error.contains("matrix"), "{error}");
         assert!(error.contains("check"), "{error}");
+    }
+
+    #[test]
+    fn missing_fuzz_workspace_step_fails() {
+        let temp = complete_fixture();
+        let step = "      - name: Check keld-ipc fuzz workspace\n        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.rust == 'true'\n        run: |\n          cargo check --manifest-path crates/keld-ipc/fuzz/Cargo.toml\n";
+        temp.write(WORKFLOW, &valid_workflow().replace(step, ""));
+        let error = check(temp.path()).expect_err("missing fuzz workspace check must fail");
+        assert!(error.contains("Check keld-ipc fuzz workspace"), "{error}");
+    }
+
+    #[test]
+    fn fuzz_workspace_step_must_be_ubuntu_and_rust_routed() {
+        let temp = complete_fixture();
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replace(
+                "matrix.os == 'ubuntu-latest' && needs.changes.outputs.rust == 'true'",
+                "matrix.os == 'ubuntu-latest'",
+            ),
+        );
+        let error = check(temp.path()).expect_err("fuzz workspace step needs both routing gates");
+        assert!(error.contains("exact condition"), "{error}");
+    }
+
+    #[test]
+    fn fuzz_workspace_step_must_run_the_exact_stable_check() {
+        let temp = complete_fixture();
+        temp.write(
+            WORKFLOW,
+            &valid_workflow().replace(
+                "cargo check --manifest-path crates/keld-ipc/fuzz/Cargo.toml",
+                "cargo check",
+            ),
+        );
+        let error = check(temp.path()).expect_err("fuzz workspace step needs its direct command");
+        assert!(
+            error.contains("stable fuzz-workspace cargo check"),
+            "{error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Derive the crate-fixture to Bun-suite reverse edge from actual Bun-discovered test files, so the shared receiver-semantics TSV routes packages/@keld/electron without a hard-coded package list.
- Add one failure-preserving stable cargo check for the standalone keld-ipc fuzz workspace on the rust-routed Ubuntu check row only.
- Pin both contracts with router and hygiene negative controls.
- Prompt identity: prompts/NEW/ci/02-kel153-corpus-bun-lane-fuzz-check.md, SHA-256 3e9391ff2eae2f7baaf1c2d38d49c30ec2cb9ecafc8d3748c531662199e1d51e. Base pin refreshed from 43cab25 to bc15cb9 after #136, #139, #140, and #141 landed.

## Spec refs

No boundary change. .agents/ci.md required workflow/routing and .agents/testing.md CI fuzz tier. [GitHub context availability](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/contexts#context-availability) confirms matrix and needs are valid in steps.if; [GitHub status checks](https://docs.github.com/en/pull-requests/reference/status-checks) confirms skipped jobs report success, so the existing CI required applicability contract remains necessary.

## Review gates

none — unsafe: none; public API: none; permission model: none; dependency addition: none; wire protocol: none.

## Tests

- Failure-first router control: the new receiver-semantics fixture case failed with ts=false before the edge; after the fix it emits ts=true and ts_packages=packages/@keld/electron.
- Synthetic router controls prove an unreferenced crate fixture stays out of Bun while a checked-out test reference discovers a non-hard-coded package.
- Hygiene: 77/77 unit tests plus real-checkout validation; missing step, missing Rust routing, and wrong cargo command each fail.
- cargo check --manifest-path crates/keld-ipc/fuzz/Cargo.toml: passed locally in 18.00s.
- Bash syntax, Ruby YAML parse, standalone rustfmt, git diff --check, and just ci-router-test: passed.
- CARGO_INCREMENTAL=0 just ci: passed end to end, including pinned Mermaid render, workspace clippy with warnings denied, full workspace nextest, rustdoc with warnings denied, and cargo-deny.
- GitHub current-tip CI: all 16 checks passed; CI required is green at 7aa26e66198cb62620c1a1a95bf6c3b4ec9419aa.
- GitHub CodeRabbit was rate-limited at the exact tip. The mandatory isolated substitute ran CodeRabbit CLI against the committed bc15cb9..7aa26e6 diff and returned zero findings across all four files.
- Earlier environment history: the first gate stopped at KELD-DOCS006 until Docker started; a separate clippy attempt hit errno 28 until only this worktree generated targets were cleaned. One later nextest invocation returned opaque exit 100 after building; the explicit diagnostic run passed 623/623 (1 skipped), and the exact final just ci passed. No retry policy or test was weakened.

## Platforms

- Local macOS arm64: all local gates passed; the fuzz compile is diagnostic only.
- GitHub ubuntu-latest: full row passed; Check keld-ipc fuzz workspace executed successfully from 18:38:06Z to 18:38:20Z in [run 33791569400](https://github.com/gyldlab/keld/actions/runs/33791569400/job/100769309247).
- GitHub macos-latest and windows-latest: full rows passed; the fuzz step was present and skipped on each non-Ubuntu row. No real-device product acceptance applies.

## Perf impact

CI minutes only; no product runtime impact. Local cold fuzz-workspace check took 18.00s. The GitHub Ubuntu step took 14 seconds.
