### PR TITLE
fix(core): remove release-only Linux warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,10 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
             libsoup-3.0-dev pkg-config build-essential fluxbox wmctrl x11-utils xvfb xdotool
-      - name: Build keld-host
-        run: cargo build -p keld-host
+      - name: Build release keld-host with warnings denied
+        env:
+          RUSTFLAGS: -D warnings
+        run: cargo build --release -p keld-host
       # KEL-28's own DoD promised "a smoke test exists that CI can run
       # (headless/virtual display where needed)" but this job never existed
       # until now — closing a disclosed gap, not a new requirement.
@@ -368,7 +370,7 @@ jobs:
             exit 1
           fi
 
-          ./target/debug/keld-host --hello --title CI-Linux-Smoke &
+          ./target/release/keld-host --hello --title CI-Linux-Smoke &
           hello_pid=$!
 
           window_id=""

--- a/crates/keld-core/src/app_session.rs
+++ b/crates/keld-core/src/app_session.rs
@@ -1772,14 +1772,15 @@ fn linux_strict_primary_config_x86(
         .readonly_runtime(&root.join(entry_path), Path::new(LINUX_BUN_ENTRY))
         .map_err(|source| app_detail("Linux strict entry", source.to_string()))?;
 
-    let mut config = PrimaryRoleConfig::new(bun)
+    let config = PrimaryRoleConfig::new(bun)
         .arg("run")
         .arg(LINUX_BUN_ENTRY)
         .env("HOME", "/app")
         .env("TMPDIR", "/tmp")
         .env_remove(DEV_LEASE_ENV);
     #[cfg(debug_assertions)]
-    {
+    let config = {
+        let mut config = config;
         if let Some(control) = std::env::var_os("KELD_T1B_CONTROL") {
             let control = PathBuf::from(control)
                 .canonicalize()
@@ -1793,7 +1794,8 @@ fn linux_strict_primary_config_x86(
             config = config.env("KELD_T2_EXIT_ON_LINK_EOF", value);
         }
         config = config.env("KELD_T4_LINUX_STRICT", "1");
-    }
+        config
+    };
     Ok(config.linux_strict(profile))
 }
 


### PR DESCRIPTION
## Summary

- Remove the Release-only `unused_mut` failure from Linux strict-role configuration without a lint allow or a duplicated builder.
- Reuse the existing Linux GUI lane to compile the actual Release host with warnings denied, then run its existing X11 lifecycle smoke against that exact artifact.

## Spec refs

No boundary change

## Review gates

none — unsafe: none; public API: none; permission model: none; dependency addition: none; wire protocol: none.

## Tests

- Failure-first on base: `RUSTFLAGS="-D warnings" cargo check --release -p keld-core` — failed with `unused_mut` at `app_session.rs:1775`.
- Fixed tip: the same Release warning-denied command passed.
- Independent audit: `RUSTFLAGS="-D warnings" cargo build --release -p keld-host` passed; debug `RUSTFLAGS="-D warnings" cargo check -p keld-host` passed; workflow structure and Release artifact path passed.
- `cargo nextest run -p keld-host --test no_flag_linux --profile ci` — 9/9 passed.
- `cargo fmt --all --check` — passed.
- Workspace Clippy with warnings denied — passed.
- Full workspace nextest — 565/565 passed, 1 intentional skip.
- Rustdoc with warnings denied — passed.
- `cargo deny` — passed.
- `just product-status-test product-status-check llms-test llms-check hygiene` — product-status 69, llms 8, hygiene 77; all passed.
- `just ci-router-test` — passed, including every conditional lane for a workflow edit.
- Gitleaks 8.30.1 exact commit-range scan — no leaks.
- CodeRabbit CLI 0.7.5 on exact commit `2953f57` against `origin/main` — 0 findings.
- `just ci` — all reached gates passed except `KELD-DOCS006`: Docker is unavailable on this device for the pinned Mermaid renderer. No docs or diagrams changed. The GitHub hygiene job is the owning completion check and must pass before merge.

## Platforms

- Linux: Release and debug warning-denied compilation passed on the development host; Linux no-flag tests passed 9/9. The PR's routed Linux GUI job must build the Release host and pass the existing virtual-X11 resize/minimize/restore/close and lifecycle contract before merge.
- Windows and macOS: no product-contract change; workflow edits route their existing CI lanes, which must pass before merge.
- Real desktop behavior is unchanged; the landed KEL-28 Ubuntu X11 evidence remains the product baseline. This PR does not claim the still-open non-Debian real-device acceptance.

## Perf impact

none — build profile enforcement and ownership-preserving source refactor; no performance claim.

## Linear

KEL-170
