### PR TITLE
ci(linux): verify X11 window controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,12 +243,12 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
-      - name: Install WebKitGTK build deps + Xvfb + xdotool (KEL-28)
+      - name: Install WebKitGTK build deps + X11 control tools (KEL-28)
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
-            libsoup-3.0-dev pkg-config build-essential xvfb xdotool
+            libsoup-3.0-dev pkg-config build-essential fluxbox wmctrl x11-utils xvfb xdotool
       - name: Build keld-host
         run: cargo build -p keld-host
       # KEL-28's own DoD promised "a smoke test exists that CI can run
@@ -257,57 +257,252 @@ jobs:
       # No GPU/Wayland on this runner, so the GPU-safe-mode probe
       # (webkitgtk::probe_gpu_stack) reports Normal and is a no-op here;
       # this job proves window creation, not the safe-mode branch.
-      - name: Xvfb GUI smoke test — real titled window via xdotool
+      - name: Xvfb GUI smoke test — title, controls, and clean close
         run: |
-          set -uo pipefail
-          xvfb_pid=""
+          xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' bash <<'X11'
+          set -euo pipefail
+          window_manager_pid=""
           hello_pid=""
+          cleanup_probe_pid=""
+          title_confirmed=0
+          pid_bound=0
+          close_confirmed=0
           # A bare `trap '... || true' EXIT` clobbers $? with the trap's own
           # last command status, so a script that hit `exit 1` would report
           # success to the CI step. Capture the real exit code first, run
           # cleanup, then re-exit with the captured code explicitly.
+          process_alive() {
+            local process_pid=$1
+            local process_state
+            if ! process_state=$(ps -o stat= -p "$process_pid" 2>/dev/null \
+              | tr -d '[:space:]'); then
+              return 1
+            fi
+            case "$process_state" in
+              ''|Z*) return 1 ;;
+              *) return 0 ;;
+            esac
+          }
+          terminate_child() {
+            local child_pid=$1
+            [ -n "$child_pid" ] || return
+            if process_alive "$child_pid"; then
+              kill "$child_pid" 2>/dev/null || true
+              for _ in $(seq 1 20); do
+                process_alive "$child_pid" || break
+                sleep 0.1
+              done
+            fi
+            if process_alive "$child_pid"; then
+              kill -KILL "$child_pid" 2>/dev/null || true
+              for _ in $(seq 1 20); do
+                process_alive "$child_pid" || break
+                sleep 0.1
+              done
+            fi
+            if ! process_alive "$child_pid"; then
+              wait "$child_pid" 2>/dev/null || true
+            fi
+          }
           cleanup() {
             ec=$?
-            [ -n "$hello_pid" ] && kill "$hello_pid" 2>/dev/null || true
-            [ -n "$xvfb_pid" ] && kill "$xvfb_pid" 2>/dev/null || true
+            set +e
+            terminate_child "$cleanup_probe_pid"
+            terminate_child "$hello_pid"
+            terminate_child "$window_manager_pid"
             exit "$ec"
           }
           trap cleanup EXIT
 
-          Xvfb :99 -screen 0 1024x768x24 &
-          xvfb_pid=$!
-
-          for _ in $(seq 1 50); do
-            [ -e /tmp/.X11-unix/X99 ] && break
-            sleep 0.2
+          sh -c 'kill -STOP $$' &
+          cleanup_probe_pid=$!
+          probe_stopped=0
+          for _ in $(seq 1 20); do
+            case "$(ps -o stat= -p "$cleanup_probe_pid" 2>/dev/null)" in
+              T*) probe_stopped=1; break ;;
+            esac
+            sleep 0.05
           done
-          if [ ! -e /tmp/.X11-unix/X99 ]; then
-            echo "::error::Xvfb never created its X11 socket"
+          if [ "$probe_stopped" -ne 1 ]; then
+            echo "::error::cleanup negative-control child never stopped"
             exit 1
           fi
