### PR TITLE
test: justify integration-test lint allows

### DIFF
--- a/crates/keld-cli/tests/concurrent_hello.rs
+++ b/crates/keld-cli/tests/concurrent_hello.rs
@@ -1,6 +1,9 @@
 //! KEL-30: host-owned concurrent hello app-link (Bun + echo live together).
 
-#![allow(clippy::expect_used)]
+#![allow(
+    clippy::expect_used,
+    reason = "This integration test uses expect to make process and IPC failures part of its assertion oracle"
+)]
 
 use std::fs;
 use std::process::Command;

--- a/crates/keld-cli/tests/window_phase_crash.rs
+++ b/crates/keld-cli/tests/window_phase_crash.rs
@@ -55,7 +55,10 @@
 //! AC5 and is human-gated; without it the restarted generation hangs, which is
 //! precisely the condition documented above.
 
-#![allow(clippy::expect_used)]
+#![allow(
+    clippy::expect_used,
+    reason = "These integration tests use expect to make process-lifecycle observations part of their assertion oracle"
+)]
 
 use std::fs;
 use std::process::Command;

--- a/crates/keld-guard/tests/strict_probe.rs
+++ b/crates/keld-guard/tests/strict_probe.rs
@@ -1,6 +1,10 @@
 //! KEL-78 T1: the synthetic probe binary must not claim OS containment.
 
-#![allow(clippy::expect_used, clippy::panic)]
+#![allow(
+    clippy::expect_used,
+    clippy::panic,
+    reason = "This integration test uses expect and assertion panics as its probe-process contract oracle"
+)]
 
 use std::process::Command;
 


### PR DESCRIPTION
## Summary

- Give the three bare integration-test `clippy::expect_used` allows inline reasons that identify their assertion oracle, while retaining the guard probe's existing `clippy::panic` allowance.
- Keep the change attribute-only: no new lint, `#[expect]`, test logic, or other file.
- Prompt/pin evidence: `prompts/NEW/testing/10-kel156-allow-reasons.md` SHA-256 `cd9f2573850caec53de808b6f226c24021b0bf7851f51fc1f1a7d8826a3c28b5`; Keld pin `43cab25dd13b3d7379e03c4662482d3f40ea1a40` → fetched `origin/main` `8863ff4ed22f7c3d5fdf4d39b11f06dcd9b02ccd` (target attributes unchanged); Prompt Tracker parent `be8a16ebe6e5d7198ae5fb9b6f098fa1595eb1bb` → `83eb3d3193d34ca356074ecc9addbfe50f10befd`; research stayed at `20eaea5eeda93473e021fa6ecd7a7f4cea22e17e`; open Keld PRs #150/#144 and zero open Prompt Tracker PRs do not overlap this scope.

## Spec refs

Root `AGENTS.md` § Rust: “A new `allow` needs inline justification.” Precedent: `crates/keld-guard/tests/acl.rs:2-5`. No boundary change.

## Review gates

none

## Tests

- `git grep -n "allow(clippy::expect_used" -- crates/keld-cli/tests/concurrent_hello.rs crates/keld-cli/tests/window_phase_crash.rs crates/keld-guard/tests/strict_probe.rs | grep -v reason` — no output; exit 1 as expected.
- `just ci` — passed on exact tip `260eb2a`: pinned Mermaid renderer validated 11 diagrams; format and workspace clippy with `-D warnings` passed; nextest ran 623 tests (623 passed, 1 skipped); rustdoc and cargo-deny passed.
- CodeRabbit CLI 0.7.5 reviewed commit `260eb2a` against `origin/main`: 0 findings across all three changed files. The GitHub bot's separate rate-limit status is not counted as review.
- GitHub Actions run `33829203668` — `CI required` passed on exact tip `260eb2a`; Ubuntu/macOS/Windows clippy+test, MSRV, Linux GUI smoke, rustfmt, gitleaks, and metadata checks passed.

## Platforms

CI-only. macOS local `just ci` passed; GitHub Ubuntu/macOS/Windows clippy+test, MSRV, and Linux GUI smoke passed. No real OS/device product acceptance applies to an attribute-only change.

## Perf impact

none
