### PR TITLE
fix(cli): reject foreign-owned project roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,11 @@ jobs:
               cargo nextest run -p "$package" --profile ci --no-tests=pass
             fi
           done
+      - name: Real Linux foreign-owner refusal (KEL-167)
+        if: matrix.os == 'ubuntu-latest' && contains(needs.changes.outputs.ubuntu_packages, 'keld-cli')
+        env:
+          KELD_REAL_LINUX_OWNER_PROOF: "1"
+        run: cargo test -p keld-cli --test project_owner_linux real_linux_second_account_refuses_foreign_owned_project -- --ignored --exact --nocapture
       - name: rustdoc (warnings deny)
         if: matrix.os == 'ubuntu-latest'
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "keld-ipc",
  "keld-runtime",
  "rmcp",
+ "rustix",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/keld-cli/Cargo.toml
+++ b/crates/keld-cli/Cargo.toml
@@ -30,6 +30,9 @@ tokio = { workspace = true }
 getrandom = { workspace = true }
 sha2 = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true, features = ["process"] }
+
 [target.'cfg(windows)'.dependencies]
 windows-permissions = { workspace = true }
 windows-sys = { workspace = true }

--- a/crates/keld-cli/src/boot.rs
+++ b/crates/keld-cli/src/boot.rs
@@ -1,7 +1,8 @@
 //! Non-release owner-private boot stage compiler (KEL-96/T1a/T4).
 
+use std::fs;
 #[cfg(any(target_os = "macos", target_os = "linux", windows))]
-use std::fs::{self, File, OpenOptions};
+use std::fs::{File, OpenOptions};
 #[cfg(any(target_os = "macos", target_os = "linux", windows))]
 use std::io::{self, Read, Seek, SeekFrom, Write};
 #[cfg(any(target_os = "macos", target_os = "linux", windows))]
@@ -11,9 +12,11 @@ use std::path::{Path, PathBuf};
 #[cfg(any(target_os = "macos", target_os = "linux", windows))]
 use sha2::{Digest, Sha256};
 #[cfg(windows)]
+use windows_permissions::constants::{SeObjectType, SecurityInformation};
+#[cfg(windows)]
 use windows_permissions::utilities::current_process_sid;
 #[cfg(windows)]
-use windows_permissions::wrappers::ConvertSidToStringSid;
+use windows_permissions::wrappers::{ConvertSidToStringSid, GetNamedSecurityInfo};
 #[cfg(windows)]
 use windows_permissions::{LocalBox, SecurityDescriptor};
 #[cfg(windows)]
@@ -61,30 +64,120 @@ impl DevBootStage {
     }
 }
 
+/// Failure to prove that project input belongs to the invoking OS principal.
+#[derive(Debug)]
+pub struct ProjectOwnershipError {
+    path: PathBuf,
+    detail: String,
+}
+
+impl ProjectOwnershipError {
+    pub(crate) fn foreign(path: PathBuf) -> Self {
+        Self {
+            path,
+            detail: String::from("owner does not equal the invoking OS principal"),
+        }
+    }
+
+    fn inspection(path: PathBuf, source: impl std::fmt::Display) -> Self {
+        Self {
+            path,
+            detail: format!("owner could not be verified: {source}"),
+        }
+    }
+}
+
+impl std::fmt::Display for ProjectOwnershipError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "KELD-CLI-049: refusing project path `{}` — {}. \
+             Move the project below a directory owned by the invoking user and correct the path's ownership before running Keld.",
+            self.path.display(),
+            self.detail
+        )
+    }
+}
+
+impl std::error::Error for ProjectOwnershipError {}
+
+/// Returns only after `path` is proven to belong to the invoking OS principal.
+pub(crate) fn ensure_current_principal_owns(path: &Path) -> Result<(), ProjectOwnershipError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let metadata = fs::metadata(path)
+            .map_err(|source| ProjectOwnershipError::inspection(path.to_owned(), source))?;
+        let invoking_uid = rustix::process::geteuid().as_raw();
+        if metadata.uid() != invoking_uid {
+            return Err(ProjectOwnershipError::foreign(path.to_owned()));
+        }
+        Ok(())
+    }
+    #[cfg(windows)]
+    {
+        let current = current_process_sid()
+            .map_err(|source| ProjectOwnershipError::inspection(path.to_owned(), source))?;
+        let descriptor = GetNamedSecurityInfo(
+            path.as_os_str(),
+            SeObjectType::SE_FILE_OBJECT,
+            SecurityInformation::Owner,
+        )
+        .map_err(|source| ProjectOwnershipError::inspection(path.to_owned(), source))?;
+        if descriptor.owner() != Some(&current) {
+            return Err(ProjectOwnershipError::foreign(path.to_owned()));
+        }
+        Ok(())
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        Err(ProjectOwnershipError::inspection(
+            path.to_owned(),
+            "this platform has no implemented project-owner identity check",
+        ))
+    }
+}
+
 /// Failure while compiling the non-release boot stage.
 #[derive(Debug)]
