### PR TITLE
fix(cli): cover installation staging failures

### DIFF
--- a/crates/keld-cli/src/boot.rs
+++ b/crates/keld-cli/src/boot.rs
@@ -175,7 +175,8 @@ impl std::fmt::Display for BootCompileError {
             Self::Staging { phase, detail } => write!(
                 f,
                 "KELD-CLI-047: boot staging failed during {phase} — {detail}. \
-                 Fix the project files and regenerate a fresh owner-private dev stage."
+                 Fix the named project or installation input, or the reported staging \
+                 integrity failure, then generate a fresh owner-private dev stage."
             ),
         }
     }
@@ -793,6 +794,30 @@ fn create_windows_stage_root(path: &Path) -> io::Result<()> {
 fn verify_windows_stage_acl(path: &Path) -> Result<(), BootCompileError> {
     keld_core::app_session::validate_windows_dev_stage_acl(path)
         .map_err(|source| BootCompileError::new("stage DACL readback", source.to_string()))
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)] // rendered diagnostics are assertion oracles
+mod error_tests {
+    use super::*;
+
+    #[test]
+    fn staging_remediation_covers_project_and_installation_inputs() {
+        for (phase, expected_fix) in [
+            ("project config", "project"),
+            ("developer launcher", "installation"),
+        ] {
+            let rendered = BootCompileError::new(phase, "fixture failure").to_string();
+
+            assert_eq!(rendered.matches("KELD-CLI-047").count(), 1, "{rendered}");
+            assert!(rendered.contains(phase), "{rendered}");
+            assert!(rendered.contains(expected_fix), "{rendered}");
+            assert!(
+                rendered.contains("fresh owner-private dev stage"),
+                "{rendered}"
+            );
+        }
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/docs/engineering/keld-error-codes.md
+++ b/docs/engineering/keld-error-codes.md
@@ -227,7 +227,7 @@ match the crate that already emits the code. Do not invent a third spelling.
 
 - crate: keld-cli
 - message: Owner-private no-flag boot staging failed
-- fix: Fix the named project input or host-copy integrity failure, then generate a fresh dev stage.
+- fix: Fix the named project or installation input, or the reported staging integrity failure, then generate a fresh owner-private dev stage.
 
 ## KELD-CLI-048
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4022,7 +4022,7 @@ match the crate that already emits the code. Do not invent a third spelling.
 
 - crate: keld-cli
 - message: Owner-private no-flag boot staging failed
-- fix: Fix the named project input or host-copy integrity failure, then generate a fresh dev stage.
+- fix: Fix the named project or installation input, or the reported staging integrity failure, then generate a fresh owner-private dev stage.
 
 ## KELD-CLI-048
 


### PR DESCRIPTION
## Summary

- Correct KELD-CLI-047 so boot staging failures cover named installation inputs such as the required Linux role launcher, not only project files.
- Keep valid project-input and staging-integrity actions in the same single-owner diagnostic.
- Add a cross-platform regression contract and update the canonical registry plus generated corpus.

## Spec refs

- KEL-173, atomic child of KEL-127 audit finding DW-05.
- No boundary change: staging, cleanup, launch, process, ownership, permission, and wire behavior are unchanged.

## Review gates

- unsafe — none.
- public API — applicable: documented KELD-CLI-047 remediation wording changes.
- permission model — none.
- dependency addition — none.
- wire protocol — none.
- CodeRabbit CLI 0.7.6 reviewed exact commit `f3ec03c`. Its one minor suggestion requested a phase-specific rewrite across all staging phases; rejected because the controlling audit found that broader framing 3/4 invalid and KEL-173 explicitly forbids a 20-phase taxonomy expansion.

## Tests

- Failure-first regression: failed on missing `installation` guidance before the fix.
- Focused remediation regression — 1/1 passed for both project and developer-launcher rows.
- Error registry tests — 7/7 passed.
- `just llms-check`, formatting, warning-denied CLI Clippy, and `git diff --check` — passed.
- Exact committed-tip isolated `just ci` — policy/generated-doc/Docker Mermaid gates, frozen TypeScript install/typecheck/41 tests, format, warning-denied workspace Clippy, 630/630 nextest with 2 intentional skips, rustdoc, and cargo-deny passed.

## Platforms

- Local macOS arm64 full repository gate passed.
- The rendering contract is platform-independent and compiles under every target; hosted Ubuntu/macOS/Windows matrices remain required before merge.

## Perf impact

None. Only a cold failure message and its test data change.
