### PR TITLE
fix(git): prevent checkout from running branch code

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,31 +1,18 @@
 #!/usr/bin/env bash
-# After branch checkout: refresh local-only research + competitor clones.
-# Soft-skip on missing just / no private-repo access — never fail the checkout.
+# After branch checkout: remind maintainers to refresh local-only clones deliberately.
+# This installed copy must never execute code from the incoming working tree.
 # Args from git: previous HEAD, new HEAD, branch(1)/file(0) flag.
-# competitors-sync is backgrounded so checkout is not blocked on shallow clones.
-set -uo pipefail
+set -u
 
 # File checkouts (flag 0) should not re-sync trees.
 if [[ "${3:-0}" != "1" ]]; then
   exit 0
 fi
 
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-cd "$ROOT" || exit 0
-
-if ! command -v just >/dev/null 2>&1; then
-  echo "warning: just not found; skip research-sync / competitors-sync" >&2
-  exit 0
-fi
-
-if ! just research-sync; then
-  echo "warning: research-sync failed; research tree may be stale (checkout succeeded)" >&2
-fi
-
-(
-  if ! just competitors-sync; then
-    echo "warning: competitors-sync failed; checkout succeeded (local-only trees unchanged)" >&2
-  fi
-) &
+printf '%s\n' \
+  'keld hook: checkout ran no repository code.' \
+  'After reviewing the checked-out revision, refresh local-only clones explicitly:' \
+  '  just research-sync' \
+  '  just competitors-sync'
 
 exit 0

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,25 +1,12 @@
 #!/usr/bin/env bash
-# After merge (e.g. git pull): refresh local-only research + competitor clones.
-# Soft-skip on missing just / no private-repo access — never fail the pull.
-# competitors-sync is backgrounded so pull is not blocked on shallow clones.
-set -uo pipefail
+# After merge: remind maintainers to refresh local-only clones deliberately.
+# This installed copy must never execute code from the merged working tree.
+set -u
 
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-cd "$ROOT" || exit 0
-
-if ! command -v just >/dev/null 2>&1; then
-  echo "warning: just not found; skip research-sync / competitors-sync" >&2
-  exit 0
-fi
-
-if ! just research-sync; then
-  echo "warning: research-sync failed; research tree may be stale (pull succeeded)" >&2
-fi
-
-(
-  if ! just competitors-sync; then
-    echo "warning: competitors-sync failed; pull succeeded (local-only trees unchanged)" >&2
-  fi
-) &
+printf '%s\n' \
+  'keld hook: merge ran no repository code.' \
+  'After reviewing the merged revision, refresh local-only clones explicitly:' \
+  '  just research-sync' \
+  '  just competitors-sync'
 
 exit 0

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /Cargo.lock                         @nixn7 @rahul-tumma @hp282000 @amishabenramani @Rajkakadiya07 @0monish
 /rust-toolchain.toml                @nixn7 @rahul-tumma @hp282000 @amishabenramani @Rajkakadiya07 @0monish
 /.github/                           @nixn7 @rahul-tumma @hp282000 @amishabenramani @Rajkakadiya07 @0monish
+/.githooks/                         @nixn7 @rahul-tumma @hp282000 @amishabenramani @Rajkakadiya07 @0monish
 /AGENTS.md                          @nixn7 @rahul-tumma @hp282000 @amishabenramani @Rajkakadiya07 @0monish
 /.agents/                           @nixn7 @rahul-tumma @hp282000 @amishabenramani @Rajkakadiya07 @0monish
 /.codex/                            @nixn7 @rahul-tumma @hp282000 @amishabenramani @Rajkakadiya07 @0monish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,15 @@ Engineering rules, the verification gate, and review gates are in
 
 1. Clone this repository.
 2. Use the pinned toolchain in `rust-toolchain.toml` (1.97.1).