-          export DISPLAY=:99
+          terminate_child "$cleanup_probe_pid"
+          if process_alive "$cleanup_probe_pid"; then
+            echo "::error::cleanup did not reap a stopped child within its bound"
+            exit 1
+          fi
+          cleanup_probe_pid=""
+
+          if ! xdpyinfo -display "$DISPLAY" >/dev/null 2>&1; then
+            echo "::error::xvfb-run display is unreachable: $DISPLAY"
+            exit 1
+          fi
+
+          fluxbox -display "$DISPLAY" >"$RUNNER_TEMP/fluxbox.log" 2>&1 &
+          window_manager_pid=$!
+          window_manager_ready=0
+          for _ in $(seq 1 50); do
+            if ! kill -0 "$window_manager_pid" 2>/dev/null; then
+              echo "::error::Fluxbox exited before owning the X11 display"
+              cat "$RUNNER_TEMP/fluxbox.log"
+              break
+            fi
+            if root_check=$(xprop -root _NET_SUPPORTING_WM_CHECK 2>/dev/null); then
+              supporting_window=$(printf '%s\n' "$root_check" | awk '/window id/ { print $NF }')
+              if [ -n "$supporting_window" ] && \
+                child_check=$(xprop -id "$supporting_window" _NET_SUPPORTING_WM_CHECK 2>/dev/null) && \
+                wm_name=$(xprop -id "$supporting_window" _NET_WM_NAME 2>/dev/null); then
+                child_window=$(printf '%s\n' "$child_check" | awk '/window id/ { print $NF }')
+                if [ "$child_window" = "$supporting_window" ] && \
+                  printf '%s\n' "$wm_name" | grep -q '= "Fluxbox"$'; then
+                  window_manager_ready=1
+                  break
+                fi
+              fi
+            fi
+            sleep 0.2
+          done
+          if [ "$window_manager_ready" -ne 1 ]; then
+            echo "::error::Fluxbox never advertised its EWMH control window"
+            exit 1
+          fi
 
           ./target/debug/keld-host --hello --title CI-Linux-Smoke &
           hello_pid=$!
 
-          found=0
+          window_id=""
           for _ in $(seq 1 60); do
             if ! kill -0 "$hello_pid" 2>/dev/null; then
               echo "::error::keld-host --hello exited before a window was found"
               break
             fi
-            if xdotool search --name "CI-Linux-Smoke" >/dev/null 2>&1; then
-              found=1
+            if matches=$(xdotool search --all --onlyvisible --pid "$hello_pid" \
+              --name '^CI-Linux-Smoke$' 2>/dev/null); then
+              if [ "$(printf '%s\n' "$matches" | wc -l)" -ne 1 ]; then
+                echo "::error::expected one exact Linux smoke window, got: $matches"
+                exit 1
+              fi
+              window_id=$matches
               break
+            else
+              search_status=$?
+              if [ "$search_status" -ne 1 ]; then
+                echo "::error::xdotool window search failed with $search_status"
+                exit 1
+              fi
             fi
             sleep 0.5
           done
 
-          if [ "$found" -ne 1 ]; then
+          if [ -z "$window_id" ]; then
             echo "::error::keld-host --hello never produced a titled window under Xvfb"
             exit 1
           fi
