### PR TITLE
fix(cli): report staged host launch failures

### DIFF
--- a/crates/keld-cli/src/dev.rs
+++ b/crates/keld-cli/src/dev.rs
@@ -44,6 +44,15 @@ pub enum DevError {
     Doctor(String),
     /// Child process or thread failure.
     Io(io::Error),
+    /// The owner-private staged host could not be launched.
+    StagedHostLaunch {
+        /// Exact staged executable path passed to the OS.
+        path: PathBuf,
+        /// Primary process-spawn failure.
+        source: io::Error,
+        /// Secondary cleanup failure, when the launch directory could not be removed.
+        cleanup: Option<io::Error>,
+    },
     /// IPC or host failure surfaced as text.
     Runtime(String),
     /// The supervised app process died while the host owned the window
@@ -72,6 +81,29 @@ impl std::fmt::Display for DevError {
                 "KELD-CLI-030: dev session I/O error — {e}. \
                  Check that `bun` is on PATH and the project files are readable."
             ),
+            Self::StagedHostLaunch {
+                path,
+                source,
+                cleanup,
+            } => {
+                write!(
+                    f,
+                    "KELD-CLI-050: staged host launch failed for `{}` — {source}.",
+                    path.display()
+                )?;
+                if let Some(cleanup) = cleanup {
+                    let launch_root = path.parent().unwrap_or(path);
+                    write!(
+                        f,
+                        " Cleanup of `{}` also failed — {cleanup}.",
+                        launch_root.display()
+                    )?;
+                }
+                write!(
+                    f,
+                    " Verify that `keld` and `keld-host` came from the same installation and that the staged path is executable. If cleanup failed, remove only the named launch directory after confirming no staged process remains."
+                )
+            }
             Self::Runtime(msg) => write!(
                 f,
                 "KELD-CLI-031: dev session failed — {msg}. \
@@ -209,6 +241,18 @@ fn doctor_or_err(project_root: &Path) -> Result<(), DevError> {
     Err(DevError::Doctor(msg))
 }
 
+fn staged_host_launch_error(
+    path: PathBuf,
+    source: io::Error,
+    cleanup: Result<(), io::Error>,
+) -> DevError {
+    DevError::StagedHostLaunch {
+        path,
+        source,
+        cleanup: cleanup.err(),
+    }
+}
+
 /// Doctor checks, then one Bun IPC echo round-trip without opening a window.
 ///
 /// Starts the host-owned app-link + supervised Bun, awaits the ready marker,
@@ -286,7 +330,8 @@ fn run_dev_host(project_root: &Path) -> Result<(), DevError> {
     #[cfg(windows)]
     let mut stage = stage;
     let stage_root = stage.root().to_owned();
-    let mut command = Command::new(stage.host());
+    let staged_host = stage.host().to_owned();
+    let mut command = Command::new(&staged_host);
     command
         .current_dir(stage.root())
         .env("KELD_DEV_LEASE", "stdin-v1")
@@ -300,14 +345,8 @@ fn run_dev_host(project_root: &Path) -> Result<(), DevError> {
         Ok(host) => host,
         Err(source) => {
             drop(stage);
-            if let Err(cleanup) = fs::remove_dir_all(&stage_root) {
-                return Err(DevError::Doctor(format!(
-                    "KELD-CLI-047: boot staging failed during host launch cleanup — \
-                     spawn failed: {source}; cleanup failed: {cleanup}. \
-                     Remove that owner-private nonce directory and retry."
-                )));
-            }
-            return Err(DevError::Io(source));
+            let cleanup = fs::remove_dir_all(&stage_root);
+            return Err(staged_host_launch_error(staged_host, source, cleanup));
         }
     };
     let lease_writer = host.stdin.take().ok_or_else(|| {
@@ -654,6 +693,43 @@ mod tests {
         // The shipping success path: supervision fine, window closed normally.
         // `keld dev` must still exit 0.
         assert!(window_phase_outcome(Ok(()), Ok(())).is_ok());
+    }
+
+    #[test]
+    fn staged_host_spawn_failure_names_host_path_not_bun() {
+        let path = PathBuf::from("/owner-private/stage/keld-host");
+        let error = staged_host_launch_error(
+            path.clone(),
+            io::Error::new(ErrorKind::PermissionDenied, "spawn denied"),
+            Ok(()),
+        );
+        let rendered = error.to_string();
+
+        assert!(rendered.starts_with("KELD-CLI-050"), "{rendered}");
+        assert!(rendered.contains(&path.display().to_string()), "{rendered}");
+        assert!(rendered.contains("spawn denied"), "{rendered}");
+        assert!(!rendered.contains("bun"), "{rendered}");
+        assert!(!rendered.contains("KELD-CLI-047"), "{rendered}");
+    }
+
+    #[test]
+    fn staged_host_cleanup_failure_is_context_not_a_second_primary_code() {
+        let error = staged_host_launch_error(
+            PathBuf::from("/owner-private/stage/keld-host"),
+            io::Error::new(ErrorKind::NotFound, "staged host missing"),
+            Err(io::Error::new(
+                ErrorKind::PermissionDenied,
+                "cleanup denied",
+            )),
+        );
+        let rendered = error.to_string();
+
+        assert_eq!(rendered.matches("KELD-CLI-").count(), 1, "{rendered}");
+        assert!(rendered.starts_with("KELD-CLI-050"), "{rendered}");
+        assert!(rendered.contains("staged host missing"), "{rendered}");
+        assert!(rendered.contains("cleanup denied"), "{rendered}");
+        assert!(!rendered.contains("bun"), "{rendered}");
+        assert!(!rendered.contains("KELD-CLI-047"), "{rendered}");
     }
 
     #[test]

--- a/docs/engineering/keld-error-codes.md
+++ b/docs/engineering/keld-error-codes.md
@@ -241,6 +241,12 @@ match the crate that already emits the code. Do not invent a third spelling.
 - message: Project path is not owned by the invoking OS principal
 - fix: Move the project below a directory owned by the invoking user and correct the path's ownership before running Keld.
 
+## KELD-CLI-050
+
+- crate: keld-cli
+- message: Owner-private staged host could not be launched
+- fix: Verify `keld` and `keld-host` came from the same installation and the named staged path is executable. If cleanup also failed, remove only the named launch directory after confirming no staged process remains.
+
 ## KELD-MCP001
 
 - crate: keld-cli

--- a/docs/onboarding/03-api-and-cli-surface.md
+++ b/docs/onboarding/03-api-and-cli-surface.md
@@ -553,7 +553,7 @@ subcommands can call in. Selected modules:
 |---|---|
 | `create` | `CreateError::{InvalidName, Exists, Io}`, `validate_name(&str)`, `create_project(parent: &Path, name: &str) -> Result<PathBuf, CreateError>` |
 | `boot` | `ProjectOwnershipError`, `stage_dev_boot(project, developer_host) -> Result<DevBootStage, BootCompileError>`; the sole current-principal ownership predicate and owner-private stage producer |
-| `dev` | `DevError::{Doctor, Io, Runtime, WindowPhase, Renderer}`, `find_project_root(&Path) -> Result<Option<PathBuf>, ProjectOwnershipError>`, `run_dev(&Path) -> Result<(), DevError>`; macOS/Windows/Linux `run_dev` delegates to the staged no-flag host |
+| `dev` | `DevError::{Doctor, Io, StagedHostLaunch, Runtime, WindowPhase, Renderer}`, `find_project_root(&Path) -> Result<Option<PathBuf>, ProjectOwnershipError>`, `run_dev(&Path) -> Result<(), DevError>`; macOS/Windows/Linux `run_dev` delegates to the staged no-flag host |
 | `doctor` | `Check { label, ok, detail }`, `run_checks(Option<&Path>) -> Vec<Check>`, `all_ok(&[Check]) -> bool` |
 | `echo_link` | `EchoServer::{start -> io::Result, link, join, shutdown}` uses the shared platform listener; Windows retains client-only decimal diagnostic compatibility as `EchoEndpoint::Tcp(u16)`; `echo_roundtrip(link: &str, &EchoRequest) -> Result<EchoResponse, IpcError>` |
 | `template` | `TemplateFile { path, contents }`, `HELLO_TEMPLATE: &[TemplateFile]` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4036,6 +4036,12 @@ match the crate that already emits the code. Do not invent a third spelling.
 - message: Project path is not owned by the invoking OS principal
 - fix: Move the project below a directory owned by the invoking user and correct the path's ownership before running Keld.
 
+## KELD-CLI-050
+
+- crate: keld-cli
+- message: Owner-private staged host could not be launched
+- fix: Verify `keld` and `keld-host` came from the same installation and the named staged path is executable. If cleanup also failed, remove only the named launch directory after confirming no staged process remains.
+
 ## KELD-MCP001
 
 - crate: keld-cli


### PR DESCRIPTION
## Summary

- Give staged `keld-host` spawn failures their own typed `DevError::StagedHostLaunch` contract and `KELD-CLI-050` diagnostic.
- Preserve the spawn failure as the primary error while attaching launch-directory cleanup failure only as secondary context.
- Name the exact staged executable and actionable installation/executable remediation; never misdirect this failure to Bun PATH.

## Spec refs

- KEL-172, atomic child of KEL-127 audit finding F2.
- No boundary change: handle ownership, crash ownership, principal minting, permission enforcement, and wire behavior are unchanged.

## Review gates

- unsafe — none.
- public API — applicable: adds the documented `DevError::StagedHostLaunch` variant and `KELD-CLI-050` registry entry.
- permission model — none.
- dependency addition — none.
- wire protocol — none.
- CodeRabbit CLI 0.7.6 reviewed the exact committed four-file diff against `3c32a89` with zero findings.

## Tests

- Failure-first compile: regression tests initially failed because `staged_host_launch_error` did not exist.
- Focused staged-host diagnostic tests — 2/2 passed.
- Error registry tests — 7/7 passed.
- `just llms-check` and `git diff --check` — passed.
- Warning-denied `keld-cli` Clippy — passed.
- Exact committed-tip isolated `just ci` — policy/generated-doc/Docker Mermaid gates, frozen TypeScript install/typecheck/41 tests, format, warning-denied workspace Clippy, 629/629 nextest with 2 intentional skips, rustdoc, and cargo-deny passed.

## Platforms

- Local macOS arm64 full repository gate passed.
- Hosted Ubuntu/macOS/Windows matrices are required before merge; no unrun platform is claimed as passed.

## Perf impact

No steady-state performance impact. Only the already-failing staged-host spawn path constructs the structured diagnostic and optional cleanup context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development-host launch failures with a dedicated error message and error code.
  - Launch failures now report the affected staged path and any cleanup failure, making troubleshooting clearer.
  - Failed launches now attempt to remove the temporary staging directory.

- **Documentation**
  - Documented the new error code and troubleshooting guidance, including installation consistency, path executability, and safe cleanup procedures.
  - Updated CLI API documentation to include the new development-host launch error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->