-3. Maintainers (optional): run `just hooks-install` once so this clone uses
-   tracked `.githooks/` (`core.hooksPath`, local config only). After that,
-   `git pull` / checkout runs `just research-sync` then `just competitors-sync`
-   for gitignored private research and competitor clones. Git cannot enable
-   hooks automatically on clone. Push research with `just research-push` (nested
-   `docs/research/` repo only — never stage research into Keld).
+3. Maintainers (optional): after reviewing the current revision, run
+   `just hooks-install` once. It copies notification-only hooks into this clone's
+   Git common directory and sets the local `core.hooksPath`; checkout and merge
+   never execute code from the incoming working tree. The hooks print the exact
+   `just research-sync` and `just competitors-sync` commands for you to run
+   explicitly after reviewing the new revision. Rerun `just hooks-install` only
+   when you intend to trust updated hook bytes. Git cannot enable hooks on clone.
+   Push research with `just research-push` (nested `docs/research/` repo only —
+   never stage research into Keld).
 4. Run the exact full local gate:
 
    ```bash

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ hello:
 
 # Run every CI gate locally (deny requires `cargo install cargo-deny --locked`).
 # gitleaks stays GitHub-only (pinned OSS CLI in .github/workflows/ci.yml).
-ci: agents-md atomic-protocol agent-context ci-router-test mermaid-test mermaid-check mermaid-render-check product-status-test product-status-check llms-test llms-check hygiene fmt-check clippy test doc deny
+ci: agents-md atomic-protocol agent-context ci-router-test hooks-test mermaid-test mermaid-check mermaid-render-check product-status-test product-status-check llms-test llms-check hygiene fmt-check clippy test doc deny
 
 # Check playbook routing and require crate AGENTS.md wherever Rust opts into unsafe.
 agents-md:
@@ -156,6 +156,10 @@ hygiene:
 # KEL-81: keep change-based CI routing falsifiable outside GitHub Actions too.
 ci-router-test:
     tools/ci_changes_test.sh
+
+# KEL-159: checkout hooks must never execute code from the incoming revision.
+hooks-test:
+    tools/hooks_test.sh
 
 # Format the workspace in place.
 fmt:
@@ -323,11 +327,17 @@ competitors-sync *args:
         -o "$ROOT/target/competitors-sync/competitors-sync"
     "$ROOT/target/competitors-sync/competitors-sync" "$@" "$ROOT"
 
-# Point this clone at tracked .githooks/ (local config only — not --global).
+# Install reviewed hook copies outside the working tree (local config only — not --global).
 hooks-install:
     #!/usr/bin/env bash
     set -euo pipefail
     ROOT="$(git rev-parse --show-toplevel)"
-    git -C "$ROOT" config core.hooksPath .githooks
-    chmod +x "$ROOT/.githooks/post-merge" "$ROOT/.githooks/post-checkout"
-    echo "hooks-install: core.hooksPath=.githooks (local). pull/checkout will run research-sync then competitors-sync."
+    COMMON_DIR="$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir)"
+    HOOKS_DIR="$COMMON_DIR/keld-hooks"
+    mkdir -p "$HOOKS_DIR"
+    cp -- "$ROOT/.githooks/post-merge" "$HOOKS_DIR/post-merge"
+    cp -- "$ROOT/.githooks/post-checkout" "$HOOKS_DIR/post-checkout"
+    chmod +x "$HOOKS_DIR/post-merge" "$HOOKS_DIR/post-checkout"
+    git -C "$ROOT" config core.hooksPath "$HOOKS_DIR"
+    echo "hooks-install: installed reviewed reminder hooks at $HOOKS_DIR (local)."
+    echo "hooks-install: checkout/merge will not execute working-tree code."

--- a/tools/hooks_test.sh
+++ b/tools/hooks_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_root="$(git rev-parse --show-toplevel)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/keld-hooks-test.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+git -C "$fixture" init -q -b main
+empty_hooks="$fixture/empty-hooks"
+mkdir -p "$empty_hooks"
+git -C "$fixture" config core.hooksPath "$empty_hooks"
+git -C "$fixture" config user.email hooks-test@keld.invalid
+git -C "$fixture" config user.name "Keld hooks test"
+mkdir -p "$fixture/.githooks"
+cp "$source_root/justfile" "$fixture/justfile"
+cp "$source_root/.githooks/post-checkout" "$fixture/.githooks/post-checkout"
+cp "$source_root/.githooks/post-merge" "$fixture/.githooks/post-merge"
+git -C "$fixture" add justfile .githooks/post-checkout .githooks/post-merge
+git -C "$fixture" commit -qm base
+
+git -C "$fixture" switch -qc attack
+printf '%s\n' \
+  'research-sync:' \
+  '    touch attack-marker' \
+  '' \
+  'competitors-sync:' \
+  '    true' \
+  >"$fixture/justfile"
+git -C "$fixture" add justfile
+git -C "$fixture" commit -qm 'attack: replace sync recipes'
+git -C "$fixture" switch -q main
+
+# Negative control: the legacy hook behavior executes the incoming attack recipe.
+common_dir="$(git -C "$fixture" rev-parse --path-format=absolute --git-common-dir)"
+legacy_hooks="$common_dir/legacy-hooks"
+mkdir -p "$legacy_hooks"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'root="$(git rev-parse --show-toplevel)"' \
+  'cd "$root"' \
+  'just research-sync' \
+  >"$legacy_hooks/post-checkout"
+chmod +x "$legacy_hooks/post-checkout"
+git -C "$fixture" config core.hooksPath "$legacy_hooks"
+git -C "$fixture" switch attack >"$fixture/legacy-checkout.out" 2>&1
+if [[ ! -e "$fixture/attack-marker" ]]; then
+  echo "error: legacy hook negative control did not execute the attack recipe" >&2
+  exit 1
+fi
+git -C "$fixture" config core.hooksPath /dev/null
+rm "$fixture/attack-marker"
+git -C "$fixture" switch -q main
+
+(
+  cd "$fixture"
+  just hooks-install
+)
+git -C "$fixture" switch attack >"$fixture/checkout.out" 2>&1
+
+if [[ -e "$fixture/attack-marker" ]]; then
+  echo "error: checkout executed the incoming branch's justfile" >&2
+  exit 1
+fi
+
+hooks_path="$(git -C "$fixture" config --path --get core.hooksPath)"
+if [[ "$hooks_path" != "$common_dir/keld-hooks" ]]; then
+  echo "error: hooksPath '$hooks_path' is not the trusted Git-common-dir path '$common_dir/keld-hooks'" >&2
+  exit 1
+fi
+
+if grep -Eq '^[[:space:]]*just[[:space:]]' \
+  "$hooks_path/post-checkout" "$hooks_path/post-merge"; then
+  echo "error: installed hooks still execute working-tree just recipes" >&2
+  exit 1
+fi
+
+grep -Fq 'just research-sync' "$fixture/checkout.out"
+grep -Fq 'just competitors-sync' "$fixture/checkout.out"
+echo "hooks checkout trust-boundary test ok"


### PR DESCRIPTION
## Summary

- Stop checkout and merge hooks from executing `just` recipes or tools from the incoming working-tree revision.
- Install reviewed notification-only hook copies under Git’s common directory, outside branch-controlled paths; sync commands become explicit post-review actions.
- Add a real disposable-repository attack regression with a legacy negative control, document the trust boundary, and place `/.githooks/` under CODEOWNERS.
- Pin delta: Keld `origin/main=15e54d2811b364d9dcaac5f3a8023a770778631b`; Prompt Tracker `origin/main=83eb3d3193d34ca356074ecc9addbfe50f10befd`; research `origin/main=20eaea5eeda93473e021fa6ecd7a7f4cea22e17e`. Open PRs #150, #153, and #144 do not overlap these paths.

## Spec refs

KEL-159 acceptance and the repository’s default-deny/supply-chain boundary. No product architecture, public API, permission model, or wire boundary change.

## Review gates

none

Supply-chain security evidence: CodeRabbit CLI 0.7.6 and GitHub CodeRabbit reviewed all six final-tip files under the checkout trust-boundary lens. The CLI’s first pass found one valid fixture-isolation issue; the fix landed, and both final reviews report no findings. GitHub’s final review risk coverage names exact tip `1f07c2ea337348fc35c5e4477171c0e389917f31`.

## Tests

- Failure-first: `tools/hooks_test.sh` on the unfixed behavior exited 1 with `checkout executed the incoming branch's justfile` after the attack recipe wrote its marker.
- Final `tools/hooks_test.sh`: passed. Its controlled legacy hook creates the marker; production installation leaves it absent, resolves `core.hooksPath` under the Git common directory, invokes no working-tree `just`, and prints both explicit sync commands.
- `just ci-router-test`: passed.
- `just hygiene`: 77/77 tests passed.
- Exact `just ci` on `1f07c2ea337348fc35c5e4477171c0e389917f31`: passed; hook regression passed; pinned Mermaid renderer validated 9 diagrams; format and workspace clippy with warnings denied passed; nextest ran 623 tests (623 passed, 1 skipped); rustdoc and cargo-deny passed.
- GitHub Actions run `33858478076`: `CI required` passed; Ubuntu/macOS/Windows clippy+test, Bun, MSRV, cargo-deny, Linux GUI smoke, CODEOWNERS/templates, rustfmt, gitleaks, and metadata checks passed.
- `git diff --check` and Bash syntax checks passed.

## Platforms

CI-only. The real Git checkout regression passed on macOS; the GitHub Ubuntu/macOS/Windows matrix passed. No real product OS/device acceptance applies because this prevents repository checkout-time execution rather than claiming an OS sandbox.

## Perf impact

none

## Linear

KEL-159
