### PR TITLE
ci(ts): enforce strict package typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,23 +197,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: changes
-    # This lane owns one contract: the Bun suites under `packages/` pass. Its
-    # only inputs are those package trees, so a Rust-only diff skips it and a
-    # TypeScript diff runs it (tools/ci_changes.sh, `ts` output). Job-level
-    # `if` may reference needs/github/vars/inputs only — GitHub evaluates it
-    # before matrix expansion, so `matrix` here would invalidate the workflow.
+    # This lane owns the package compiler and Bun runtime contracts. Its only
+    # inputs are those package trees, so a Rust-only diff skips it and a
+    # TypeScript diff runs it (tools/ci_changes.sh, `ts` output). Job-level `if`
+    # may reference needs/github/vars/inputs only — GitHub evaluates it before
+    # matrix expansion, so `matrix` here would invalidate the workflow.
     if: needs.changes.outputs.ts == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # Exact pin (KEL-77): Bun 1.4.0 fixed kill-after-exit. Do not float `latest`.
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.4.0"
-      # No `bun install` step: every `packages/` manifest declares zero
-      # dependencies today, so there is nothing to resolve. A package that adds
-      # one must land a committed lockfile and `bun install --frozen-lockfile`
-      # here, not an unpinned resolve at job time.
-      - name: bun test
+      - name: frozen install, typecheck, and bun test
         shell: bash
         env:
           KELD_CI_TS_PACKAGES: ${{ needs.changes.outputs.ts_packages }}
@@ -226,7 +224,12 @@ jobs:
             exit 1
           fi
           for package in $KELD_CI_TS_PACKAGES; do
-            (cd "$package" && bun test)
+            (
+              cd "$package"
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun test
+            )
           done
 
   linux-gui-smoke:

--- a/justfile
+++ b/justfile
@@ -11,7 +11,13 @@ hello:
 
 # Run every CI gate locally (deny requires `cargo install cargo-deny --locked`).
 # gitleaks stays GitHub-only (pinned OSS CLI in .github/workflows/ci.yml).
-ci: agents-md atomic-protocol agent-context ci-router-test hooks-test mermaid-test mermaid-check mermaid-render-check product-status-test product-status-check llms-test llms-check hygiene fmt-check clippy test doc deny
+ci: agents-md atomic-protocol agent-context ci-router-test hooks-test mermaid-test mermaid-check mermaid-render-check product-status-test product-status-check llms-test llms-check hygiene typescript fmt-check clippy test doc deny
+
+# Verify the package compiler and runtime contracts from one frozen dependency graph.
+typescript:
+    cd packages/@keld/electron && bun install --frozen-lockfile
+    cd packages/@keld/electron && bun run typecheck
+    cd packages/@keld/electron && bun test
 
 # Check playbook routing and require crate AGENTS.md wherever Rust opts into unsafe.
 agents-md:

--- a/packages/@keld/electron/bun.lock
+++ b/packages/@keld/electron/bun.lock
@@ -1,0 +1,64 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@keld/electron",
+      "devDependencies": {
+        "@types/bun": "1.4.0",
+        "typescript": "7.0.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/packages/@keld/electron/package.json
+++ b/packages/@keld/electron/package.json
@@ -1,12 +1,21 @@
 {
   "name": "@keld/electron",
   "version": "0.0.1",
+  "packageManager": "bun@1.4.0",
   "type": "module",
   "description": "Electron API compatibility facade over kipc",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
   "exports": {
     ".": "./src/index.ts"
   },
   "files": [
     "src"
-  ]
+  ],
+  "devDependencies": {
+    "@types/bun": "1.4.0",
+    "typescript": "7.0.2"
+  }
 }