-pub struct BootCompileError {
-    phase: &'static str,
-    detail: String,
+pub enum BootCompileError {
+    /// Project input did not belong to the invoking principal.
+    ProjectOwnership(ProjectOwnershipError),
+    /// Another staging phase failed.
+    Staging {
+        /// Staging operation that failed.
+        phase: &'static str,
+        /// Underlying failure detail.
+        detail: String,
+    },
 }
 
 impl BootCompileError {
     fn new(phase: &'static str, detail: impl Into<String>) -> Self {
-        Self {
+        Self::Staging {
             phase,
             detail: detail.into(),
         }
     }
 }
 
+impl From<ProjectOwnershipError> for BootCompileError {
+    fn from(value: ProjectOwnershipError) -> Self {
+        Self::ProjectOwnership(value)
+    }
+}
+
 impl std::fmt::Display for BootCompileError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "KELD-CLI-047: boot staging failed during {} — {}. \
-             Fix the project files and regenerate a fresh owner-private dev stage.",
-            self.phase, self.detail
-        )
+        match self {
+            Self::ProjectOwnership(error) => error.fmt(f),
+            Self::Staging { phase, detail } => write!(
+                f,
+                "KELD-CLI-047: boot staging failed during {phase} — {detail}. \
+                 Fix the project files and regenerate a fresh owner-private dev stage."
+            ),
+        }
     }
 }
 