-          echo "Linux hello window confirmed via xdotool under Xvfb"
+          if [ "$(xdotool getwindowname "$window_id")" != "CI-Linux-Smoke" ]; then
+            echo "::error::Linux smoke window title is not exact"
+            exit 1
+          fi
+          window_pid=$(xdotool getwindowpid "$window_id")
+          if [ "$window_pid" != "$hello_pid" ]; then
+            echo "::error::Linux smoke window belongs to PID $window_pid, expected $hello_pid"
+            exit 1
+          fi
+          title_confirmed=1
+          pid_bound=1
+
+          xdotool windowsize "$window_id" 800 600
+          resized=0
+          width=unknown
+          height=unknown
+          for _ in $(seq 1 50); do
+            geometry=$(xdotool getwindowgeometry --shell "$window_id")
+            width=$(printf '%s\n' "$geometry" | awk -F= '$1 == "WIDTH" { print $2 }')
+            height=$(printf '%s\n' "$geometry" | awk -F= '$1 == "HEIGHT" { print $2 }')
+            if [ "$width" = 800 ] && [ "$height" = 600 ]; then
+              resized=1
+              break
+            fi
+            sleep 0.1
+          done
+          if [ "$resized" -ne 1 ]; then
+            echo "::error::resize requested 800x600, observed ${width}x${height}"
+            exit 1
+          fi
+
+          xdotool windowminimize "$window_id"
+          minimized=0
+          for _ in $(seq 1 50); do
+            if ! window_state=$(xprop -id "$window_id" WM_STATE 2>&1); then
+              echo "::error::cannot read minimized WM_STATE: $window_state"
+              exit 1
+            fi
+            if printf '%s\n' "$window_state" | grep -q 'window state: Iconic'; then
+              minimized=1
+              break
+            fi
+            sleep 0.1
+          done
+          if [ "$minimized" -ne 1 ]; then
+            echo "::error::Linux smoke window did not become minimized"
+            exit 1
+          fi
+
+          xdotool windowactivate "$window_id"
+          restored=0
+          for _ in $(seq 1 50); do
+            if ! window_state=$(xprop -id "$window_id" WM_STATE 2>&1); then
+              echo "::error::cannot read restored WM_STATE: $window_state"
+              exit 1
+            fi
+            if printf '%s\n' "$window_state" | grep -q 'window state: Normal'; then
+              restored=1
+              break
+            fi
+            sleep 0.1
+          done
+          if [ "$restored" -ne 1 ]; then
+            echo "::error::Linux smoke window did not restore"
+            exit 1
+          fi
+
+          if ! process_alive "$hello_pid"; then
+            echo "::error::keld-host stopped before the close request"
+            exit 1
+          fi
+          window_hex=$(printf '0x%x' "$window_id")
+          wmctrl -ic "$window_hex"
+          exited=0
+          for _ in $(seq 1 100); do
+            if ! process_alive "$hello_pid"; then
+              exited=1
+              break
+            fi
+            sleep 0.1
+          done
+          if [ "$exited" -ne 1 ]; then
+            echo "::error::keld-host did not exit after the window close request"
+            exit 1
+          fi
+          set +e
+          wait "$hello_pid"
+          hello_status=$?
+          set -e
+          hello_pid=""
+          if [ "$hello_status" -ne 0 ]; then
+            echo "::error::keld-host exited $hello_status after window close"
+            exit 1
+          fi
+          close_confirmed=1
+          if [ "$window_manager_ready" -ne 1 ] || [ "$title_confirmed" -ne 1 ] || \
+            [ "$pid_bound" -ne 1 ] || [ "$resized" -ne 1 ] || \
+            [ "$minimized" -ne 1 ] || [ "$restored" -ne 1 ] || \
+            [ "$close_confirmed" -ne 1 ]; then
+            echo "::error::Linux window-control receipt is incomplete"
+            exit 1
+          fi
+          echo "Linux hello title, resize, minimize, restore, close, and reap confirmed under X11"
+          X11
 
   msrv:
     name: MSRV


### PR DESCRIPTION
## Summary

- replace the title-only fixed-display Xvfb smoke with a dynamically allocated Xvfb plus Fluxbox EWMH session
- bind the exact titled window to the spawned keld-host PID
- prove resize, minimize, restore, normal WM close, clean host exit, and bounded cleanup
- add a stopped-child cleanup negative control and a final per-control receipt

## Spec refs

KEL-28 and KEL-25 shared Linux window-controls/virtual-display DoD. No product architecture or ownership boundary change.

## Review gates

- unsafe: none
- public API: none
- permission model: none
- dependency addition: CI-only Ubuntu packages fluxbox, wmctrl, and x11-utils; independently reviewed as the minimum existing OS primitives for a real WM and positive EWMH state/control oracles
- wire protocol: none

Two isolated false-green reviews covered X server/WM identity, PID binding, state transitions, graceful close, status preservation, and stopped-process cleanup. Exact committed-tip CodeRabbit returned 0 findings.

## Tests

- workflow run block parses as Bash; YAML parses
- just ci-router-test: passed
- just hygiene: 77/77 and checkout validation passed
- cargo fmt --all --check: passed
- cargo clippy --workspace --all-targets -- -D warnings: passed
- cargo nextest run --workspace --profile ci: 565/565 passed, 1 skipped
- rustdoc with warnings denied: passed
- cargo-deny: advisories/bans/licenses/sources passed
- product-status and llms contract/check gates: passed
- checksum-pinned gitleaks working-tree scan: no leaks
- just ci stopped only at KELD-DOCS006 because local Docker is unavailable; no Mermaid/docs changed, and GitHub hygiene will execute the pinned renderer

## Platforms

Local Ubuntu static/contract and complete Rust gates passed. Actual X11 control acceptance is intentionally pending the PR ubuntu-latest Linux GUI smoke; no Wayland or non-Debian claim is made by this change.

## Perf impact

No product runtime impact. The routed Linux GUI job installs three small X11-control packages and performs bounded state checks only when the router selects the GUI lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Linux GUI smoke testing to validate window-manager readiness and application window behavior.
  * Added checks for exact window title, process association, resizing, minimizing, restoring, and closing.
  * Improved cleanup verification to confirm child processes exit correctly, including stopped-process scenarios.
  * Added required graphical testing tools to support the enhanced validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->