--- a/packages/@keld/electron/src/app.test.ts
+++ b/packages/@keld/electron/src/app.test.ts
@@ -27,8 +27,8 @@ async function waitChildOrKill(
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     const finished = Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
+      new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+      new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
       proc.exited,
     ]).then(([stdout, stderr, code]) => ({ stdout, stderr, code }));
     const timeout = new Promise<never>((_, reject) => {

--- a/packages/@keld/electron/src/link.test.ts
+++ b/packages/@keld/electron/src/link.test.ts
@@ -393,7 +393,7 @@ describe("LifecycleLink write deadlines", () => {
     Bun.connect = (async (opts: { socket?: Record<string, (...args: never[]) => void> }) => {
       captured.handlers = opts.socket ?? {};
       return socket;
-    }) as typeof Bun.connect;
+    }) as unknown as typeof Bun.connect;
     return captured;
   }
 
@@ -508,7 +508,7 @@ describe("LifecycleLink shared receiver rules (kel133)", () => {
         },
         end(): void {},
       };
-    }) as typeof Bun.connect;
+    }) as unknown as typeof Bun.connect;
     return captured;
   }
 

--- a/packages/@keld/electron/src/link.ts
+++ b/packages/@keld/electron/src/link.ts
@@ -552,11 +552,9 @@ export type KeldCallError = Error & { code: string };
 
 /** True when `e` is a rejected `Call` carrying a registered `KELD-*` code. */
 export function isCallError(e: unknown): e is KeldCallError {
-  return (
-    e instanceof Error &&
-    typeof (e as { code?: unknown }).code === "string" &&
-    (e as { code: string }).code.startsWith("KELD-")
-  );
+  if (!(e instanceof Error)) return false;
+  const { code } = e as Error & { code?: unknown };
+  return typeof code === "string" && code.startsWith("KELD-");
 }
 
 /**

--- a/packages/@keld/electron/tsconfig.json
+++ b/packages/@keld/electron/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "lib": ["ES2024", "DOM"],
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "noImplicitOverride": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Add a strict package-root TypeScript 7.0.2 configuration and exact Bun 1.4.0 declarations for `@keld/electron`.
- Make local `just ci` and the routed hosted TypeScript lane install the committed lockfile, typecheck, and run all Bun tests.
- Correct five pre-existing strict type diagnostics without changing runtime or test behavior.

## Spec refs

- KEL-111 remaining typecheck acceptance; PR #85 already owns the existing Bun-test lane and package router.
- No boundary change: this is CI/tooling verification only and does not alter process, handle, principal, permission, public API, or wire behavior.

## Review gates

- unsafe — none.
- public API — none.
- permission model — none.
- dependency addition — applicable: exact `typescript=7.0.2` and `@types/bun=1.4.0`; the latter pins `bun-types=1.4.0`, matching CI's Bun runtime. The committed Bun text lock pins transitive/platform package versions and integrity hashes. Direct and sampled transitive licenses are Apache-2.0 or MIT.
- wire protocol — none.
- CI shared file — applicable: KEL-111 is the designated single writer; routing/job-level `if`, required fan-in, and exact Bun action pin are unchanged. The Bun checkout now disables credential persistence.
- CodeRabbit CLI 0.7.6 reviewed all eight final-tip files with zero findings. GitHub review's one valid credential-persistence finding was fixed at `40da69c`, replied to, and resolved; the new-tip hosted review was rate-limited.

## Tests

- `bun install --frozen-lockfile` — passed with no lock/manifest mutation.
- `bun run typecheck` — zero diagnostics.
- `bun test` — 41/41 passed, 485 assertions.
- Negative control: an intentional `number`→`string` assignment failed both `bun run typecheck` and `just typescript`; restoration passed.
- Package-only router probe: `ts=true`, `ts_packages=packages/@keld/electron`, with the existing Rust consumers selected.
- Workflow YAML parse, `just ci-router-test`, and `just hygiene` — passed.
- Exact final-tip `just ci` — all policy/generated-doc/Docker Mermaid gates, frozen TypeScript install/typecheck/tests, format, warning-denied workspace Clippy, 623/623 nextest (1 intentional skip), rustdoc, and cargo-deny passed.
- Hosted run `33865316204`: gitleaks and every required lane passed; `CI required` passed.

## Platforms

- Local macOS arm64: frozen TypeScript 7 native compiler, Bun 1.4.0 tests, and full repository gate passed.
- Hosted Ubuntu: selected TypeScript lane installed the frozen graph, ran `tsc --noEmit`, and passed 41/41 Bun tests.
- Hosted Ubuntu/macOS/Windows Rust matrices and Linux GUI smoke all passed on final tip `40da69c`.

## Perf impact

No product performance impact. CI adds one frozen install and one native TypeScript compiler invocation before the existing 30-second Bun suite.