@@ -138,18 +231,37 @@ pub fn stage_dev_boot(
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux", windows))]
-#[allow(clippy::too_many_lines)] // one atomic staging transaction keeps cleanup and integrity checks contiguous
 fn stage_dev_boot_platform(
     project_root: &Path,
     developer_host: &Path,
 ) -> Result<DevBootStage, BootCompileError> {
+    stage_dev_boot_platform_with_owner_check(
+        project_root,
+        developer_host,
+        ensure_current_principal_owns,
+    )
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux", windows))]
+#[allow(clippy::too_many_lines)] // one atomic staging transaction keeps cleanup and integrity checks contiguous
+fn stage_dev_boot_platform_with_owner_check<F>(
+    project_root: &Path,
+    developer_host: &Path,
+    mut owner_check: F,
+) -> Result<DevBootStage, BootCompileError>
+where
+    F: FnMut(&Path) -> Result<(), ProjectOwnershipError>,
+{
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     use std::os::unix::fs::PermissionsExt as _;
 
     let project_root = project_root
         .canonicalize()
         .map_err(|source| BootCompileError::new("project root", source.to_string()))?;
-    let config = fs::read_to_string(project_root.join("keld.config.ts"))
+    owner_check(&project_root)?;
+    let config_path = project_root.join("keld.config.ts");
+    owner_check(&config_path)?;
+    let config = fs::read_to_string(config_path)
         .map_err(|source| BootCompileError::new("project config", source.to_string()))?;
     let name = keld_core::title_from_config_ts(&config)
         .unwrap_or_else(|| keld_core::DEFAULT_HELLO_TITLE.to_owned());
@@ -162,6 +274,8 @@ fn stage_dev_boot_platform(
 
     let entry_source = contained_source(&project_root, &entry, "entry")?;
     let renderer_source = contained_source(&project_root, &renderer, "renderer")?;
+    owner_check(&entry_source)?;
+    owner_check(&renderer_source)?;
     let (developer_host_path, mut host_source, host_source_metadata) =
         open_developer_executable(developer_host, "developer host")?;
     #[cfg(not(target_os = "linux"))]
@@ -287,11 +401,22 @@ fn stage_dev_boot_platform(
 
 #[cfg(target_os = "linux")]
 fn prepare_linux_dev_root(project_root: &Path, dev_root: &Path) -> Result<(), BootCompileError> {
+    prepare_linux_dev_root_for_uid(project_root, dev_root, rustix::process::geteuid().as_raw())
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_linux_dev_root_for_uid(
+    project_root: &Path,
+    dev_root: &Path,
+    expected_uid: u32,
+) -> Result<(), BootCompileError> {
     use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _, PermissionsExt as _};
 
-    let expected_uid = fs::metadata(project_root)
-        .map_err(|source| BootCompileError::new("project root", source.to_string()))?
-        .uid();
+    let project_metadata = fs::metadata(project_root)
+        .map_err(|source| BootCompileError::new("project root", source.to_string()))?;
+    if project_metadata.uid() != expected_uid {
+        return Err(ProjectOwnershipError::foreign(project_root.to_owned()).into());
+    }
     for directory in [project_root.join(".keld"), dev_root.to_owned()] {
         match fs::symlink_metadata(&directory) {
             Ok(metadata) => {
@@ -805,6 +930,45 @@ mod tests {
         assert_ne!(first.root(), second.root());
     }
 
+    #[test]
+    fn stage_dev_boot_refuses_a_foreign_owned_project_root() {
+        let (_temp, project, source_host) = fixture();
+        let error = stage_dev_boot_platform_with_owner_check(&project, &source_host, |_| {
+            Err(ProjectOwnershipError::foreign(project.clone()))
+        })
+        .expect_err("foreign-owned project input must fail before staging");
+
+        assert!(error.to_string().contains("KELD-CLI-049"), "{error}");
+        assert!(
+            !project.join(".keld").exists(),
+            "ownership refusal must precede every staging side effect"
+        );
+    }
+
+    #[test]
+    fn stage_dev_boot_refuses_a_foreign_owned_entry_before_staging() {
+        let (_temp, project, source_host) = fixture();
+        let entry = project
+            .join("src/main.ts")
+            .canonicalize()
+            .expect("canonical entry fixture");
+        let error = stage_dev_boot_platform_with_owner_check(&project, &source_host, |candidate| {
+            if candidate == entry {
+                Err(ProjectOwnershipError::foreign(candidate.to_owned()))
+            } else {
+                Ok(())
+            }
+        })
+        .expect_err("foreign-owned executable project bytes must not be staged");
+
+        assert!(error.to_string().contains("KELD-CLI-049"), "{error}");
+        assert!(error.to_string().contains("src/main.ts"), "{error}");
+        assert!(
+            !project.join(".keld").exists(),
+            "entry ownership refusal must precede every staging side effect"
+        );
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn missing_role_launcher_fails_before_creating_a_stage() {
@@ -820,6 +984,32 @@ mod tests {
             .expect_err("Linux stage without the strict launcher must fail");
         assert!(error.to_string().contains("developer launcher"), "{error}");
         assert!(!project.join(".keld/dev").exists());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn prepare_linux_dev_root_rejects_foreign_project_before_permissions_change() {
+        let (_temp, project, _source_host) = fixture();
+        fs::set_permissions(&project, fs::Permissions::from_mode(0o755))
+            .expect("project fixture mode");
+        let actual_uid = fs::metadata(&project).expect("project metadata").uid();
+        let foreign_uid = actual_uid.checked_add(1).unwrap_or_else(|| actual_uid - 1);
+
+        let error =
+            prepare_linux_dev_root_for_uid(&project, &project.join(".keld/dev"), foreign_uid)
+                .expect_err("project ownership must be anchored to the invoking euid");
+
+        assert!(error.to_string().contains("KELD-CLI-049"), "{error}");
+        assert_eq!(
+            fs::metadata(&project)
+                .expect("project metadata after refusal")
+                .permissions()
+                .mode()
+                & 0o7777,
+            0o755,
+            "ownership mismatch must fail before any permission mutation"
+        );
+        assert!(!project.join(".keld").exists());
     }
 
     #[test]

--- a/crates/keld-cli/src/dev.rs
+++ b/crates/keld-cli/src/dev.rs
@@ -28,6 +28,7 @@ use keld_runtime::RestartPolicy;
 #[cfg(windows)]
 use windows_sys::Win32::System::Threading::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
 
+use crate::boot::{ProjectOwnershipError, ensure_current_principal_owns};
 use crate::doctor::{all_ok, renderer_load_message, renderer_path_problem, run_checks};
 
 pub use crate::doctor::RENDERER_LOAD_CODE;
@@ -112,16 +113,44 @@ pub struct DevEchoResult {
     pub link: String,
 }
 
-/// Finds the project root containing `keld.config.ts`, starting at `cwd`.
-#[must_use]
-pub fn find_project_root(cwd: &Path) -> Option<PathBuf> {
+/// Finds an owner-controlled project root containing `keld.config.ts`, starting at `cwd`.
+///
+/// Discovery stops at the first ancestor not owned by the invoking OS principal.
+/// If that boundary itself contains a Keld config, the ownership fault is
+/// returned instead of being mistaken for an absent project.
+///
+/// # Errors
+///
+/// Returns [`ProjectOwnershipError`] (`KELD-CLI-049`) when a candidate project
+/// directory or its config is not owned by the invoking principal, or its
+/// owner cannot be inspected.
+pub fn find_project_root(cwd: &Path) -> Result<Option<PathBuf>, ProjectOwnershipError> {
+    find_project_root_with_owner_check(cwd, ensure_current_principal_owns)
+}
+
+fn find_project_root_with_owner_check<F>(
+    cwd: &Path,
+    mut owner_check: F,
+) -> Result<Option<PathBuf>, ProjectOwnershipError>
+where
+    F: FnMut(&Path) -> Result<(), ProjectOwnershipError>,
+{
     let mut dir = cwd.to_path_buf();
     loop {
-        if dir.join("keld.config.ts").is_file() {
-            return Some(dir);
+        let config = dir.join("keld.config.ts");
+        if let Err(error) = owner_check(&dir) {
+            return if config.is_file() {
+                Err(error)
+            } else {
+                Ok(None)
+            };
+        }
+        if config.is_file() {
+            owner_check(&config)?;
+            return Ok(Some(dir));
         }
         if !dir.pop() {
-            return None;
+            return Ok(None);
         }
     }
 }
@@ -675,7 +704,9 @@ mod tests {
         fs::create_dir_all(root.join("src")).expect("src");
         fs::write(root.join("keld.config.ts"), "export default {}\n").expect("config");
         assert_eq!(
-            find_project_root(&root.join("src")).as_deref(),
+            find_project_root(&root.join("src"))
+                .expect("owned project discovery")
+                .as_deref(),
             Some(root.as_path())
         );
     }
@@ -683,7 +714,65 @@ mod tests {
     #[test]
     fn missing_config_is_none() {
         let dir = tempfile::tempdir().expect("tempdir");
-        assert_eq!(find_project_root(dir.path()), None);
+        assert_eq!(find_project_root(dir.path()).expect("owned search"), None);
+    }
+
+    #[test]
+    fn find_project_root_skips_an_ancestor_owned_by_another_principal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let trusted_project = dir.path().join("trusted-project");
+        let foreign_boundary = trusted_project.join("foreign-boundary");
+        let cwd = foreign_boundary.join("nested");
+        fs::create_dir_all(&cwd).expect("nested cwd");
+        fs::write(
+            trusted_project.join("keld.config.ts"),
+            "export default {}\n",
+        )
+        .expect("higher trusted config");
+
+        let selected = find_project_root_with_owner_check(&cwd, |candidate| {
+            if candidate == foreign_boundary {
+                Err(ProjectOwnershipError::foreign(candidate.to_owned()))
+            } else {
+                Ok(())
+            }
+        })
+        .expect("an unowned boundary without a config stops discovery cleanly");
+
+        assert_eq!(
+            selected, None,
+            "the walk must not skip a foreign boundary and adopt a higher config"
+        );
+    }
+
+    #[test]
+    fn find_project_root_rejects_a_foreign_candidate_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let foreign_project = dir.path().join("foreign-project");
+        let cwd = foreign_project.join("nested");
+        fs::create_dir_all(&cwd).expect("nested cwd");
+        fs::write(
+            foreign_project.join("keld.config.ts"),
+            "export default {}\n",
+        )
+        .expect("foreign config");
+
+        let error = find_project_root_with_owner_check(&cwd, |candidate| {
+            if candidate == foreign_project {
+                Err(ProjectOwnershipError::foreign(candidate.to_owned()))
+            } else {
+                Ok(())
+            }
+        })
+        .expect_err("a foreign candidate config must be an explicit ownership fault");
+
+        assert!(error.to_string().contains("KELD-CLI-049"), "{error}");
+        assert!(
+            error
+                .to_string()
+                .contains(&foreign_project.display().to_string()),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/keld-cli/src/main.rs
+++ b/crates/keld-cli/src/main.rs
@@ -47,10 +47,9 @@ fn main() {
         },
         Some("dev") => match parse_dev_flags(&args[2..]) {
             Ok(()) => match env::current_dir() {
-                Ok(cwd) => {
-                    let root = find_project_root(&cwd).unwrap_or(cwd);
-                    run_dev(&root).map_err(|e| e.to_string())
-                }
+                Ok(cwd) => find_project_root(&cwd)
+                    .map_err(|error| error.to_string())
+                    .and_then(|root| run_dev(&root.unwrap_or(cwd)).map_err(|e| e.to_string())),
                 Err(e) => Err(e.to_string()),
             },
             Err(err) => {
@@ -59,11 +58,9 @@ fn main() {
             }
         },
         Some("doctor") => match env::current_dir() {
-            Ok(cwd) => {
-                let root = find_project_root(&cwd);
-                run_doctor_cmd(root.as_deref(), &args[2..]);
-                Ok(())
-            }
+            Ok(cwd) => find_project_root(&cwd)
+                .map_err(|error| error.to_string())
+                .map(|root| run_doctor_cmd(root.as_deref(), &args[2..])),
             Err(e) => Err(e.to_string()),
         },
         Some("mcp") => run_mcp_cmd(&args[2..]),
@@ -131,7 +128,7 @@ fn run_mcp_cmd(args: &[String]) -> Result<(), String> {
     match args.first().map(String::as_str) {
         Some("serve") => {
             let cwd = env::current_dir().map_err(|e| e.to_string())?;
-            let root = find_project_root(&cwd);
+            let root = find_project_root(&cwd).map_err(|error| error.to_string())?;
             run_mcp_serve(root.as_deref()).map_err(|e| e.to_string())
         }
         Some(other) => {

--- a/crates/keld-cli/tests/project_owner_linux.rs
+++ b/crates/keld-cli/tests/project_owner_linux.rs
@@ -1,0 +1,258 @@
+//! Real Linux project-owner boundary proof (KEL-167).
+
+#![cfg(unix)]
+#![allow(clippy::expect_used, clippy::panic, clippy::too_many_lines)] // fixture/setup failures are test assertions; one test keeps account cleanup and product oracles contiguous
+
+use std::fs;
+use std::io::Read as _;
+use std::os::unix::fs::MetadataExt as _;
+use std::os::unix::process::CommandExt as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const PROOF_ENV: &str = "KELD_REAL_LINUX_OWNER_PROOF";
+
+struct ForeignAccount {
+    name: String,
+    fixture_root: PathBuf,
+    invoking_uid: u32,
+    invoking_gid: u32,
+    active: bool,
+}
+
+impl ForeignAccount {
+    fn cleanup(&mut self) -> Result<(), String> {
+        if !self.active {
+            return Ok(());
+        }
+        checked_command(
+            Command::new("sudo").args([
+                "chown",
+                "-R",
+                &format!("{}:{}", self.invoking_uid, self.invoking_gid),
+                &self.fixture_root.display().to_string(),
+            ]),
+            "restore fixture ownership",
+        )?;
+        checked_command(
+            Command::new("sudo").args(["userdel", &self.name]),
+            "delete foreign fixture account",
+        )?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for ForeignAccount {
+    fn drop(&mut self) {
+        let _ = self.cleanup();
+    }
+}
+
+fn checked_command(command: &mut Command, label: &str) -> Result<(), String> {
+    let output = command
+        .output()
+        .map_err(|error| format!("{label}: could not start command: {error}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(format!(
+        "{label}: status={} stdout={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ))
+}
+
+fn command_output(command: &mut Command, label: &str) -> Output {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0);
+    let mut child = command
+        .spawn()
+        .unwrap_or_else(|error| panic!("{label}: could not start command: {error}"));
+    let pid =
+        rustix::process::Pid::from_raw(i32::try_from(child.id()).expect("child pid fits i32"))
+            .expect("child pid is nonzero");
+    let mut stdout = child.stdout.take().expect("captured child stdout");
+    let mut stderr = child.stderr.take().expect("captured child stderr");
+    let stdout_reader = thread::spawn(move || {
+        let mut bytes = Vec::new();
+        stdout.read_to_end(&mut bytes).map(|_| bytes)
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut bytes = Vec::new();
+        stderr.read_to_end(&mut bytes).map(|_| bytes)
+    });
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => thread::yield_now(),
+            Ok(None) => {
+                let _ = rustix::process::kill_process_group(pid, rustix::process::Signal::KILL);
+                let _ = child.kill();
+                let status = child.wait().expect("reap timed-out child");
+                let stdout = stdout_reader
+                    .join()
+                    .expect("join stdout reader")
+                    .expect("read timed-out child stdout");
+                let stderr = stderr_reader
+                    .join()
+                    .expect("join stderr reader")
+                    .expect("read timed-out child stderr");
+                panic!(
+                    "{label}: exceeded 10s and was reaped with {status}; stdout={} stderr={}",
+                    String::from_utf8_lossy(&stdout),
+                    String::from_utf8_lossy(&stderr)
+                );
+            }
+            Err(error) => panic!("{label}: could not poll child: {error}"),
+        }
+    };
+    Output {
+        status,
+        stdout: stdout_reader
+            .join()
+            .expect("join stdout reader")
+            .expect("read child stdout"),
+        stderr: stderr_reader
+            .join()
+            .expect("join stderr reader")
+            .expect("read child stderr"),
+    }
+}
+
+fn assert_cli_refusal(binary: &Path, cwd: &Path, project: &Path, arguments: &[&str]) {
+    let output = command_output(
+        Command::new(binary).args(arguments).current_dir(cwd),
+        "run shipping CLI against foreign-owned project",
+    );
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("KELD-CLI-049"), "{stderr}");
+    assert!(stderr.contains(&project.display().to_string()), "{stderr}");
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("keld project at"),
+        "foreign project was reported as adopted: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "requires a real Linux x86_64 runner with passwordless sudo"]
+fn real_linux_second_account_refuses_foreign_owned_project() {
+    assert_eq!(std::env::var(PROOF_ENV).as_deref(), Ok("1"));
+    assert_eq!(std::env::consts::ARCH, "x86_64");
+
+    let fixture = tempfile::tempdir().expect("owner-proof fixture root");
+    let project = fixture.path().join("foreign-project");
+    let victim = project.join("victim");
+    let source = project.join("src/main.ts");
+    let renderer = project.join("index.html");
+    let config = project.join("keld.config.ts");
+    let marker = fixture.path().join("foreign-entry-executed");
+    fs::create_dir_all(&victim).expect("victim cwd");
+    fs::create_dir_all(project.join("src")).expect("project source directory");
+    fs::write(
+        &config,
+        "export default { entry: \"src/main.ts\", renderer: \"index.html\" } as const;\n",
+    )
+    .expect("foreign config");
+    fs::write(
+        &source,
+        format!("await Bun.write({marker:?}, \"executed\\n\");\n"),
+    )
+    .expect("foreign entry");
+    fs::write(&renderer, "<!doctype html><title>foreign owner</title>\n")
+        .expect("foreign renderer");
+
+    let invoking_principal = (
+        rustix::process::geteuid().as_raw(),
+        rustix::process::getegid().as_raw(),
+    );
+    let account_name = format!("keld167{}", std::process::id());
+    checked_command(
+        Command::new("sudo").args([
+            "useradd",
+            "--no-create-home",
+            "--shell",
+            "/usr/sbin/nologin",
+            &account_name,
+        ]),
+        "create foreign fixture account",
+    )
+    .expect("real second unprivileged account");
+    let mut account = ForeignAccount {
+        name: account_name.clone(),
+        fixture_root: fixture.path().to_owned(),
+        invoking_uid: invoking_principal.0,
+        invoking_gid: invoking_principal.1,
+        active: true,
+    };
+    let uid_output = command_output(
+        Command::new("id").args(["-u", &account_name]),
+        "read foreign fixture uid",
+    );
+    assert!(uid_output.status.success(), "{uid_output:?}");
+    let foreign_uid = String::from_utf8(uid_output.stdout)
+        .expect("foreign uid UTF-8")
+        .trim()
+        .parse::<u32>()
+        .expect("foreign numeric uid");
+    assert_ne!(foreign_uid, invoking_principal.0);
+
+    for path in [&project, &config, &source, &renderer] {
+        checked_command(
+            Command::new("sudo").args([
+                "chown",
+                &foreign_uid.to_string(),
+                &path.display().to_string(),
+            ]),
+            "assign foreign fixture ownership",
+        )
+        .expect("foreign path owner");
+        assert_eq!(
+            fs::metadata(path).expect("foreign path metadata").uid(),
+            foreign_uid
+        );
+    }
+    assert_eq!(
+        fs::metadata(&victim).expect("victim metadata").uid(),
+        invoking_principal.0
+    );
+
+    let binary = Path::new(env!("CARGO_BIN_EXE_keld"));
+    assert_cli_refusal(binary, &victim, &project, &["doctor", "--json"]);
+    assert_cli_refusal(binary, &victim, &project, &["dev"]);
+    assert_cli_refusal(binary, &victim, &project, &["mcp", "serve"]);
+
+    let stage_error = keld_cli::boot::stage_dev_boot(&project, Path::new("unreached-host"))
+        .expect_err("direct staging must reject the real foreign uid before host lookup");
+    assert!(stage_error.to_string().contains("KELD-CLI-049"));
+    assert!(!project.join(".keld").exists());
+    assert!(
+        !marker.exists(),
+        "foreign entry executed as the invoking user"
+    );
+    println!(
+        "KELD_LINUX_PROJECT_OWNER invoking_uid={} foreign_uid={foreign_uid} \
+         doctor=refused dev=refused mcp=refused stage=refused marker=absent",
+        invoking_principal.0
+    );
+
+    account
+        .cleanup()
+        .expect("remove real foreign account fixture");
+    let deleted = command_output(
+        Command::new("id").args(["-u", &account_name]),
+        "verify foreign fixture account deletion",
+    );
+    assert!(
+        !deleted.status.success(),
+        "foreign account survived cleanup"
+    );
+}

--- a/docs/engineering/keld-error-codes.md
+++ b/docs/engineering/keld-error-codes.md
@@ -235,6 +235,12 @@ match the crate that already emits the code. Do not invent a third spelling.
 - message: The delegated staged host exited unsuccessfully
 - fix: Fix the preceding host diagnostic, then re-run `keld dev`.
 
+## KELD-CLI-049
+
+- crate: keld-cli
+- message: Project path is not owned by the invoking OS principal
+- fix: Move the project below a directory owned by the invoking user and correct the path's ownership before running Keld.
+
 ## KELD-MCP001
 
 - crate: keld-cli

--- a/docs/onboarding/03-api-and-cli-surface.md
+++ b/docs/onboarding/03-api-and-cli-surface.md
@@ -140,14 +140,19 @@ conditionals, and no per-file logic.
 The one verb that ties everything together. Sequence, from
 [`dev.rs::run_dev`](../../crates/keld-cli/src/dev.rs):
 
-1. **Find the project root.** `main.rs` calls `find_project_root(&cwd)`, which walks up
-   from the cwd looking for a `keld.config.ts` file. If none is found anywhere up the
-   tree it falls back to the cwd (`unwrap_or(cwd)`) — so step 2 is what produces the
-   error message, not the search.
+1. **Find an owner-controlled project root.** `main.rs` calls
+   `find_project_root(&cwd)`, which walks up from the cwd looking for a
+   `keld.config.ts` file while every traversed directory remains owned by the
+   invoking OS principal. The walk stops at the first foreign-owned boundary. A
+   candidate root and config are both owner-checked; a foreign candidate fails as
+   `KELD-CLI-049` instead of being read or executed. If no config exists below the
+   ownership boundary, `dev` falls back to the cwd and step 2 reports the missing
+   layout.
 2. **Run the doctor checks.** Any failure aborts with `KELD-CLI-032` and the full check
    list, before any process is spawned.
 3. **On macOS, Windows, and the current Ubuntu/Debian x86_64 Linux profile, compile one fresh stage.** `stage_dev_boot` reads the reviewed
-   project fields, copies the sibling developer `keld-host`,
+   project fields, rechecks that the resolved entry and renderer belong to the
+   invoking principal, copies the sibling developer `keld-host`,
    writes the strict boot descriptor and explicit permissions fixture, and
    returns the owner-private launch root. macOS verifies exact `0o700`; Linux
    also makes `.keld`, `dev`, and the nonce owner-private and copies the minimal
@@ -547,8 +552,8 @@ subcommands can call in. Selected modules:
 | Module | Public items |
 |---|---|
 | `create` | `CreateError::{InvalidName, Exists, Io}`, `validate_name(&str)`, `create_project(parent: &Path, name: &str) -> Result<PathBuf, CreateError>` |
-| `boot` | `stage_dev_boot(project, developer_host) -> Result<DevBootStage, BootCompileError>`; the sole owner-private stage producer |
-| `dev` | `DevError::{Doctor, Io, Runtime, WindowPhase, Renderer}`, `find_project_root(&Path) -> Option<PathBuf>`, `run_dev(&Path) -> Result<(), DevError>`; macOS/Windows `run_dev` delegates to the staged no-flag host |
+| `boot` | `ProjectOwnershipError`, `stage_dev_boot(project, developer_host) -> Result<DevBootStage, BootCompileError>`; the sole current-principal ownership predicate and owner-private stage producer |
+| `dev` | `DevError::{Doctor, Io, Runtime, WindowPhase, Renderer}`, `find_project_root(&Path) -> Result<Option<PathBuf>, ProjectOwnershipError>`, `run_dev(&Path) -> Result<(), DevError>`; macOS/Windows/Linux `run_dev` delegates to the staged no-flag host |
 | `doctor` | `Check { label, ok, detail }`, `run_checks(Option<&Path>) -> Vec<Check>`, `all_ok(&[Check]) -> bool` |
 | `echo_link` | `EchoServer::{start -> io::Result, link, join, shutdown}` uses the shared platform listener; Windows retains client-only decimal diagnostic compatibility as `EchoEndpoint::Tcp(u16)`; `echo_roundtrip(link: &str, &EchoRequest) -> Result<EchoResponse, IpcError>` |
 | `template` | `TemplateFile { path, contents }`, `HELLO_TEMPLATE: &[TemplateFile]` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4030,6 +4030,12 @@ match the crate that already emits the code. Do not invent a third spelling.
 - message: The delegated staged host exited unsuccessfully
 - fix: Fix the preceding host diagnostic, then re-run `keld dev`.
 
+## KELD-CLI-049
+
+- crate: keld-cli
+- message: Project path is not owned by the invoking OS principal
+- fix: Move the project below a directory owned by the invoking user and correct the path's ownership before running Keld.
+
 ## KELD-MCP001
 
 - crate: keld-cli


### PR DESCRIPTION
## Summary

- Reject project roots, configs, entries, and renderers not owned by the invoking OS principal before reading, staging, or executing them.
- Stop ancestor discovery at the first foreign-owned directory and propagate `KELD-CLI-049` through `keld dev`, `keld doctor`, and `keld mcp serve`.
- Anchor Linux stage ownership to the invoking effective UID and add a real Ubuntu x86_64 second-account product proof.

## Spec refs

- KEL-167 project-root identity/admission defect and its named negative tests.
- `docs/architecture/06-runtime-and-tooling.md` §2 existing CLI boot boundary.
- No architecture boundary change: process, handle, crash, and principal-minting ownership are unchanged; this tightens the existing CLI/filesystem admission boundary.

## Review gates

- unsafe — none.
- public API — applicable: `find_project_root` is fallible with public `ProjectOwnershipError`; all three shipping callers and onboarding API docs are migrated.
- permission model — applicable: one cross-platform predicate owns current-euid/TokenUser path ownership and is enforced before project bytes or staging side effects.
- dependency addition — applicable: `keld-cli` directly enables the already workspace-pinned/current `rustix=1.1.4` safe process API on Unix; no new package/version is resolved.
- wire protocol — none.
- CI shared file — applicable: a Linux-only, explicitly selected real-owner step runs the ignored integration proof; existing routing and fan-in remain unchanged.
- Exact-tip CodeRabbit CLI 0.7.6 reviewed all ten files with zero remaining findings. Its entry/renderer ownership and bounded-child findings were reproduced and fixed.

## Tests

- Failure-first: the issue's named selector/staging tests did not compile before the owner-aware seams existed.
- Negative controls: removing the ancestor stop selected a higher config; bypassing the staging check produced a stage; both named tests failed.
- Entry-source regression failed before the review fix because a foreign-owned `src/main.ts` was staged; it passes on final tip.
- Child-runner review fix: every probe command runs in a fresh process group, has a 10-second deadline, and kills/reaps the group while retaining stdout/stderr on timeout.
- Exact-tip `just ci` in isolated worktree-specific Cargo target: all policy/generated-doc/Docker Mermaid/TypeScript gates passed; formatter and warning-denied workspace Clippy passed; nextest 627/627 passed with 2 intentional skips; rustdoc and cargo-deny passed.
- Local macOS product proof: all three shipping commands exited 1 with `KELD-CLI-049`; marker absent.
- Hosted gitleaks and full protected matrix are required on exact tip `e59bee7`.

## Platforms

- macOS real product proof passed under root-owned world-writable `/private/tmp`; fixture was removed completely.
- Windows cross-target compilation passed. A superseded-tip Windows host lifecycle test failed `LINK_EOF` before READY; the substantive rebased tip must settle the complete Windows lane rather than reuse earlier evidence.
- Ubuntu x86_64 proof creates a disposable nologin account, assigns the project root/config/entry/renderer to its distinct kernel UID, runs doctor/dev/MCP as the runner user, requires four ownership refusals and no marker/`.keld`, restores ownership, deletes the account, and verifies deletion.

## Perf impact

No performance claim. Project discovery adds bounded metadata/owner checks on the cold CLI ancestor walk and staging inputs; the real account proof is CI-only.
