### PR TITLE
docs(runtime): name both strict launchers

### DIFF
--- a/crates/keld-runtime/src/linux_strict.rs
+++ b/crates/keld-runtime/src/linux_strict.rs
@@ -727,10 +727,11 @@ fn failed_child_stderr(child: &mut Child) -> String {
 
 /// Runs the fixed in-sandbox Landlock launcher role.
 ///
-/// This is called only by the `keld-linux-strict-launcher` binary after
+/// This is called by the runtime-owned `keld-linux-strict-launcher` boundary-test
+/// binary and the shipping `keld-role-launcher` beside `keld-host`, after
 /// Bubblewrap finished namespace/mount/seccomp setup. It applies the stacked
-/// Landlock layer, reports it through a launcher-only pipe, closes that
-/// capability, then replaces itself with the exact target.
+/// Landlock layer, reports it through a launcher-only pipe, closes that capability,
+/// then replaces itself with the exact target.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
## Summary

- Correct `run_linux_strict_launcher` rustdoc to name both callers: the runtime-owned boundary-test binary and the shipping launcher staged beside `keld-host`.
- Record why the two tiny Cargo entrypoints are distinct artifacts while all trusted parsing/Landlock/readiness/exec policy remains single-owned by the shared function.
- Leave both binaries and every executable byte untouched.

## Spec refs

- KEL-176, refutation and narrow surviving fix for KEL-127 teardown leads DG-04/DN-04.
- No boundary change: documentation only; containment, process, staging, permission, and wire behavior are unchanged.

## Review gates

- unsafe — none.
- public API — applicable: corrects documentation on a public Linux-only function.
- permission model — none.
- dependency addition — none.
- wire protocol — none.
- CodeRabbit CLI 0.7.6 reviewed exact commit `468d5c2` against `9f19d3d` with zero findings.

## Tests

- Source census proved both binary mains delegate to the same `run_linux_strict_launcher`; runtime tests consume `CARGO_BIN_EXE_keld-linux-strict-launcher`, while host tests/CLI staging consume `keld-role-launcher`.
- `cargo fmt --all --check` and `git diff --check` passed.
- Exact committed-tip isolated `just ci` — policy/generated-doc/Docker Mermaid gates, product-status 69/69, frozen TypeScript install/typecheck/41 tests, format, warning-denied workspace Clippy, 630/630 nextest with 2 intentional skips, rustdoc, and cargo-deny passed.

## Platforms

- Local macOS full repository gate passed, but the Linux-only public item is cfg-excluded from local rustdoc.
- Hosted Ubuntu warning-denied rustdoc is required before merge; no unrun Linux result is claimed.

## Perf impact

None. Comment-only change.
