### PR TITLE
fix(ci): restore retained Mermaid permissions

### DIFF
--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -173,23 +173,74 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         "running_under_msys() {",
         "docker_host_path() {",
         "prepare_docker_output_dir() {",
+        "restore_docker_output_dir() {",
+        "if ! running_under_msys; then",
+        "\"$render_parent\"/keld-mermaid-render.*) ;;",
+        "cleanup() {",
+        "local cleanup_status=$?",
+        "local cleanup_failed=0",
+        "trap - EXIT",
+        "if restore_docker_output_dir \"$render_dir\"; then",
+        "exit \"$cleanup_status\"",
         "render_dir=$(mktemp -d \"$render_parent/keld-mermaid-render.XXXXXX\")",
         "prepare_docker_output_dir \"$render_dir\"",
         "docker_render_dir=$(docker_host_path \"$render_dir\")",
         "export MSYS2_ARG_CONV_EXCL='*'",
     ];
-    let [running, docker_path, prepare, render_create, prepare_call, render_path, exclusion] =
-        required.map(|line| {
+    let [
+        running,
+        docker_path,
+        prepare,
+        restore,
+        restore_guard,
+        restore_allowlist,
+        cleanup,
+        cleanup_status,
+        cleanup_failed,
+        disable_exit_trap,
+        restore_call,
+        exit_with_status,
+        render_create,
+        prepare_call,
+        render_path,
+        exclusion,
+    ] = required.map(|line| {
         shell_line_position(&lines, line).ok_or_else(|| {
             format!(
-                "CI-HYGIENE: `{MERMAID_RENDERER}` is missing executable shell line `{line}`. Restore the PowerShell-launched Git-Bash detection, host-path conversion, and writable isolated output bind."
+                "CI-HYGIENE: `{MERMAID_RENDERER}` is missing executable shell line `{line}`. Restore the PowerShell-launched Git-Bash detection, host-path conversion, writable isolated output bind, and owner-only retained-output cleanup."
             )
         })
     });
-    let (running, docker_path, prepare, render_create, prepare_call, render_path, exclusion) = (
+    let (
+        running,
+        docker_path,
+        prepare,
+        restore,
+        restore_guard,
+        restore_allowlist,
+        cleanup,
+        cleanup_status,
+        cleanup_failed,
+        disable_exit_trap,
+        restore_call,
+        exit_with_status,
+        render_create,
+        prepare_call,
+        render_path,
+        exclusion,
+    ) = (
         running?,
         docker_path?,
         prepare?,
+        restore?,
+        restore_guard?,
+        restore_allowlist?,
+        cleanup?,
+        cleanup_status?,
+        cleanup_failed?,
+        disable_exit_trap?,
+        restore_call?,
+        exit_with_status?,
         render_create?,
         prepare_call?,
         render_path?,
@@ -197,12 +248,21 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
     );
     if !(running < docker_path
         && docker_path < prepare
-        && prepare < render_create
+        && prepare < restore
+        && restore < restore_guard
+        && restore_guard < restore_allowlist
+        && restore_allowlist < cleanup
+        && cleanup < cleanup_status
+        && cleanup_status < cleanup_failed
+        && cleanup_failed < disable_exit_trap
+        && disable_exit_trap < restore_call
+        && restore_call < exit_with_status
+        && exit_with_status < render_create
         && render_create < prepare_call
         && prepare_call < render_path)
     {
         return Err(format!(
-            "CI-HYGIENE: `{MERMAID_RENDERER}` has the MSYS detector, converter, output preparation, or render-directory calls out of order. Restore definition-before-use and prepare the directory before converting/mounting it."
+            "CI-HYGIENE: `{MERMAID_RENDERER}` has the MSYS detector, converter, output preparation/restoration, cleanup, or render-directory calls out of order. Restore definition-before-use, owner-only failure cleanup, and preparation before conversion/mounting it."
         ));
     }
     let uname = lines
@@ -215,6 +275,7 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         .collect();
     let cygpath = shell_line_position(&lines, "cygpath -am \"$path\"");
     let chmod = shell_line_position(&lines, "chmod 0777 -- \"$path\" || {");
+    let restore_chmod = shell_line_position(&lines, "chmod 0700 -- \"$path\" || {");
     let docker_run = lines
         .iter()
         .position(|line| line.starts_with("run_with_timeout 120 docker run"));
@@ -222,15 +283,13 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         || !msys_conditionals
             .iter()
             .any(|index| docker_path < *index && *index < prepare)
-        || !msys_conditionals
-            .iter()
-            .any(|index| prepare < *index && *index < render_create)
         || !cygpath.is_some_and(|index| docker_path < index && index < prepare)
-        || !chmod.is_some_and(|index| prepare < index && index < render_create)
+        || !chmod.is_some_and(|index| prepare < index && index < restore)
+        || !restore_chmod.is_some_and(|index| restore < index && index < cleanup)
         || !docker_run.is_some_and(|index| exclusion < index)
     {
         return Err(format!(
-            "CI-HYGIENE: `{MERMAID_RENDERER}` has inert or reordered MSYS handling. The uname fallback and both guarded function bodies must be executable, and path-conversion exclusion must precede Docker."
+            "CI-HYGIENE: `{MERMAID_RENDERER}` has inert or reordered MSYS handling. Detection, 0777 preparation, 0700 retained-output restoration, failure-status preservation, and path-conversion exclusion must remain executable and ordered."
         ));
     }
     Ok(())
@@ -1824,7 +1883,8 @@ fn check_mermaid_gate_files(root: &Path) -> Result<(), String> {
         r#"if [[ -L "$workspace/target" ]]; then"#,
         r#"render_parent=$(cd "$workspace/target" && pwd -P)"#,
         r#"[[ "$render_parent" == "$workspace/target" ]] || {"#,
-        r#""$render_parent"/keld-mermaid-render.*) rm -rf -- "$render_dir" ;;"#,
+        r#""$render_parent"/keld-mermaid-render.*)"#,
+        r#"if ! rm -rf -- "$render_dir"; then"#,
     ] {
         if !uncommented_line_contains(&renderer, needle) {
             return Err(format!(
@@ -3422,6 +3482,196 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    fn write_msys_renderer_fixture(
+        temp: &TempDir,
+        docker: &str,
+        chmod: Option<&str>,
+        remove: Option<&str>,
+    ) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt as _;
+        use std::process::Command;
+
+        let checkout = temp.path().join("checkout");
+        fs::create_dir(&checkout).expect("checkout directory");
+        assert!(
+            Command::new("git")
+                .args(["init", "--quiet"])
+                .arg(&checkout)
+                .status()
+                .expect("initialize fixture")
+                .success()
+        );
+        fs::write(
+            checkout.join("diagram.md"),
+            "```mermaid\nflowchart LR\n A-->B\n```\n",
+        )
+        .expect("tracked diagram");
+        assert!(
+            Command::new("git")
+                .args(["add", "diagram.md"])
+                .current_dir(&checkout)
+                .status()
+                .expect("track diagram")
+                .success()
+        );
+        fs::create_dir(checkout.join("tools")).expect("fixture tools");
+        fs::write(checkout.join(MERMAID_CONFIG), "{}\n").expect("renderer config");
+        temp.write("renderer.sh", include_str!("mermaid_render_check.sh"));
+        temp.write("bin/docker", docker);
+        temp.write("bin/uname", "#!/usr/bin/env bash\nprintf 'MSYS_NT-10.0\\n'\n");
+        temp.write(
+            "bin/cygpath",
+            "#!/usr/bin/env bash\n[[ \"$1\" == '-am' ]] || exit 64\nprintf '%s\\n' \"$2\"\n",
+        );
+        temp.write(
+            "bin/chmod",
+            chmod.unwrap_or(
+                "#!/usr/bin/env bash\nmode=$1\nshift\n[[ \"${1:-}\" == -- ]] && shift\nexec /bin/chmod \"$mode\" \"$@\"\n",
+            ),
+        );
+        if let Some(remove) = remove {
+            temp.write("bin/rm", remove);
+        }
+        for shim in ["docker", "uname", "cygpath", "chmod"] {
+            let path = temp.path().join("bin").join(shim);
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+                .expect("shim executable");
+        }
+        for shim in ["rm"] {
+            let path = temp.path().join("bin").join(shim);
+            if path.exists() {
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+                    .expect("shim executable");
+            }
+        }
+        checkout
+    }
+
+    #[cfg(unix)]
+    fn run_msys_renderer_fixture(temp: &TempDir, checkout: &Path) -> std::process::Output {
+        use std::process::Command;
+
+        let mut paths = vec![temp.path().join("bin")];
+        paths.extend(env::split_paths(&env::var_os("PATH").expect("tool PATH")));
+        Command::new("bash")
+            .arg(temp.path().join("renderer.sh"))
+            .current_dir(checkout)
+            .env_remove("MSYSTEM")
+            .env("PATH", env::join_paths(paths).expect("fixture PATH"))
+            .output()
+            .expect("execute real renderer script")
+    }
+
+    #[cfg(unix)]
+    fn retained_render_dirs(checkout: &Path) -> Vec<PathBuf> {
+        fs::read_dir(checkout.join("target"))
+            .expect("checkout-local output directory")
+            .map(|entry| entry.expect("retained output entry").path())
+            .collect()
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn mermaid_renderer_retains_msys_failure_output_with_owner_only_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new();
+        let checkout = write_msys_renderer_fixture(
+            &temp,
+            "#!/usr/bin/env bash\ncase \"$1\" in\ninfo|image|rm) exit 0 ;;\ncontext) printf 'unix:///unused-kel152.sock\\n' ;;\nrun) exit 42 ;;\n*) exit 99 ;;\nesac\n",
+            None,
+            None,
+        );
+        let output = run_msys_renderer_fixture(&temp, &checkout);
+        assert_eq!(output.status.code(), Some(1));
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("failed-render output retained"),
+            "missing retained-output receipt: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let retained = retained_render_dirs(&checkout);
+        assert_eq!(retained.len(), 1, "retained output: {retained:?}");
+        assert!(
+            retained[0]
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("keld-mermaid-render.")),
+            "wrong retained output path: {:?}",
+            retained[0]
+        );
+        assert_eq!(
+            fs::metadata(&retained[0])
+                .expect("retained output metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn mermaid_renderer_does_not_claim_owner_only_when_restoration_fails() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new();
+        let checkout = write_msys_renderer_fixture(
+            &temp,
+            "#!/usr/bin/env bash\ncase \"$1\" in\ninfo|image|rm) exit 0 ;;\ncontext) printf 'unix:///unused-kel152.sock\\n' ;;\nrun) exit 42 ;;\n*) exit 99 ;;\nesac\n",
+            Some(
+                "#!/usr/bin/env bash\nmode=$1\nshift\n[[ \"${1:-}\" == -- ]] && shift\nif [[ \"$mode\" == 0700 ]]; then exit 44; fi\nexec /bin/chmod \"$mode\" \"$@\"\n",
+            ),
+            None,
+        );
+        let output = run_msys_renderer_fixture(&temp, &checkout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(output.status.code(), Some(1));
+        assert!(stderr.contains("owner-only restoration failed"), "{stderr}");
+        assert!(!stderr.contains("with owner-only host access"), "{stderr}");
+        let retained = retained_render_dirs(&checkout);
+        assert_eq!(retained.len(), 1, "retained output: {retained:?}");
+        assert_eq!(
+            fs::metadata(&retained[0])
+                .expect("retained output metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o777
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn mermaid_renderer_restores_output_when_success_cleanup_cannot_remove_it() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new();
+        let checkout = write_msys_renderer_fixture(
+            &temp,
+            "#!/usr/bin/env bash\ncase \"$1\" in\ninfo|image) exit 0 ;;\ncontext) printf 'unix:///unused-kel152.sock\\n' ;;\nrm) exit 0 ;;\nrun)\n  out=''\n  shift\n  while [[ $# -gt 0 ]]; do\n    if [[ \"$1\" == --volume ]]; then\n      case \"$2\" in *:/out) out=\"${2%:/out}\" ;; esac\n      shift 2\n    else\n      shift\n    fi\n  done\n  [[ -n \"$out\" ]] || exit 64\n  printf '<svg><title>fixture</title><desc>fixture</desc></svg>' >\"$out/fixture.svg\"\n  ;;\n*) exit 99 ;;\nesac\n",
+            None,
+            Some("#!/usr/bin/env bash\nexit 66\n"),
+        );
+        let output = run_msys_renderer_fixture(&temp, &checkout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(output.status.code(), Some(1));
+        assert!(
+            stderr.contains("successful-render output could not be removed; retained"),
+            "{stderr}"
+        );
+        let retained = retained_render_dirs(&checkout);
+        assert_eq!(retained.len(), 1, "retained output: {retained:?}");
+        assert_eq!(
+            fs::metadata(&retained[0])
+                .expect("retained output metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+    }
+
     #[test]
     fn mermaid_output_outside_the_shared_checkout_fails() {
         let temp = complete_fixture();
@@ -3474,6 +3724,49 @@ mod tests {
         );
         let error = check(temp.path()).expect_err("MSYS output bind must remain writable");
         assert!(error.contains("prepare_docker_output_dir"), "{error}");
+    }
+
+    #[test]
+    fn missing_mermaid_msys_permission_restoration_fails() {
+        let temp = complete_fixture();
+        temp.write(
+            MERMAID_RENDERER,
+            &read(temp.path(), MERMAID_RENDERER)
+                .expect("renderer fixture")
+                .replace(
+                    "if restore_docker_output_dir \"$render_dir\"; then",
+                    "",
+                ),
+        );
+        let error =
+            check(temp.path()).expect_err("retained output must return to owner-only access");
+        assert!(error.contains("restore_docker_output_dir"), "{error}");
+    }
+
+    #[test]
+    fn mermaid_permission_restoration_must_stay_bounded_and_preserve_status() {
+        for (old, replacement) in [
+            ("if ! running_under_msys; then", "if false; then"),
+            ("\"$render_parent\"/keld-mermaid-render.*) ;;", "*) ;;"),
+            (
+                "chmod 0700 -- \"$path\" || {",
+                "chmod 0777 -- \"$path\" || {",
+            ),
+            ("local cleanup_status=$?", "local cleanup_status=0"),
+            ("trap - EXIT", "true"),
+            ("exit \"$cleanup_status\"", "exit 0"),
+        ] {
+            let temp = complete_fixture();
+            temp.write(
+                MERMAID_RENDERER,
+                &read(temp.path(), MERMAID_RENDERER)
+                    .expect("renderer fixture")
+                    .replace(old, replacement),
+            );
+            let error = check(temp.path())
+                .expect_err("retained-output restoration must remain bounded and failure-safe");
+            assert!(error.contains("CI-HYGIENE"), "{old}: {error}");
+        }
     }
 
     #[test]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -176,8 +176,8 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         "windows_native_command() {",
         "MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \"$@\"",
         "restore_windows_owner_only_dacl() {",
-        "for command in cygpath whoami.exe powershell.exe; do",
-        "identity=$(windows_native_command whoami.exe /user /fo csv /nh) || {",
+        "for command in cygpath powershell.exe; do",
+        "$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()",
         "function Set-KeldOwnerOnlyDacl($item) {",
         "windows_native_command powershell.exe -NoProfile -NonInteractive -Command \"$powershell_script\"; then",
         "restore_docker_output_dir() {",
@@ -279,6 +279,7 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         exclusion?,
     );
     for line in [
+        "try { $ownerSid = $identity.User } finally { $identity.Dispose() }",
         "$acl.SetAccessRuleProtection($true, $false)",
         "foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRuleAll($rule) }",
         "$ownerRule = New-Object @ownerRuleParams",
@@ -3533,6 +3534,71 @@ mod tests {
         );
     }
 
+    #[test]
+    #[cfg(windows)]
+    fn mermaid_native_dacl_does_not_depend_on_path_whoami() {
+        use std::process::Command;
+
+        let temp = TempDir::new();
+        let parent = temp.path().join("target");
+        let output_dir = parent.join("keld-mermaid-render.fixture");
+        fs::create_dir_all(output_dir.join("child")).expect("retained directory fixture");
+        fs::write(output_dir.join("child/diagnostic.txt"), "diagnostic")
+            .expect("retained file fixture");
+        // Exercise the owning script with real Windows ACL APIs. A colliding GNU-shaped
+        // executable must not supply identity to the native restoration process.
+        let renderer = include_str!("mermaid_render_check.sh");
+        let start = renderer.find("running_under_msys() {").expect("MSYS owner");
+        let end = renderer
+            .find("\ndocker info >/dev/null")
+            .expect("helper boundary");
+        let script = format!(
+            "set -euo pipefail\n{}\nrender_parent=$(cd \"$1\" && pwd -P)\nwhoami.exe() {{ echo 'GNU whoami rejects Windows arguments' >&2; return 64; }}\nrestore_docker_output_dir \"$render_parent/keld-mermaid-render.fixture\"\n",
+            &renderer[start..end]
+        );
+        let output = Command::new("bash")
+            .args(["-c", &script, "kel152-native-test"])
+            .arg(&parent)
+            .output()
+            .expect("execute native restoration");
+        assert!(
+            output.status.success(),
+            "native restoration failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let oracle = r#"
+$ErrorActionPreference = 'Stop'
+$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
+$root = Get-Item -LiteralPath $env:KELD_TEST_OUTPUT
+$items = @($root) + @(Get-ChildItem -LiteralPath $root.FullName -Recurse -Force)
+if ($items.Count -ne 3) { throw 'incomplete native census' }
+foreach ($item in $items) {
+    $acl = Get-Acl -LiteralPath $item.FullName
+    $rules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))
+    if (-not $acl.AreAccessRulesProtected -or $rules.Count -ne 1) { throw 'DACL not protected single-owner' }
+    $rule = $rules[0]
+    $inheritance = if ($item.PSIsContainer) { 3 } else { 0 }
+    if ($rule.IdentityReference -ne $sid -or $rule.IsInherited -or
+        $rule.AccessControlType -ne 'Allow' -or $rule.FileSystemRights -ne 'FullControl' -or
+        [int]$rule.InheritanceFlags -ne $inheritance -or [int]$rule.PropagationFlags -ne 0) {
+        throw 'native ACE differs from owner-only contract'
+    }
+}
+'native DACL census: 3/3'
+"#;
+        let output = Command::new("powershell.exe")
+            .args(["-NoProfile", "-NonInteractive", "-Command", oracle])
+            .env("KELD_TEST_OUTPUT", &output_dir)
+            .output()
+            .expect("read native DACL inventory");
+        assert!(
+            output.status.success(),
+            "native DACL oracle failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(String::from_utf8_lossy(&output.stdout).contains("native DACL census: 3/3"));
+    }
+
     #[cfg(unix)]
     fn write_msys_renderer_fixture(
         temp: &TempDir,
@@ -3571,14 +3637,17 @@ mod tests {
         fs::write(checkout.join(MERMAID_CONFIG), "{}\n").expect("renderer config");
         temp.write("renderer.sh", include_str!("mermaid_render_check.sh"));
         temp.write("bin/docker", docker);
-        temp.write("bin/uname", "#!/usr/bin/env bash\nprintf 'MSYS_NT-10.0\\n'\n");
+        temp.write(
+            "bin/uname",
+            "#!/usr/bin/env bash\nprintf 'MSYS_NT-10.0\\n'\n",
+        );
         temp.write(
             "bin/cygpath",
             "#!/usr/bin/env bash\n[[ \"$1\" == '-am' || \"$1\" == '-aw' ]] || exit 64\nprintf '%s\\n' \"$2\"\n",
         );
         temp.write(
             "bin/whoami.exe",
-            "#!/usr/bin/env bash\nprintf '\"fixture\",\"S-1-5-21-1\"\\r\\n'\n",
+            "#!/usr/bin/env bash\necho 'GNU whoami rejects Windows arguments' >&2\nexit 64\n",
         );
         temp.write(
             "bin/powershell.exe",
@@ -3593,10 +3662,16 @@ mod tests {
         if let Some(remove) = remove {
             temp.write("bin/rm", remove);
         }
-        for shim in ["docker", "uname", "cygpath", "whoami.exe", "powershell.exe", "chmod"] {
+        for shim in [
+            "docker",
+            "uname",
+            "cygpath",
+            "whoami.exe",
+            "powershell.exe",
+            "chmod",
+        ] {
             let path = temp.path().join("bin").join(shim);
-            fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
-                .expect("shim executable");
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).expect("shim executable");
         }
         for shim in ["rm"] {
             let path = temp.path().join("bin").join(shim);
@@ -3649,6 +3724,11 @@ mod tests {
         assert!(
             String::from_utf8_lossy(&output.stderr).contains("failed-render output retained"),
             "missing retained-output receipt: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("with owner-only host access"),
+            "native restoration must not depend on PATH whoami: {}",
             String::from_utf8_lossy(&output.stderr)
         );
         let retained = retained_render_dirs(&checkout);
@@ -3814,10 +3894,7 @@ mod tests {
             MERMAID_RENDERER,
             &read(temp.path(), MERMAID_RENDERER)
                 .expect("renderer fixture")
-                .replace(
-                    "if restore_docker_output_dir \"$render_dir\"; then",
-                    "",
-                ),
+                .replace("if restore_docker_output_dir \"$render_dir\"; then", ""),
         );
         let error =
             check(temp.path()).expect_err("retained output must return to owner-only access");

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -173,9 +173,17 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         "running_under_msys() {",
         "docker_host_path() {",
         "prepare_docker_output_dir() {",
+        "windows_native_command() {",
+        "MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \"$@\"",
+        "restore_windows_owner_only_dacl() {",
+        "for command in cygpath whoami.exe powershell.exe; do",
+        "identity=$(windows_native_command whoami.exe /user /fo csv /nh) || {",
+        "function Set-KeldOwnerOnlyDacl($item) {",
+        "windows_native_command powershell.exe -NoProfile -NonInteractive -Command \"$powershell_script\"; then",
         "restore_docker_output_dir() {",
         "if ! running_under_msys; then",
         "\"$render_parent\"/keld-mermaid-render.*) ;;",
+        "restore_windows_owner_only_dacl \"$path\"",
         "cleanup() {",
         "local cleanup_status=$?",
         "local cleanup_failed=0",
@@ -191,9 +199,17 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         running,
         docker_path,
         prepare,
+        native_command,
+        native_conversion,
+        native_restore,
+        native_tools,
+        native_identity,
+        native_dacl_function,
+        native_powershell,
         restore,
         restore_guard,
         restore_allowlist,
+        native_call,
         cleanup,
         cleanup_status,
         cleanup_failed,
@@ -215,9 +231,17 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         running,
         docker_path,
         prepare,
+        native_command,
+        native_conversion,
+        native_restore,
+        native_tools,
+        native_identity,
+        native_dacl_function,
+        native_powershell,
         restore,
         restore_guard,
         restore_allowlist,
+        native_call,
         cleanup,
         cleanup_status,
         cleanup_failed,
@@ -232,9 +256,17 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         running?,
         docker_path?,
         prepare?,
+        native_command?,
+        native_conversion?,
+        native_restore?,
+        native_tools?,
+        native_identity?,
+        native_dacl_function?,
+        native_powershell?,
         restore?,
         restore_guard?,
         restore_allowlist?,
+        native_call?,
         cleanup?,
         cleanup_status?,
         cleanup_failed?,
@@ -246,12 +278,31 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         render_path?,
         exclusion?,
     );
+    for line in [
+        "$acl.SetAccessRuleProtection($true, $false)",
+        "foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRuleAll($rule) }",
+        "$ownerRule = New-Object @ownerRuleParams",
+    ] {
+        if shell_line_position(&lines, line).is_none() {
+            return Err(format!(
+                "CI-HYGIENE: `{MERMAID_RENDERER}` is missing native owner-only DACL operation `{line}`. Restore protected inheritance, removal of prior explicit grants, and the one-SID replacement rule."
+            ));
+        }
+    }
     if !(running < docker_path
         && docker_path < prepare
-        && prepare < restore
+        && prepare < native_command
+        && native_command < native_conversion
+        && native_conversion < native_restore
+        && native_restore < native_tools
+        && native_tools < native_identity
+        && native_identity < native_dacl_function
+        && native_dacl_function < native_powershell
+        && native_powershell < restore
         && restore < restore_guard
         && restore_guard < restore_allowlist
-        && restore_allowlist < cleanup
+        && restore_allowlist < native_call
+        && native_call < cleanup
         && cleanup < cleanup_status
         && cleanup_status < cleanup_failed
         && cleanup_failed < disable_exit_trap
@@ -285,7 +336,7 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
             .any(|index| docker_path < *index && *index < prepare)
         || !cygpath.is_some_and(|index| docker_path < index && index < prepare)
         || !chmod.is_some_and(|index| prepare < index && index < restore)
-        || !restore_chmod.is_some_and(|index| restore < index && index < cleanup)
+        || !restore_chmod.is_some_and(|index| restore < index && index < native_call)
         || !docker_run.is_some_and(|index| exclusion < index)
     {
         return Err(format!(
@@ -3488,6 +3539,7 @@ mod tests {
         docker: &str,
         chmod: Option<&str>,
         remove: Option<&str>,
+        native_dacl: Option<&str>,
     ) -> PathBuf {
         use std::os::unix::fs::PermissionsExt as _;
         use std::process::Command;
@@ -3522,7 +3574,15 @@ mod tests {
         temp.write("bin/uname", "#!/usr/bin/env bash\nprintf 'MSYS_NT-10.0\\n'\n");
         temp.write(
             "bin/cygpath",
-            "#!/usr/bin/env bash\n[[ \"$1\" == '-am' ]] || exit 64\nprintf '%s\\n' \"$2\"\n",
+            "#!/usr/bin/env bash\n[[ \"$1\" == '-am' || \"$1\" == '-aw' ]] || exit 64\nprintf '%s\\n' \"$2\"\n",
+        );
+        temp.write(
+            "bin/whoami.exe",
+            "#!/usr/bin/env bash\nprintf '\"fixture\",\"S-1-5-21-1\"\\r\\n'\n",
+        );
+        temp.write(
+            "bin/powershell.exe",
+            native_dacl.unwrap_or("#!/usr/bin/env bash\nexit 0\n"),
         );
         temp.write(
             "bin/chmod",
@@ -3533,7 +3593,7 @@ mod tests {
         if let Some(remove) = remove {
             temp.write("bin/rm", remove);
         }
-        for shim in ["docker", "uname", "cygpath", "chmod"] {
+        for shim in ["docker", "uname", "cygpath", "whoami.exe", "powershell.exe", "chmod"] {
             let path = temp.path().join("bin").join(shim);
             fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
                 .expect("shim executable");
@@ -3582,6 +3642,7 @@ mod tests {
             "#!/usr/bin/env bash\ncase \"$1\" in\ninfo|image|rm) exit 0 ;;\ncontext) printf 'unix:///unused-kel152.sock\\n' ;;\nrun) exit 42 ;;\n*) exit 99 ;;\nesac\n",
             None,
             None,
+            None,
         );
         let output = run_msys_renderer_fixture(&temp, &checkout);
         assert_eq!(output.status.code(), Some(1));
@@ -3623,6 +3684,7 @@ mod tests {
                 "#!/usr/bin/env bash\nmode=$1\nshift\n[[ \"${1:-}\" == -- ]] && shift\nif [[ \"$mode\" == 0700 ]]; then exit 44; fi\nexec /bin/chmod \"$mode\" \"$@\"\n",
             ),
             None,
+            None,
         );
         let output = run_msys_renderer_fixture(&temp, &checkout);
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -3643,6 +3705,24 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn mermaid_renderer_does_not_claim_owner_only_when_native_dacl_restoration_fails() {
+        let temp = TempDir::new();
+        let checkout = write_msys_renderer_fixture(
+            &temp,
+            "#!/usr/bin/env bash\ncase \"$1\" in\ninfo|image|rm) exit 0 ;;\ncontext) printf 'unix:///unused-kel152.sock\\n' ;;\nrun) exit 42 ;;\n*) exit 99 ;;\nesac\n",
+            None,
+            None,
+            Some("#!/usr/bin/env bash\nexit 45\n"),
+        );
+        let output = run_msys_renderer_fixture(&temp, &checkout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(output.status.code(), Some(1));
+        assert!(stderr.contains("owner-only restoration failed"), "{stderr}");
+        assert!(!stderr.contains("with owner-only host access"), "{stderr}");
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn mermaid_renderer_restores_output_when_success_cleanup_cannot_remove_it() {
         use std::os::unix::fs::PermissionsExt as _;
 
@@ -3652,6 +3732,7 @@ mod tests {
             "#!/usr/bin/env bash\ncase \"$1\" in\ninfo|image) exit 0 ;;\ncontext) printf 'unix:///unused-kel152.sock\\n' ;;\nrm) exit 0 ;;\nrun)\n  out=''\n  shift\n  while [[ $# -gt 0 ]]; do\n    if [[ \"$1\" == --volume ]]; then\n      case \"$2\" in *:/out) out=\"${2%:/out}\" ;; esac\n      shift 2\n    else\n      shift\n    fi\n  done\n  [[ -n \"$out\" ]] || exit 64\n  printf '<svg><title>fixture</title><desc>fixture</desc></svg>' >\"$out/fixture.svg\"\n  ;;\n*) exit 99 ;;\nesac\n",
             None,
             Some("#!/usr/bin/env bash\nexit 66\n"),
+            None,
         );
         let output = run_msys_renderer_fixture(&temp, &checkout);
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -3748,6 +3829,9 @@ mod tests {
         for (old, replacement) in [
             ("if ! running_under_msys; then", "if false; then"),
             ("\"$render_parent\"/keld-mermaid-render.*) ;;", "*) ;;"),
+            ("restore_windows_owner_only_dacl \"$path\"", "true"),
+            ("MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'", "true"),
+            ("$acl.SetAccessRuleProtection($true, $false)", "true"),
             (
                 "chmod 0700 -- \"$path\" || {",
                 "chmod 0777 -- \"$path\" || {",

--- a/tools/mermaid_render_check.sh
+++ b/tools/mermaid_render_check.sh
@@ -85,9 +85,85 @@ prepare_docker_output_dir() {
   fi
 }
 
+# Keep native Windows commands outside Git Bash's argument conversion boundary.
+windows_native_command() {
+  MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' "$@"
+}
+
+# Git Bash's `noacl` mount can accept chmod while leaving the native DACL broad.
+# Restore one protected DACL for the invoking SID after the output path passed
+# the caller's checkout-local validation. Each reparse point is refused before
+# it is traversed or modified, and every retained file/directory gets the same
+# owner-only rule.
+restore_windows_owner_only_dacl() {
+  local path=$1
+  local native_path
+  local identity
+  local owner_sid
+  local powershell_script
+  for command in cygpath whoami.exe powershell.exe; do
+    command -v "$command" >/dev/null 2>&1 || {
+      echo "KELD-DOCS006: \`$command\` is required to restore the native Windows DACL for retained Docker output. Repair Git for Windows/Windows system tools, then rerun." >&2
+      return 1
+    }
+  done
+  native_path=$(cygpath -aw "$path") || {
+    echo "KELD-DOCS006: cannot convert retained Docker output '$path' to a native Windows path for DACL restoration." >&2
+    return 1
+  }
+  identity=$(windows_native_command whoami.exe /user /fo csv /nh) || {
+    echo "KELD-DOCS006: cannot determine the invoking Windows SID for retained Docker output restoration." >&2
+    return 1
+  }
+  identity=${identity//$'\r'/}
+  owner_sid=${identity##*,}
+  owner_sid=${owner_sid#\"}
+  owner_sid=${owner_sid%\"}
+  [[ "$owner_sid" =~ ^S-[0-9-]+$ ]] || {
+    echo "KELD-DOCS006: cannot parse the invoking Windows SID for retained Docker output restoration." >&2
+    return 1
+  }
+  powershell_script='
+$ErrorActionPreference = "Stop"
+$root = Get-Item -LiteralPath $env:KELD_MERMAID_DACL_PATH -Force
+if (-not $root.PSIsContainer) { throw "retained output is not a directory" }
+$ownerSid = New-Object System.Security.Principal.SecurityIdentifier($env:KELD_MERMAID_DACL_SID)
+$rights = [System.Security.AccessControl.FileSystemRights]::FullControl
+$propagation = [System.Security.AccessControl.PropagationFlags]::None
+$allow = [System.Security.AccessControl.AccessControlType]::Allow
+function Set-KeldOwnerOnlyDacl($item) {
+  if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+    throw "reparse point refused: $($item.FullName)"
+  }
+  if ($item -is [System.IO.DirectoryInfo]) {
+    foreach ($child in $item.EnumerateFileSystemInfos()) { Set-KeldOwnerOnlyDacl $child }
+    $inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+  } else {
+    $inheritance = [System.Security.AccessControl.InheritanceFlags]::None
+  }
+  $acl = Get-Acl -LiteralPath $item.FullName
+  $acl.SetAccessRuleProtection($true, $false)
+  foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRuleAll($rule) }
+  $ownerRuleParams = @{
+    TypeName = "System.Security.AccessControl.FileSystemAccessRule"
+    ArgumentList = @($ownerSid, $rights, $inheritance, $propagation, $allow)
+  }
+  $ownerRule = New-Object @ownerRuleParams
+  [void]$acl.AddAccessRule($ownerRule)
+  Set-Acl -LiteralPath $item.FullName -AclObject $acl
+}
+Set-KeldOwnerOnlyDacl $root
+'
+  if ! KELD_MERMAID_DACL_PATH="$native_path" KELD_MERMAID_DACL_SID="$owner_sid" \
+    windows_native_command powershell.exe -NoProfile -NonInteractive -Command "$powershell_script"; then
+    echo "KELD-DOCS006: cannot install an exact owner-only native Windows DACL on retained Docker output '$path'. Repair its native DACL before inspection or removal." >&2
+    return 1
+  fi
+}
+
 # A failed render is intentionally retained for diagnosis. Undo the temporary
-# broad mode before returning it to the invoking user; do not apply chmod to an
-# unvalidated path or alter the mktemp-owned Unix path.
+# broad mode before returning it to the invoking user; do not alter the
+# mktemp-owned Unix path or claim owner-only access without native DACL success.
 restore_docker_output_dir() {
   local path=$1
   if ! running_under_msys; then
@@ -100,10 +176,15 @@ restore_docker_output_dir() {
       return 1
       ;;
   esac
+  [[ -d "$path" && ! -L "$path" ]] || {
+    echo "KELD-DOCS006: refused to restore permissions on missing or symlinked retained Docker output '$path'. Remove it manually after inspection." >&2
+    return 1
+  }
   chmod 0700 -- "$path" || {
     echo "KELD-DOCS006: cannot restore owner-only access on retained Docker output '$path'. Repair its Windows ACL before inspecting or removing it." >&2
     return 1
   }
+  restore_windows_owner_only_dacl "$path"
 }
 
 docker info >/dev/null 2>&1 || {

--- a/tools/mermaid_render_check.sh
+++ b/tools/mermaid_render_check.sh
@@ -98,10 +98,8 @@ windows_native_command() {
 restore_windows_owner_only_dacl() {
   local path=$1
   local native_path
-  local identity
-  local owner_sid
   local powershell_script
-  for command in cygpath whoami.exe powershell.exe; do
+  for command in cygpath powershell.exe; do
     command -v "$command" >/dev/null 2>&1 || {
       echo "KELD-DOCS006: \`$command\` is required to restore the native Windows DACL for retained Docker output. Repair Git for Windows/Windows system tools, then rerun." >&2
       return 1
@@ -111,23 +109,12 @@ restore_windows_owner_only_dacl() {
     echo "KELD-DOCS006: cannot convert retained Docker output '$path' to a native Windows path for DACL restoration." >&2
     return 1
   }
-  identity=$(windows_native_command whoami.exe /user /fo csv /nh) || {
-    echo "KELD-DOCS006: cannot determine the invoking Windows SID for retained Docker output restoration." >&2
-    return 1
-  }
-  identity=${identity//$'\r'/}
-  owner_sid=${identity##*,}
-  owner_sid=${owner_sid#\"}
-  owner_sid=${owner_sid%\"}
-  [[ "$owner_sid" =~ ^S-[0-9-]+$ ]] || {
-    echo "KELD-DOCS006: cannot parse the invoking Windows SID for retained Docker output restoration." >&2
-    return 1
-  }
   powershell_script='
 $ErrorActionPreference = "Stop"
 $root = Get-Item -LiteralPath $env:KELD_MERMAID_DACL_PATH -Force
 if (-not $root.PSIsContainer) { throw "retained output is not a directory" }
-$ownerSid = New-Object System.Security.Principal.SecurityIdentifier($env:KELD_MERMAID_DACL_SID)
+$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+try { $ownerSid = $identity.User } finally { $identity.Dispose() }
 $rights = [System.Security.AccessControl.FileSystemRights]::FullControl
 $propagation = [System.Security.AccessControl.PropagationFlags]::None
 $allow = [System.Security.AccessControl.AccessControlType]::Allow
@@ -154,7 +141,7 @@ function Set-KeldOwnerOnlyDacl($item) {
 }
 Set-KeldOwnerOnlyDacl $root
 '
-  if ! KELD_MERMAID_DACL_PATH="$native_path" KELD_MERMAID_DACL_SID="$owner_sid" \
+  if ! KELD_MERMAID_DACL_PATH="$native_path" \
     windows_native_command powershell.exe -NoProfile -NonInteractive -Command "$powershell_script"; then
     echo "KELD-DOCS006: cannot install an exact owner-only native Windows DACL on retained Docker output '$path'. Repair its native DACL before inspection or removal." >&2
     return 1

--- a/tools/mermaid_render_check.sh
+++ b/tools/mermaid_render_check.sh
@@ -70,7 +70,7 @@ docker_host_path() {
   fi
 }
 
-# Docker Desktop presents Git-Bash /tmp binds to Linux containers as root-owned
+# Docker Desktop can present Git-Bash bind mounts to Linux containers as root-owned
 # even when the host directory belongs to the invoking Windows user. The
 # renderer deliberately runs as the non-root Git-Bash uid/gid, so grant that
 # isolated random output directory write access on MSYS only. Unix permissions
@@ -83,6 +83,27 @@ prepare_docker_output_dir() {
       return 1
     }
   fi
+}
+
+# A failed render is intentionally retained for diagnosis. Undo the temporary
+# broad mode before returning it to the invoking user; do not apply chmod to an
+# unvalidated path or alter the mktemp-owned Unix path.
+restore_docker_output_dir() {
+  local path=$1
+  if ! running_under_msys; then
+    return 0
+  fi
+  case "$path" in
+    "$render_parent"/keld-mermaid-render.*) ;;
+    *)
+      echo "KELD-DOCS006: refused to restore permissions on unexpected render path '$path'. Remove it manually after inspection." >&2
+      return 1
+      ;;
+  esac
+  chmod 0700 -- "$path" || {
+    echo "KELD-DOCS006: cannot restore owner-only access on retained Docker output '$path'. Repair its Windows ACL before inspecting or removing it." >&2
+    return 1
+  }
 }
 
 docker info >/dev/null 2>&1 || {
@@ -137,18 +158,50 @@ export DOCKER_HOST=$docker_host
 export DOCKER_CONFIG=$docker_config_dir
 
 cleanup() {
+  local cleanup_status=$?
+  local cleanup_failed=0
+  trap - EXIT
   if [[ -n "$active_container" ]]; then
     docker rm --force "$active_container" >/dev/null 2>&1 || true
   fi
-  if [[ "$render_succeeded" == 1 && "$keep_output" == 0 && -n "$render_dir" ]]; then
-    case "$render_dir" in
-      "$render_parent"/keld-mermaid-render.*) rm -rf -- "$render_dir" ;;
-      *)
-        echo "KELD-DOCS006: refused to clean unexpected render path '$render_dir'. Remove it manually after inspection." >&2
-        ;;
-    esac
+  if [[ -n "$render_dir" ]]; then
+    if [[ "$render_succeeded" == 1 && "$keep_output" == 0 ]]; then
+      case "$render_dir" in
+        "$render_parent"/keld-mermaid-render.*)
+          if ! rm -rf -- "$render_dir"; then
+            cleanup_failed=1
+            if [[ -d "$render_dir" ]]; then
+              if restore_docker_output_dir "$render_dir"; then
+                echo "KELD-DOCS006: successful-render output could not be removed; retained in $render_dir with owner-only host access." >&2
+              else
+                echo "KELD-DOCS006: successful-render output could not be removed and owner-only restoration failed for $render_dir. Repair its Windows ACL before inspection or removal." >&2
+              fi
+            fi
+          fi
+          ;;
+        *)
+          echo "KELD-DOCS006: refused to clean unexpected render path '$render_dir'. Remove it manually after inspection." >&2
+          cleanup_failed=1
+          ;;
+      esac
+    else
+      if restore_docker_output_dir "$render_dir"; then
+        if [[ "$render_succeeded" == 0 ]]; then
+          echo "KELD-DOCS006: failed-render output retained in $render_dir with owner-only host access." >&2
+        fi
+      else
+        cleanup_failed=1
+        if [[ "$render_succeeded" == 0 ]]; then
+          echo "KELD-DOCS006: failed-render output retained in $render_dir, but owner-only restoration failed. Repair its Windows ACL before inspection or removal." >&2
+        fi
+      fi
+    fi
   fi
-  rmdir "$docker_config_dir" >/dev/null 2>&1 || true
+  rmdir "$docker_config_dir" >/dev/null 2>&1 || cleanup_failed=1
+  if [[ "$cleanup_status" == 0 && "$cleanup_failed" == 1 ]]; then
+    exit 1
+  fi
+  exit "$cleanup_status"
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM HUP


### PR DESCRIPTION
## Summary

Failed Mermaid renders retain their checkout-local diagnostics with an owner-only native Windows DACL. On Git for Windows, the previous identity lookup selected GNU `whoami.exe` and aborted before restoring permissions, leaving other users able to write. Read the invoking SID directly from the existing PowerShell process token and remove the extra executable, CSV parser, and SID environment transfer.

## Spec refs

KEL-152. No product boundary change. Reuse the existing validated output path, MSYS guard, protected-DACL routine, and EXIT cleanup. Preserve the pinned renderer, non-root user, read-only source/config mounts, isolation limits, original failure status, and successful output removal.

## Review gates

Five root gates: unsafe none; public API none; permission model retained Windows-output DACL; dependency addition none; wire protocol none. Native filesystem security independently reviewed on `b39128f428f6ffd227cf26f0cf0fd08049cc61d1` by `/root/kel152_security_review`, with independent refutation by `/root/kel152_refuter`; no remaining scoped findings. This is the repository-authorized isolated substitute because the local CodeRabbit CLI is unavailable. No GitHub review threads were outstanding.

## Tests

- Real Windows regression fails before the identity fix and passes after it; deleting native restoration makes its DACL oracle fail.
- Native hygiene: 88/88 passed, including real root/child/file DACL readback.
- Exact-tip Windows Docker forced failure: exit 1; all 16 retained items have protected DACLs with exactly one explicit invoking-SID FullControl ACE and correct inheritance; no reparse items.
- Invoking owner creates/writes/deletes a file. Independently identified ordinary `RAMANI\KeldDaclTest` gets `UnauthorizedAccessException` / native error 5 on CreateNew; the file is absent.
- Source restored byte-for-byte. Real pinned renderer succeeds on all 9 diagrams and removes its new output; validated failed output removed and worktree clean.
- Exact-tip Windows `just ci`: exit 0. Format, workspace Clippy with `-D warnings`, TypeScript, docs, hygiene, renderer and cargo-deny passed. Full nextest summary: `583 tests run: 583 passed (1 leaky), 3 skipped`; these are the configured gate's actual results.

## Platforms

Real Windows 11 build 26200, Git Bash 5.2.37 / Git for Windows 2.52.0.windows.1, Docker Desktop 4.88.1 in Linux-container mode. Actual native permission and authenticated foreign-principal acceptance passed. Unix-specific subprocess fixtures require the hosted hygiene lane; earlier macOS evidence does not substitute for this final diff.

Scope remains an owner-private checkout without concurrent hostile host writers. A host-planted hardlink can alias an external file; independent pinned-container probes refuted that as reachable from renderer authority (outside links fail EXDEV/ENOENT). No protection against arbitrary host-side namespace tampering is claimed.

## Perf impact

No performance-motivated replacement. Native ACL work remains limited to retained MSYS output; one extra identity subprocess and its parsing were removed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retained Docker output protection on Windows MSYS environments through native owner-only access restoration.
  - Added validation to reject unsafe, missing, symlinked, or reparse-point output directories.
  - Restoration failures now report accurately without claiming owner-only access was applied.
  - Improved compatibility when standard identity tools are unavailable or behave unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->