### PR TITLE
docs(ci): fix stale ownership references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 Intake form. Policy lives in AGENTS.md — do not restate it here.
 Strip every HTML comment from the submitted PR body (this block and the per-heading hints). Do not delete them from this file — hygiene reads them. Leftover comments are paid on every later `gh pr view`.
 
-Branch: `agent/kel-<n>-<slug>` from `origin/main` (AGENTS.md § Commits & PRs).
+Branch: `agent/kel-<n>-<slug>` from `origin/main` (`.agents/review.md` § Branch and commit contract).
 
 Required headings below: keep the names. Fill them. Omit any optional heading that would be empty — do not write N/A.
 Optional (only if they have content): `## Linear` (KEL-n), `## Rollback`, `## Screenshots`.

--- a/.github/workflows/keldbot.yml
+++ b/.github/workflows/keldbot.yml
@@ -148,7 +148,7 @@ jobs:
           github-token: ${{ secrets.ROBOKELD_TOKEN }}   # keldrobo ke naam se comment/label post ho, github-actions[bot] se nahi
           script: |
             // Squash-merge PR title ko hi final commit message banata hai, isliye title yahan lint hota hai —
-            // individual commits nahi. Types AGENTS.md § Commits & PRs se (source of truth) — dono jagah साथ update karo.
+            // individual commits nahi. Types .agents/ci.md § KeldBot se (source of truth) — dono jagah साथ update karo.
             const TYPES = ["feat", "fix", "docs", "test", "chore", "ci", "style", "build"];
             const TITLE_RE = new RegExp(`^(${TYPES.join("|")})(\\([\\w./-]+\\))?!?: .+`);
             const MARKER = "<!-- keldbot:title-check -->";
@@ -169,7 +169,7 @@ jobs:
               const commentBody =
                 `${MARKER}\n👋 The PR title doesn't match the conventional-commit format: \`type(scope): subject\`\n\n` +
                 `Allowed types: \`${TYPES.join("`, `")}\`. Example: \`feat(ipc): add shm channel\`. ` +
-                `Edit the title and I'll re-check automatically (AGENTS.md § Commits & PRs).`;
+                `Edit the title and I'll re-check automatically (.agents/ci.md § KeldBot).`;
 
               if (existing) {
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: commentBody });

--- a/docs/specs/keld-mcp-server-v1.md
+++ b/docs/specs/keld-mcp-server-v1.md
@@ -1,6 +1,6 @@
 # Spec: keld MCP server v1 (doctor · docs search · permissions explain)
 
-Status: **APPROVED** (human approval 2026-08-11)
+Status: done
 Linear: KEL-42 · Owner: TBD (human approver) · Updated: 2026-08-13
 
 > Status flipped to **APPROVED** on 2026-08-11; implementation may proceed under


### PR DESCRIPTION
## Summary

- Point KeldBot title-policy references at `.agents/ci.md` § KeldBot and the PR branch instruction at `.agents/review.md` § Branch and commit contract.
- Mark the fully landed MCP server spec `Status: done`; T1–T5 remain checked.
- The `.github/workflows/keldbot.yml` diff is comment/text only: no job logic, action, permission, label, trigger, title regex, or executable value changed.
- PIN delta: Keld `43cab25dd13b3d7379e03c4662482d3f40ea1a40` → fetched `8863ff4ed22f7c3d5fdf4d39b11f06dcd9b02ccd` (PR #136 landed at `8f3ac55`; rebase-only); tracker parent `be8a16e` → `83eb3d3`, prompt identity `prompts/NEW/ci/03-kel157-stale-refs-mcp-status.md` + SHA-256 `93027c2cc51be2e9cd5944e559f1c043fd0499deb056a0a695ea740e656db821`; research stayed at `20eaea5`. Open PRs #150/#144 do not overlap.

## Spec refs

- `.agents/ci.md` § KeldBot
- `.agents/review.md` § Branch and commit contract
- `docs/agents/spec-template.md` status vocabulary
- `docs/specs/keld-mcp-server-v1.md` § 6
- No boundary change.

## Review gates

none

CODEOWNERS review applies to `/.github/` and requested owners remain attached. CodeRabbit CLI 0.7.5 and GitHub CodeRabbit were rate-limited, so neither status is counted as final-tip review. Mandatory isolated substitute ran in a fresh read-only GPT-5.6 Sol/medium process over the exact `origin/main` → final-tree diff with lens `CI behavioral integrity and ownership-reference correctness`. It found one medium concern that `Status: done` conflicted with stale owner/date/open-question prose. A second fresh read-only GPT-5.6 Sol/medium refuter found the concern invalid: the canonical template does not couple `done` to those independent fields; T1–T5 and their implementation/tests are landed; KEL-157 requires `Status: done` and permits only that spec-line edit. No actionable findings survived refutation. A fresh post-rebase isolated review against `origin/main` independently confirmed the three-file diff is clean.

## Tests

- `git grep -n "Commits & PRs" -- .github docs` — no output, exit 1 as required.
- Ruby 2.6 YAML parse of `.github/workflows/keldbot.yml` — passed.
- `just ci-router-test` — passed; the suite confirms a KeldBot workflow edit exercises every conditional lane and every Bun suite.
- `just hygiene` — 77/77 passed plus live checkout check.
- `just ci` on rebased tip `f1923ba` — passed: atomic protocol 19/19; agent context 14/14; Mermaid 7/7 plus 11 digest-pinned renders; product status 69/69; LLM docs 8/8; hygiene 77/77; format; warning-denied workspace Clippy; full workspace nextest; rustdoc; cargo-deny.
- `just llms` — passed with no generated changes because the MCP spec is outside the allowlisted corpus; `just llms-check` passed.
- `git diff --check` — passed.

## Platforms

CI-only comment/text edits on all platforms; no real OS/device acceptance applies. Local macOS full gate passed. The workflow path deliberately causes GitHub’s router to exercise every conditional CI lane.

## Perf impact

none

## Linear

KEL-157

