### PR TITLE
docs(onboarding): publish current scope and contributor quick-start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,7 @@ dist/
 /competitors/
 /docs/research/
 
-# Roadmap remains local; agent docs outputs are tracked and stale-checked.
-/ROADMAP.md
+# Public roadmap and generated agent docs are tracked.
 
 # CI workflows, CODEOWNERS, and templates are tracked (KEL-39).
 /.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+Keld is in pre-alpha development. No alpha/dev-preview release is announced here;
+the Cargo package version is not a release record. Future releases will link their
+actual tag, release notes, tested platforms, and known limitations.
+
+### Current development baseline
+
+- A source-built Rust host and CLI provide project scaffolding, diagnostics, and the
+  current native-window/Bun/app-link demo.
+- kipc framing, codecs, authentication, permission evaluation, and scoped runtime
+  supervision have implementations and tests.
+- `@keld/electron` provides a limited lifecycle facade with recorded divergences.
+- Public architecture, CI, and evidence scoreboards describe the intended contracts
+  and measured slices.
+
+The [product-status ledger](docs/engineering/product-status.md) is the authoritative
+inventory and links code/tests for these statements. Migration, broad Electron
+compatibility, installers, and signed updates remain future work. The
+[commit history](https://github.com/gyldlab/keld/commits/main/) records individual
+changes; the [roadmap](ROADMAP.md) explains prerequisites.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ cd hello-keld
 ```
 
 The expected result is a `hello-keld` window. Close it to end the session;
-`IPC echo ok` is printed when captured Bun output is forwarded at shutdown. This builds both binaries required by `dev`;
-there is no npm installation or packaged app release yet.
+`IPC echo ok` is printed when captured Bun output is forwarded at shutdown. Both
+binaries required by `dev` are built from source; there is no npm installation or
+packaged app release yet.
 
 ## Evidence
 

--- a/README.md
+++ b/README.md
@@ -1,70 +1,92 @@
 # KELD
 
-**The desktop framework that replaces Electron without requiring a full app rewrite.**
-Rust core · Bun-powered JS/TS main process · system webviews · security by default.
+Keld is a desktop framework being built around a Rust host, Bun application processes,
+and the operating system's webview. Its goal is to make Electron applications smaller
+and easier to secure while measuring compatibility against real application behavior.
 By [GYLDLAB](https://github.com/gyldlab).
 
-> Status: **pre-alpha** — this checkout contains implementation and tracked architecture
-> specs. The generated [Current/Target/Evidence ledger](docs/engineering/product-status.md)
-> is the canonical repository-status view; private research is optional evidence in a
-> separate nested repository.
+**Pre-alpha: build from source.** The current runnable slice scaffolds an application,
+opens a native webview window, and runs an authenticated IPC echo in a supervised Bun
+process. Electron migration, application installers, and signed updates are future work.
 
-## The idea in 30 seconds
+## What works today
 
-Keld starts from Electron's observable API and process contracts, measures them against
-a versioned app corpus, and keeps unsupported behavior explicit. Median apps should
-migrate through configuration; demanding apps may drive targeted runtime, host or app
-patches behind the same compatibility facade.
+- `keld create`, `keld dev`, and `keld doctor` support the current hello application.
+- The Rust host owns the window and Bun lifecycle; kipc provides authenticated app-link
+  communication, framed messages, and typed codecs.
+- Permission parsing and guard-before-handler checks exist. Broad native services and
+  complete strict-profile admission remain incomplete.
+- `@keld/electron` implements a limited application-lifecycle facade. Its
+  [compatibility board](docs/engineering/compat-scoreboard.md) records the known
+  matches and divergences; broad Electron compatibility is not measured yet.
 
-The following is the **target product flow**. `migrate` and `build` are not implemented
-in the current pre-alpha CLI:
+The generated [Current/Target/Evidence ledger](docs/engineering/product-status.md)
+is the source of truth for implemented scope and its evidence. These platform rows
+summarize its current no-flag app-session surfaces, not release support:
 
-```bash
-cd my-electron-app
-bunx keld migrate   # analyzes your app, generates config, aliases electron → @keld/electron
-bunx keld dev       # no bundled Chromium/Node executable; exact gaps reported
-bunx keld build     # signed installers + kilobyte-scale delta updates
-```
+| Platform | Current app-session slice | Qualification still needed |
+|---|---|---|
+| macOS / WKWebView | Native window, app link, recovery, ordered cleanup | Complete strict profiles and release packaging |
+| Windows / WebView2 | Native window, named-pipe app link, recovery, ordered cleanup | Remaining strict admission and release packaging |
+| Ubuntu/Debian x86_64 / WebKitGTK / Wayland | Window, authenticated link, strict Bun generations, recovery and cleanup | X11 product run, other distributions/architectures, release packaging |
 
-The target architecture replaces Electron's architecture, not its API:
+## Try it
 
-- **A prebuilt Rust host** owns windows, webviews, and every native API — you never
-  install a Rust toolchain.
-- **Your JS/TS main process and named compatibility roles run on Bun** as supervised,
-  strict-profile principals — npm/Node behavior is corpus-tested, ambient OS access is
-  denied, and a child crash does not take your windows down.
-- **System webviews by default** (WebView2 / WKWebView / WebKitGTK) with a polyfill
-  pack and per-platform engine policy.
-- **Typed binary IPC** (schema-first and backpressured; optional per-role shared-memory
-  bulk lanes only after workload and sandbox measurements justify them).
-- **Default-deny permissions** generated from your code, reviewed like a lockfile.
-- **Delta updates (bsdiff+zstd, signed)** and cross-target-assembled installers;
-  signing/notarization remains an exercised per-platform credential flow.
-
-The current implementation is a vertical slice, not the target product. See the
-generated [product-status ledger](docs/engineering/product-status.md) for the exact
-crate, package, phase, platform, and evidence split. Architecture documents continue to
-own target design; Linear owns live execution state.
-
-## Workspace layout
-
-```
-crates/   keld-core · keld-wv · keld-ipc · keld-guard · keld-native · keld-runtime
-          keld-update · keld-pack · keld-compat · keld-host (bin) · keld-cli (bin)
-packages/ @keld/electron; planned package surfaces are classified in the status ledger
-```
-
-## Development
-
-See [`AGENTS.md`](AGENTS.md) for engineering rules and verification gates.
+Use the [source-build quick-start](docs/onboarding/README.md#run-the-current-demo)
+for prerequisites, expected output, and Windows instructions. With Rust and Bun
+installed, run this in a macOS or qualified Linux desktop terminal:
 
 ```bash
-cargo nextest run --workspace --profile ci
-just hello    # launch the diagnostic hello backend for the current platform
+git clone https://github.com/gyldlab/keld.git
+cd keld
+cargo build --locked -p keld-cli -p keld-host
+./target/debug/keld create hello-keld
+cd hello-keld
+../target/debug/keld doctor
+../target/debug/keld dev
 ```
+
+The expected result is a `hello-keld` window. Close it to end the session;
+`IPC echo ok` is printed when captured Bun output is forwarded at shutdown. This builds both binaries required by `dev`;
+there is no npm installation or packaged app release yet.
+
+## Evidence
+
+- [Product status](docs/engineering/product-status.md): code and tests behind every
+  current capability, with target-only work called out.
+- [Electron compatibility](docs/engineering/compat-scoreboard.md): implemented
+  lifecycle behavior and divergences. No product corpus percentage is published yet.
+- [Benchmarks](https://github.com/gyldlab/keld-benches) and the
+  [measurement scoreboard](docs/engineering/budget-scoreboard.md): OS-qualified
+  fixtures, pinned measurements, and limitations. Historical hello measurements do not
+  establish a performance claim for a complete migrated application.
+- [CI](https://github.com/gyldlab/keld/actions/workflows/ci.yml): current automated
+  checks. A CI run and a real desktop acceptance run are different evidence.
+
+## Roadmap
+
+The public [roadmap](ROADMAP.md) explains the next prerequisites and their exit
+criteria. [GitHub Issues](https://github.com/gyldlab/keld/issues) is the public place to
+report defects, find contribution opportunities, and follow work.
+
+## Target
+
+Keld aims to provide a prebuilt Rust host, supervised Bun application roles, typed
+kipc, and generated host-enforced default-deny permissions. Electron applications
+would migrate through a compatibility facade with unsupported behavior visible.
+
+`keld migrate` and `keld build` are reserved commands today. VS Code migration is a
+future stress workload that depends on those framework contracts; it is not a current
+demo. The [architecture](docs/architecture/01-overview.md) defines the destination.
+
+## Contribute
+
+Start with [CONTRIBUTING.md](CONTRIBUTING.md), the
+[maintainers](MAINTAINERS.md), and the [Code of Conduct](CODE_OF_CONDUCT.md).
+Report vulnerabilities through [SECURITY.md](SECURITY.md). Public code, documentation,
+and tests are sufficient to contribute; private research is optional.
 
 ## License
 
-MIT OR Apache-2.0 — [`LICENSE`](LICENSE), [`LICENSE-MIT`](LICENSE-MIT),
-[`LICENSE-APACHE`](LICENSE-APACHE), and workspace `Cargo.toml`. See
-[`CONTRIBUTING.md`](CONTRIBUTING.md) and [`SECURITY.md`](SECURITY.md).
+MIT OR Apache-2.0 — [LICENSE](LICENSE), [LICENSE-MIT](LICENSE-MIT),
+[LICENSE-APACHE](LICENSE-APACHE).

--- a/README.md
+++ b/README.md
@@ -21,20 +21,22 @@ process. Electron migration, application installers, and signed updates are futu
   matches and divergences; broad Electron compatibility is not measured yet.
 
 The generated [Current/Target/Evidence ledger](docs/engineering/product-status.md)
-is the source of truth for implemented scope and its evidence. These platform rows
-summarize its current no-flag app-session surfaces, not release support:
+is the source of truth for implemented scope and its evidence. These rows summarize
+its no-flag app-session implementation and the latest acceptance limitations; they
+do not establish release support:
 
 | Platform | Current app-session slice | Qualification still needed |
 |---|---|---|
 | macOS / WKWebView | Native window, app link, recovery, ordered cleanup | Complete strict profiles and release packaging |
-| Windows / WebView2 | Native window, named-pipe app link, recovery, ordered cleanup | Remaining strict admission and release packaging |
-| Ubuntu/Debian x86_64 / WebKitGTK / Wayland | Window, authenticated link, strict Bun generations, recovery and cleanup | X11 product run, other distributions/architectures, release packaging |
+| Windows / WebView2 | Native window, named-pipe app link, recovery, ordered cleanup | Quick-start requalification awaits an existing endpoint-security prerequisite; remaining strict admission and release packaging |
+| Ubuntu/Debian x86_64 / WebKitGTK / Wayland | Window, authenticated link, strict Bun generations, recovery | Stock app native Close fails the latest Wayland acceptance; X11 product run, other distributions/architectures, release packaging |
 
 ## Try it
 
 Use the [source-build quick-start](docs/onboarding/README.md#run-the-current-demo)
 for prerequisites, expected output, and Windows instructions. With Rust and Bun
-installed, run this in a macOS or qualified Linux desktop terminal:
+installed, run this in a macOS or Ubuntu/Debian x86_64 Wayland desktop terminal
+after checking the platform prerequisites and current limitations below:
 
 ```bash
 git clone https://github.com/gyldlab/keld.git
@@ -46,10 +48,16 @@ cd hello-keld
 ../target/debug/keld dev
 ```
 
-The expected result is a `hello-keld` window. Close it to end the session;
-`IPC echo ok` is printed when captured Bun output is forwarded at shutdown. Both
-binaries required by `dev` are built from source; there is no npm installation or
-packaged app release yet.
+The expected result is a `hello-keld` window. Captured Bun output, including
+`IPC echo ok`, appears at shutdown. The Mac demo verified Ctrl-C shutdown and relaunch;
+it did not independently exercise the window's Close button.
+
+**Known Linux lifecycle gap:** on the tested Ubuntu/Wayland candidate, native Close
+removes the renderer but leaves the host, Bun, and launch stage running. Ctrl-C
+cleaned up that session; this separate interrupt result does not pass normal-close
+acceptance. The [lifecycle issue](https://github.com/gyldlab/keld/issues/176) tracks
+the required stock-app fix. Both binaries are built from source; there is
+no npm installation or packaged app release yet.
 
 ## Evidence
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,66 @@
+# Keld public roadmap
+
+Keld is pre-alpha. The generated [Current/Target/Evidence ledger](docs/engineering/product-status.md)
+owns implementation status; the [architecture](docs/architecture/01-overview.md) and
+approved issue specs own the target contracts. This page presents their dependencies
+and exit criteria, without creating another completion ledger or promising dates.
+
+Follow [public GitHub issues](https://github.com/gyldlab/keld/issues) for scope,
+progress, and decisions. The [open-source foundation work](https://github.com/gyldlab/keld/issues/167)
+tracks public documentation, governance, security checks, genuine testing, and release
+readiness. Maintainers connect public issues to internal planning; private tracker
+access is not needed to follow or contribute to the project.
+
+## What is available
+
+The current slice includes scaffolding and diagnostics, a native webview window with
+a supervised Bun process, authenticated app-link communication, permission evaluation,
+and a limited Electron lifecycle facade. The [quick-start](docs/onboarding/README.md)
+runs that slice. Native services, the wider compatibility surface, migration, packaging,
+and updates remain incomplete; consult the ledger for each component's exact scope.
+
+## Prerequisites and exit criteria
+
+| Order | Work | Evidence needed to advance |
+|---|---|---|
+| Foundation | Make the current slice reproducible and its limitations public; establish contributor, security, and review procedures | A stranger can build and run the documented demo, report a result publicly, and trace each product claim to the ledger and its evidence |
+| Guarded application slice | Complete the public lifecycle/window contract and remaining runtime admission for the declared platforms | Host-owned windows survive the specified child failures; fresh generations invalidate stale authority; the documented app runs on every platform claimed |
+| Bounded native and compatibility plane | Complete required IPC ordering/backpressure/cancellation, generated permissions, renderer bridge, native brokers, and common Electron behavior | Approved contracts have failure-path and negative-control evidence; a declared representative application corpus exercises `migrate` and `dev`, with gaps visible |
+| Distribution and recovery | Build installable artifacts, qualify signing and package channels, implement signed updates and rollback | Clean-machine installation and interrupted/corrupt-update scenarios pass on each claimed OS/channel; shipped security profiles have real containment evidence |
+| Compatibility depth | Expand the measured app corpus and only the named roles, addon support, or engine options that it requires | A committed denominator, pinned artifacts, operation-level results, and explicit failures/waivers support each published compatibility claim |
+
+The ledger's [phase view](docs/engineering/product-status.md#phases) shows how much
+of each area exists today. Work can advance independently when its prerequisites are
+satisfied; a partial implementation does not mark an entire phase complete.
+
+## A release follows evidence
+
+The source version is currently development metadata, not proof of an alpha release.
+An alpha/dev-preview release should name its supported runnable slice and known limits,
+include reproducible validation, and link a real tag and release notes. Automated
+release publishing, checksums, SBOM/provenance, and signed or attested artifacts belong
+with the reviewed artifact pipeline when binaries begin shipping. The
+[changelog](CHANGELOG.md) records the current unreleased baseline.
+
+## VS Code and other demanding applications
+
+VS Code migration is future work. It depends on the framework's migration command,
+process contracts, native services, extension behavior, and installable artifacts.
+It is a separately measured stress workload, with its input artifact and permitted
+adaptations declared. An opened editor window cannot stand in for a migrated desktop
+application, and showcase results do not change the general product denominator.
+
+## Research that earns implementation
+
+Material unknowns need a bounded question, competing hypotheses, primary evidence,
+and the smallest discriminating experiment before implementation. Current examples
+include Bun/Electron semantic differences, platform containment and engine behavior,
+compatibility corpus coverage, and end-to-end performance attribution. Existing
+[compatibility evidence](docs/engineering/compat-scoreboard.md) and
+[benchmark evidence](docs/engineering/budget-scoreboard.md) identify their limitations.
+New research does not by itself create a roadmap obligation.
+
+Keld protects four core ideas: a prebuilt host, supervised Bun roles, kipc, and
+generated host-enforced default-deny. It does not need a new browser engine, mandatory
+shared memory, or a VS Code-specific core to demonstrate those contracts. See the
+[architecture's non-goals](docs/architecture/01-overview.md#6-what-keld-is-not-v1-non-goals).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,13 @@ and a limited Electron lifecycle facade. The [quick-start](docs/onboarding/READM
 runs that slice. Native services, the wider compatibility surface, migration, packaging,
 and updates remain incomplete; consult the ledger for each component's exact scope.
 
+The latest device acceptance also leaves current work open: the stock application's
+native Close fails on tested Ubuntu/Wayland even though SIGINT cleanup succeeds;
+Windows candidate requalification awaits an existing endpoint-security prerequisite.
+The [quick-start](docs/onboarding/README.md#run-the-current-demo) preserves those
+separate results. Resolve the lifecycle regression and complete admitted platform
+acceptance before treating the demo as release-ready.
+
 ## Prerequisites and exit criteria
 
 | Order | Work | Evidence needed to advance |

--- a/docs/architecture/06-runtime-and-tooling.md
+++ b/docs/architecture/06-runtime-and-tooling.md
@@ -362,9 +362,12 @@ hand-written, wire-exact v0 client embedded into the generated self-contained
 pipeline. `keld ipc-client echo` remains a separate CLI-side kipc client,
 useful standalone; the template no longer shells out to it.
 
-Distribution: `@keld/cli` npm package with per-platform binaries under
-`optionalDependencies` (esbuild pattern); `bunx keld` / `npx keld` work with zero
-global install. Host + runtime binaries fetched signed, verified, cached.
+Target distribution (not implemented): an `@keld/cli` npm package with per-platform
+binaries under `optionalDependencies` (esbuild pattern). `bunx keld` / `npx keld`
+are planned package-manager invocations; no npm wrapper is currently shipped.
+The target fetches signed, verified host and runtime binaries into a cache. Today,
+use the [source-build quick-start](../onboarding/README.md#run-the-current-demo);
+the [product-status ledger](../engineering/product-status.md#packages) owns package maturity.
 
 ## 3. keld-pack: packaging & cross-compilation
 

--- a/docs/onboarding/03-api-and-cli-surface.md
+++ b/docs/onboarding/03-api-and-cli-surface.md
@@ -29,7 +29,9 @@ cargo build -p keld-cli && ./target/debug/keld <verb> [args]
 ```
 
 `cargo run` keeps your current working directory, which matters for `create`, `dev`, and
-`doctor` — all three resolve paths relative to the cwd.
+`doctor` — all three resolve paths relative to the cwd. For `dev`, first build both
+`keld-cli` and `keld-host`; the [quick-start](README.md#run-the-current-demo) includes
+the required sibling executables.
 
 ### 1.2 Dispatch, in one place
 
@@ -88,7 +90,7 @@ prints **`KELD-CLI-046`** first, then the same block, and exits **2**.
 
 ### 1.5 `keld create <name>`
 
-Writes the five embedded template files into `./<name>`. Nothing is downloaded and
+Writes the six embedded template files into `./<name>`. Nothing is downloaded and
 nothing is installed; the files are compiled into the binary with `include_str!`
 ([`template.rs`](../../crates/keld-cli/src/template.rs)).
 
@@ -102,6 +104,7 @@ my-app/.gitignore
 my-app/index.html
 my-app/keld.config.ts
 my-app/package.json
+my-app/src/kipc.ts
 my-app/src/main.ts
 ```
 

--- a/docs/onboarding/05-development-guide.md
+++ b/docs/onboarding/05-development-guide.md
@@ -25,9 +25,12 @@ For the complete verification gate, also install:
 | `cargo-deny` | Supply-chain checks (`cargo install cargo-deny --locked`) |
 | Docker-compatible engine | Runs the digest-pinned Mermaid renderer for `just ci` |
 
-Use the pinned Rust toolchain and record your actual Bun version with any reported
-result. No private repository, optional checkout hook, or contributor-memory service
-is needed to build or contribute.
+Use the pinned Rust toolchain and **Bun 1.4.0 for the full workspace gate**, matching
+CI and the exact Linux strict-fixture assertion. Record the selected version/revision;
+a demo observed with Bun 1.4.2 is separate evidence. The
+[quick-start prerequisites](README.md#prerequisites) also explain Linux trusted-checkout
+permissions. No private repository, optional checkout hook, or contributor-memory
+service is needed to build or contribute.
 
 ## 2. First run
 
@@ -37,9 +40,12 @@ Bun app-link output. `cargo build -p keld-cli` alone does not provide the host i
 fresh checkout. `just hello` exercises only the diagnostic backend window.
 
 The [platform surfaces ledger](../engineering/product-status.md#platform-surfaces)
-owns current qualification. Linux has a native Ubuntu/Debian x86_64 Wayland no-flag
-slice; X11 product runs, other distributions, and release packaging remain unverified.
-This source-built demo is not an installer or a migrated Electron application.
+owns implemented scope. The [quick-start](README.md#run-the-current-demo) records the
+latest acceptance gaps: Windows candidate execution awaits an existing endpoint-security
+prerequisite; Linux stock native Close leaves session processes/stage alive, while
+SIGINT cleanup is a separate observed result. X11 product runs, other distributions,
+and release packaging remain unverified. This source-built demo is not an installer
+or a migrated Electron application.
 
 ---
 
@@ -400,7 +406,7 @@ repo — if something points you at one, it is describing a different project.
 ## 12. Troubleshooting
 
 **The macOS window does not open.**
-Check, in order: (1) you are on macOS — Windows and Linux return `KELD-WV-001` by design;
+Check, in order: (1) the command is running in the intended macOS desktop session;
 (2) you have a real window server (not a bare SSH session) — window-creation failure
 surfaces as `KELD-WV-002` with that hint; (3) the window opened behind your terminal —
 the binary is not a `.app` bundle, so check Mission Control / cmd-tab before concluding

--- a/docs/onboarding/05-development-guide.md
+++ b/docs/onboarding/05-development-guide.md
@@ -15,82 +15,31 @@ this guide and those disagree, they win.
 
 ## 1. Prerequisites
 
-| Tool | Required? | Install | Why |
-|---|---|---|---|
-| Rust 1.97.1 | Yes | nothing to do — [`rust-toolchain.toml`](../../rust-toolchain.toml) pins `channel = "1.97.1"` with `rustfmt` + `clippy`, and rustup installs it on your first `cargo` command in this directory | Every crate; edition 2024 |
-| `cargo-nextest` | Yes | `cargo install cargo-nextest --locked` | The test gate is `cargo nextest run --workspace --profile ci` ([`.config/nextest.toml`](../../.config/nextest.toml)) |
-| `cargo-deny` | For `just ci` / the supply-chain gate | `cargo install cargo-deny --locked` | The `deny` job in CI ([`deny.toml`](../../deny.toml)) |
-| `just` | Optional, but assumed by the docs | `cargo install just` (or `brew install just`) | [`justfile`](../../justfile) is the canonical local mirror of CI |
-| Bun | Yes in practice | https://bun.sh | `keld dev` spawns `bun run src/main.ts`; the `bun_echo` integration test **fails** (does not skip) without it |
+The [quick-start](README.md#prerequisites) owns current build and runtime setup.
+For the complete verification gate, also install:
 
-You do **not** need Xcode-the-IDE or Node. `@keld/electron` is a zero-dependency
-TS package (`bun` runs it directly); `keld create`'s hello template still has
-nothing to `bun install`.
+| Tool | Purpose |
+|---|---|
+| `just` | Runs the checked-in gate recipes (`cargo install just --locked`) |
+| `cargo-nextest` | Workspace test runner (`cargo install cargo-nextest --locked`) |
+| `cargo-deny` | Supply-chain checks (`cargo install cargo-deny --locked`) |
+| Docker-compatible engine | Runs the digest-pinned Mermaid renderer for `just ci` |
 
-Versions this guide was written against (macOS, Darwin 25.5.0, aarch64):
-
-```
-rustc 1.97.1 (8bab26f4f 2026-07-14)     # matches rust-toolchain.toml
-cargo 1.97.1 (c980f4866 2026-06-30)
-cargo-nextest 0.9.140
-cargo-deny 0.19.9
-bun 1.4.0
-just                                    # NOT installed on this machine — see §3.3 for raw equivalents
-```
-
----
+Use the pinned Rust toolchain and record your actual Bun version with any reported
+result. No private repository, optional checkout hook, or contributor-memory service
+is needed to build or contribute.
 
 ## 2. First run
 
-```bash
-git clone https://github.com/gyldlab/keld.git
-cd keld
+Follow [Run the current demo](README.md#run-the-current-demo), which builds the CLI
+and its required sibling host, scaffolds an app, and exercises doctor, the window, and
+Bun app-link output. `cargo build -p keld-cli` alone does not provide the host in a
+fresh checkout. `just hello` exercises only the diagnostic backend window.
 
-cargo build --workspace          # first build pulls tao/wry on macOS; a few minutes
-just hello                       # == cargo run -p keld-host -- --hello
-cargo run -p keld-cli -- doctor
-```
-
-`just hello` opens a 960×640 window titled "Keld" and blocks until you close it. Live
-backends exist on all three platforms now: macOS (`WKWebView`), Windows (`WebView2`,
-direct COM since KEL-65), and Linux (`WebKitGTK`, wry interim since KEL-28) —
-([`crates/keld-wv/src/wkwebview/mod.rs`](../../crates/keld-wv/src/wkwebview/mod.rs),
-[`webview2/mod.rs`](../../crates/keld-wv/src/webview2/mod.rs),
-[`webkitgtk/mod.rs`](../../crates/keld-wv/src/webkitgtk/mod.rs)). The Linux backend
-compiles, passes its unit tests, and its full crate/workspace suite is green on a real
-Ubuntu box (GTK3 + `libwebkit2gtk-4.1-dev`) — but a real window opening has **not**
-been visually verified anywhere yet (KEL-28 landed from a sandbox with no display
-server; `gtk::init()` fails there with "Failed to initialize GTK", not a code defect).
-Confirm on real Linux hardware/VM with a display before relying on it. `WvError::UnsupportedPlatform`
-(`KELD-WV-001`) still exists for any other target. Everything else in the
-workspace (kipc, the CLI, `create`, `doctor`, the echo tests) is cross-platform and
-builds and tests on all three today.
-
-Expected `doctor` output outside a project (macOS shown; Windows/Linux differ only in
-the `webview` line's detail text — "Windows WebView2..." / "Linux WebKitGTK..."):
-
-```
-[ok] bun — found bun 1.4.0
-[ok] project — no project directory (run inside a scaffolded app for layout checks)
-[ok] webview — macOS WKWebView hello window available via `keld dev`
-```
-
-To see the whole vertical slice end to end:
-
-```bash
-cargo build -p keld-cli
-KELD=$PWD/target/debug/keld          # from the repo root
-
-cd /tmp && "$KELD" create my-app && cd my-app
-"$KELD" dev
-```
-
-which prints `ipc-echo ok: …` and `my-app: main process ready (IPC echo ok)` and opens
-the window. Close the window (or Ctrl-C the terminal) to end the session. Confirmed on
-macOS and Windows with a real display. Linux now has both the X11 Xvfb/window-manager
-smoke (`xdotool search --name Keld`) and native Ubuntu GNOME Wayland no-flag product
-evidence for rendered navigation, two calls, recovery, ordered teardown, strict
-descendant reaping, stage cleanup, and relaunch. A real X11 product run remains open.
+The [platform surfaces ledger](../engineering/product-status.md#platform-surfaces)
+owns current qualification. Linux has a native Ubuntu/Debian x86_64 Wayland no-flag
+slice; X11 product runs, other distributions, and release packaging remain unverified.
+This source-built demo is not an installer or a migrated Electron application.
 
 ---
 
@@ -362,10 +311,12 @@ approval.
 
 ---
 
-## 9. The workflow loop
+## 9. The maintainer and assigned-agent workflow loop
 
-For anything bigger than a bug fix, [`docs/agents/workflow.md`](../agents/workflow.md) is
-the process of record. Condensed:
+External contributors follow [CONTRIBUTING.md](../../CONTRIBUTING.md) through public
+GitHub issues and forks. Maintainers handle private planning links and coordination.
+For maintainers and assigned agents, [`docs/agents/workflow.md`](../agents/workflow.md)
+is the process of record. Condensed:
 
 1. **Read before writing** — the issue, the governing spec section in
    `docs/architecture/`, the target crate's `AGENTS.md`, and
@@ -497,3 +448,18 @@ owning process is gone before removing stale files manually
 Much of this tree is uncommitted work in progress (§3.2). Confirm against a clean
 checkout of `main` before assuming your change caused it — and if it did not, say so in
 the PR rather than fixing it silently in an unrelated diff.
+
+
+## Optional maintainer checkout setup
+
+External contributors do not need this setup. Maintainers with access to the separate
+research repository can run `just research-sync` after reviewing the checked-out
+revision, and `just competitors-sync` for the pinned local competitor trees.
+`just research-push` applies only to the nested research repository; never stage that
+repository from the Keld root.
+
+After reviewing their bytes, `just hooks-install` copies notification-only hooks into
+the clone's Git common directory and sets its local `core.hooksPath`. Checkout and
+merge do not run incoming repository code. The hooks print the explicit sync commands;
+Git does not enable them on clone. Rerun installation only when intending to trust
+updated hook bytes.

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -1,59 +1,137 @@
-# Keld Onboarding
+# Run and contribute to Keld
 
-Human-facing orientation for an engineer joining this repo. Narrative, not rules — the
-binding rules live in [`AGENTS.md`](../../AGENTS.md) and the normative specs live in
-[`docs/architecture/`](../architecture/). Everything here is traceable to a file in this
-tree; where something is specified but not built, it says so and names the source.
+Keld is a pre-alpha desktop framework. This guide runs its current source-built
+application slice: a native webview window, a supervised Bun main process, and an
+authenticated kipc echo. The [product-status ledger](../engineering/product-status.md)
+distinguishes this implementation from the target architecture. There is no npm
+wrapper or packaged application release to install yet.
 
-This set avoids frozen LOC/test/HEAD counts. “Current” means the checked-out source plus
-fresh gate and target-host evidence, not the date this prose was last edited.
+## Prerequisites
 
-| # | Document | Read it when |
-|---|---|---|
-| 01 | [What Keld is, and where it actually stands](01-project-summary.md) | First. The thesis, the competitive position, the perf budgets, and an honest spec-vs-code ledger. |
-| 02 | [Architecture guide](02-architecture-guide.md) | Before touching any crate. Three-principal trust model, end-to-end request flow, all 11 crates with real status. |
-| 03 | [API and CLI surface](03-api-and-cli-surface.md) | When you need to *use* Keld. Every implemented `keld` verb with real output, the public Rust surface, and what the README promises that doesn't exist yet. |
-| 04 | [Wire formats and contracts](04-wire-formats-and-contracts.md) | When you touch kipc, config files, or anything on the wire. Byte-level frame layout, handshake, codec, error taxonomy. |
-| 05 | [Development guide](05-development-guide.md) | Day one setup, and every day after. Prerequisites, the `just ci` gate and core Rust subset, review gates, PR conventions, troubleshooting. |
-| 06 | [Documentation map](06-documentation-map.md) | When you're lost. Every document in the repo, what's normative vs exploratory, and a reading order. |
-| 07 | [Use Keld from an MCP client](07-mcp-server.md) | When registering Keld's shipped local, read-only, three-tool MCP server. |
-| 08 | [Optional agent memory for Keld contributors](08-optional-agent-memory.md) | Only when evaluating the external, opt-in KEL-67 contributor pilot. It is not a Keld product feature. |
+- Git and Rust installed through rustup. The checked-in
+  [rust-toolchain.toml](../../rust-toolchain.toml) selects the compiler and components;
+  Cargo uses the committed lockfile in the commands below.
+- Bun on `PATH`. [CI](../../.github/workflows/ci.yml) pins Bun 1.4.0; record `bun --version`
+  and `bun --revision` when reporting a run with another version. The scaffold has no
+  package dependencies to install.
+- A desktop session and platform build prerequisites:
 
-## The short version
+  | Platform | Prerequisites and qualification |
+  |---|---|
+  | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
+  | Windows | Rust's MSVC build tools and the WebView2 runtime; use PowerShell commands below |
+  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and the strict-launch prerequisites in the [Linux runtime contract](../../crates/keld-runtime/src/linux_strict.rs); X11 product runs and other distributions remain unverified |
 
-Keld replaces Electron's architecture while preserving a measured API contract: a
-prebuilt Rust host owns every OS resource; the developer's JS/TS primary process and
-any named compatibility roles run as supervised Bun principals whose destination strict
-profile has zero undeclared ambient OS authority; UI runs in system webviews; and the sides talk over a
-typed binary IPC plane (kipc) behind a default-deny capability manifest.
+The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
+A desktop session and the required Linux containment primitives are separate from
+compilation. If `dev` reports an unavailable security primitive, preserve its diagnostic
+and report the unsupported environment instead of disabling the check.
 
-**It is pre-alpha and the gap between the specs and the code is large.** The architecture
-documents describe the approved destination; the current tree contains CLI/MCP, guard,
-framed-echo and three platform hello slices, while the supervisor, brokers, packages,
-compatibility and distribution systems remain incomplete. Doc 01 records the gap by
-observable behavior — read it before treating a target contract as live.
+## Run the current demo
 
-## Day one
+Clone the public repository, or start in an existing checkout. Record the exact source
+and runtime versions with a result:
 
 ```bash
-cargo build --workspace
-cargo nextest run --workspace --profile ci
-just hello                                   # launches the current platform hello backend
-cargo run -p keld-cli -- doctor
+git clone https://github.com/gyldlab/keld.git
+cd keld
+git rev-parse HEAD
+bun --version
+bun --revision
+cargo build --locked -p keld-cli -p keld-host
 ```
 
-Then the verification gate that must pass before anything is "done" — see
-[05 §3](05-development-guide.md):
+**Build both crates.** `keld dev` requires `keld-host` next to the CLI executable;
+Linux also needs the sibling `keld-role-launcher` binary built by `keld-host`.
+Building only `keld-cli` is insufficient in a fresh checkout. If using a custom Cargo
+target directory, substitute that directory for `target` in the following paths.
+
+On macOS or qualified Linux, in the repository root:
 
 ```bash
-cargo fmt --all --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo nextest run --workspace --profile ci
+./target/debug/keld create hello-keld
+cd hello-keld
+../target/debug/keld doctor
+../target/debug/keld dev
 ```
+
+On Windows, in PowerShell at the repository root:
+
+```powershell
+.\target\debug\keld.exe create hello-keld
+Set-Location hello-keld
+..\target\debug\keld.exe doctor
+..\target\debug\keld.exe dev
+```
+
+The command creates a new `hello-keld` directory; it refuses to overwrite an existing
+one. Expected behavior:
+
+1. `create` reports the new project path; `doctor` reports successful environment and
+   project checks.
+2. `dev` opens a native window titled `hello-keld`. Its content says that IPC echo runs
+   in the Bun main process.
+3. Close the window to end the session (or use Ctrl-C). Captured Bun output is
+   forwarded at shutdown; do not wait for these lines before closing the window:
+
+
+   ```text
+   ipc-echo ok: message="keld" count=1
+   hello-keld: main process ready (IPC echo ok)
+   ```
+
+4. The host and its supervised process are cleaned up; rerunning `dev` starts a fresh
+   session.
+
+The generated app is the canonical current example. Its `index.html` is the renderer;
+`src/main.ts` contains the app-link client and echo. It is not an Electron migration
+example, and changing HTML requires restarting the current dev session.
+`just hello` is a separate diagnostic backend window; it does not exercise the Bun
+application session above.
+
+## Report a run or a problem
+
+Post to a relevant [public issue](https://github.com/gyldlab/keld/issues), or open one
+with your source SHA, OS/architecture/session, Bun version/revision, exact commands,
+expected versus actual behavior, and sanitized output. State separately whether the
+build, doctor, rendered window, IPC output, normal close, and relaunch succeeded.
+Never infer other-platform acceptance from a successful local run.
+
+For `KELD-CLI-*`, `KELD-CORE-*`, or `KELD-WV-*` failures, keep the full diagnostic and
+follow its suggested correction. The [error registry](../engineering/keld-error-codes.md)
+explains the contracts. A missing host usually means both crates were not built into
+the same output directory. A successful `doctor` alone is not a desktop acceptance run.
+
+## Contribute and verify
+
+Start with [CONTRIBUTING.md](../../CONTRIBUTING.md). Install `just`, `cargo-nextest`,
+and `cargo-deny` for the complete local gate; its Mermaid renderer also requires a
+running Docker-compatible engine. The exact gate inventory belongs to the
+[justfile](../../justfile):
+
+```bash
+just ci
+```
+
+The [development guide](05-development-guide.md) explains test commands and maintainer
+procedures. Report real results and unavailable checks when opening a draft PR.
+
+## Explore the contracts
+
+| Document | Purpose |
+|---|---|
+| [Project summary](01-project-summary.md) | Product purpose and source/target distinction |
+| [Architecture guide](02-architecture-guide.md) | Crate ownership, processes, and trust boundaries |
+| [API and CLI surface](03-api-and-cli-surface.md) | Implemented command shapes and errors |
+| [Wire formats and contracts](04-wire-formats-and-contracts.md) | kipc bytes, handshake, and codec contracts |
+| [Development guide](05-development-guide.md) | Verification and maintainer coordination |
+| [Documentation map](06-documentation-map.md) | Authoritative and exploratory documentation |
+| [MCP client setup](07-mcp-server.md) | The local read-only MCP server |
+| [Optional contributor memory](08-optional-agent-memory.md) | An optional external pilot, unrelated to running Keld |
 
 ## Agent-readable documentation
 
-Tracked authoritative docs are projected into [`llms.txt`](../../llms.txt) and
-[`llms-full.txt`](../../llms-full.txt). The compact index defines the exact corpus;
+Tracked authoritative docs are projected into [llms.txt](../../llms.txt) and
+[llms-full.txt](../../llms-full.txt). The compact index defines the exact corpus;
 exploratory research and local-only material are excluded. After changing an included
-source, run `just llms` and verify it with `just llms-check`.
+source, run `just llms`, `just llms-test`, and `just llms-check`.

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -11,21 +11,45 @@ wrapper or packaged application release to install yet.
 - Git and Rust installed through rustup. The checked-in
   [rust-toolchain.toml](../../rust-toolchain.toml) selects the compiler and components;
   Cargo uses the committed lockfile in the commands below.
-- Bun on `PATH`. [CI](../../.github/workflows/ci.yml) pins Bun 1.4.0; record `bun --version`
-  and `bun --revision` when reporting a run with another version. The scaffold has no
-  package dependencies to install.
+- Bun on `PATH`. **Use CI-pinned Bun 1.4.0 for `just ci` and the full workspace test
+  gate.** The [Linux strict fixture](../../crates/keld-runtime/tests/linux_strict_boundary.rs)
+  asserts that exact version. Record `bun --version` and `bun --revision` before a
+  run. The recorded Mac and Linux demo observations used Bun 1.4.2; those observations
+  do not satisfy the full gate's version prerequisite. The scaffold has no package
+  dependencies to install.
 - A desktop session and platform build prerequisites:
 
   | Platform | Prerequisites and qualification |
   |---|---|
   | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
-  | Windows | Rust's MSVC build tools and the WebView2 runtime; use PowerShell commands below |
-  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and the strict-launch prerequisites in the [Linux runtime contract](../../crates/keld-runtime/src/linux_strict.rs); X11 product runs and other distributions remain unverified |
+  | Windows | Rust's MSVC build tools and the WebView2 runtime; the current Windows acceptance lane has not built/run this candidate and awaits an existing endpoint-security prerequisite |
+  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; stock native Close currently fails, and X11 product runs and other distributions remain unverified |
 
 The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
 A desktop session and the required Linux containment primitives are separate from
 compilation. If `dev` reports an unavailable security primitive, preserve its diagnostic
 and report the unsupported environment instead of disabling the check.
+
+On Linux, the [strict-launch path validator](../../crates/keld-runtime/src/linux_strict.rs)
+also checks trusted ancestry: directories must be real, root- or current-user-owned
+paths, and another principal must not be able to replace descendant launch entries
+before an owner-private directory protects them. Group/world-writable ancestors can
+therefore reject a launch even after a successful build and `doctor`.
+
+Use an owner-controlled checkout. For a newly created checkout that you own, inspect
+its mode before launching; a private `0700` checkout is a suitable starting point:
+
+```bash
+# Linux, from your newly created checkout root
+stat -c '%U %a %n' .
+# Only if this is your own checkout and it needs narrowing:
+chmod 0700 .
+```
+
+The recorded Linux run rejected its new `0775` worktree; narrowing that directory
+alone to `0700` admitted launch. Other ancestor layouts still need the diagnostic's
+specific check. Do not recursively change permissions or alter shared/system
+ancestors to force acceptance.
 
 ## Run the current demo
 
@@ -46,7 +70,8 @@ Linux also needs the sibling `keld-role-launcher` binary built by `keld-host`.
 Building only `keld-cli` is insufficient in a fresh checkout. If using a custom Cargo
 target directory, substitute that directory for `target` in the following paths.
 
-On macOS or qualified Linux, in the repository root:
+On macOS or Ubuntu/Debian x86_64 Wayland, with the prerequisites above, in the
+repository root:
 
 ```bash
 ./target/debug/keld create hello-keld
@@ -55,7 +80,11 @@ cd hello-keld
 ../target/debug/keld dev
 ```
 
-On Windows, in PowerShell at the repository root:
+On Windows, these are the source-checked PowerShell commands. The current Windows
+acceptance lane has not built or run this candidate; its requalification awaits an
+existing endpoint-security prerequisite. An unrun acceptance test does not change
+the ledger's implemented scope. Start in
+the repository root:
 
 ```powershell
 .\target\debug\keld.exe create hello-keld
@@ -71,17 +100,29 @@ one. Expected behavior:
    project checks.
 2. `dev` opens a native window titled `hello-keld`. Its content says that IPC echo runs
    in the Bun main process.
-3. Close the window to end the session (or use Ctrl-C). Captured Bun output is
-   forwarded at shutdown; do not wait for these lines before closing the window:
-
+3. After inspecting the demo, Ctrl-C requests shutdown. Captured Bun output is
+   forwarded at shutdown; do not wait for these lines while the window is open:
 
    ```text
    ipc-echo ok: message="keld" count=1
    hello-keld: main process ready (IPC echo ok)
    ```
 
-4. The host and its supervised process are cleaned up; rerunning `dev` starts a fresh
-   session.
+4. Check that the host/Bun session and its nonce directory under `.keld/dev` are gone
+   before a new run. Ctrl-C cleanup was observed on the recorded Mac and Linux devices;
+   it is a separate acceptance case from native window Close.
+
+**Normal-close acceptance is currently incomplete.** On physical Ubuntu/Wayland,
+clicking the stock app's Close button removed the renderer but left CLI, host, Bun,
+and the launch stage alive beyond an independent 20-second observation. Subsequent
+Ctrl-C cleaned them up; it did not fix normal Close. The
+[lifecycle issue](https://github.com/gyldlab/keld/issues/176) tracks the separate
+stock-app correction and its required native-close regression. The Mac
+probe exercised SIGINT rather than the Close button, and Windows was not executed.
+
+The Linux relaunch/early-interrupt probe also retained `KELD-CORE-037` during startup,
+although cleanup succeeded. Treat that as unresolved evidence; a fresh frame or
+successful cleanup alone is not a fully ready, clean relaunch result.
 
 The generated app is the canonical current example. Its `index.html` is the renderer;
 `src/main.ts` contains the app-link client and echo. It is not an Electron migration
@@ -107,9 +148,12 @@ the same output directory. A successful `doctor` alone is not a desktop acceptan
 Start with [CONTRIBUTING.md](../../CONTRIBUTING.md). Install `just`, `cargo-nextest`,
 and `cargo-deny` for the complete local gate; its Mermaid renderer also requires a
 running Docker-compatible engine. The exact gate inventory belongs to the
-[justfile](../../justfile):
+[justfile](../../justfile). Put the CI-pinned Bun 1.4.0 binary on this shell's `PATH`
+without replacing another project's global runtime, then verify the selected version:
 
 ```bash
+bun --version   # must report 1.4.0 for the full gate
+bun --revision
 just ci
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2397,9 +2397,12 @@ hand-written, wire-exact v0 client embedded into the generated self-contained
 pipeline. `keld ipc-client echo` remains a separate CLI-side kipc client,
 useful standalone; the template no longer shells out to it.
 
-Distribution: `@keld/cli` npm package with per-platform binaries under
-`optionalDependencies` (esbuild pattern); `bunx keld` / `npx keld` work with zero
-global install. Host + runtime binaries fetched signed, verified, cached.
+Target distribution (not implemented): an `@keld/cli` npm package with per-platform
+binaries under `optionalDependencies` (esbuild pattern). `bunx keld` / `npx keld`
+are planned package-manager invocations; no npm wrapper is currently shipped.
+The target fetches signed, verified host and runtime binaries into a cache. Today,
+use the [source-build quick-start](../onboarding/README.md#run-the-current-demo);
+the [product-status ledger](../engineering/product-status.md#packages) owns package maturity.
 
 ## 3. keld-pack: packaging & cross-compilation
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19,21 +19,45 @@ wrapper or packaged application release to install yet.
 - Git and Rust installed through rustup. The checked-in
   [rust-toolchain.toml](../../rust-toolchain.toml) selects the compiler and components;
   Cargo uses the committed lockfile in the commands below.
-- Bun on `PATH`. [CI](../../.github/workflows/ci.yml) pins Bun 1.4.0; record `bun --version`
-  and `bun --revision` when reporting a run with another version. The scaffold has no
-  package dependencies to install.
+- Bun on `PATH`. **Use CI-pinned Bun 1.4.0 for `just ci` and the full workspace test
+  gate.** The [Linux strict fixture](../../crates/keld-runtime/tests/linux_strict_boundary.rs)
+  asserts that exact version. Record `bun --version` and `bun --revision` before a
+  run. The recorded Mac and Linux demo observations used Bun 1.4.2; those observations
+  do not satisfy the full gate's version prerequisite. The scaffold has no package
+  dependencies to install.
 - A desktop session and platform build prerequisites:
 
   | Platform | Prerequisites and qualification |
   |---|---|
   | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
-  | Windows | Rust's MSVC build tools and the WebView2 runtime; use PowerShell commands below |
-  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and the strict-launch prerequisites in the [Linux runtime contract](../../crates/keld-runtime/src/linux_strict.rs); X11 product runs and other distributions remain unverified |
+  | Windows | Rust's MSVC build tools and the WebView2 runtime; the current Windows acceptance lane has not built/run this candidate and awaits an existing endpoint-security prerequisite |
+  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; stock native Close currently fails, and X11 product runs and other distributions remain unverified |
 
 The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
 A desktop session and the required Linux containment primitives are separate from
 compilation. If `dev` reports an unavailable security primitive, preserve its diagnostic
 and report the unsupported environment instead of disabling the check.
+
+On Linux, the [strict-launch path validator](../../crates/keld-runtime/src/linux_strict.rs)
+also checks trusted ancestry: directories must be real, root- or current-user-owned
+paths, and another principal must not be able to replace descendant launch entries
+before an owner-private directory protects them. Group/world-writable ancestors can
+therefore reject a launch even after a successful build and `doctor`.
+
+Use an owner-controlled checkout. For a newly created checkout that you own, inspect
+its mode before launching; a private `0700` checkout is a suitable starting point:
+
+```bash
+# Linux, from your newly created checkout root
+stat -c '%U %a %n' .
+# Only if this is your own checkout and it needs narrowing:
+chmod 0700 .
+```
+
+The recorded Linux run rejected its new `0775` worktree; narrowing that directory
+alone to `0700` admitted launch. Other ancestor layouts still need the diagnostic's
+specific check. Do not recursively change permissions or alter shared/system
+ancestors to force acceptance.
 
 ## Run the current demo
 
@@ -54,7 +78,8 @@ Linux also needs the sibling `keld-role-launcher` binary built by `keld-host`.
 Building only `keld-cli` is insufficient in a fresh checkout. If using a custom Cargo
 target directory, substitute that directory for `target` in the following paths.
 
-On macOS or qualified Linux, in the repository root:
+On macOS or Ubuntu/Debian x86_64 Wayland, with the prerequisites above, in the
+repository root:
 
 ```bash
 ./target/debug/keld create hello-keld
@@ -63,7 +88,11 @@ cd hello-keld
 ../target/debug/keld dev
 ```
 
-On Windows, in PowerShell at the repository root:
+On Windows, these are the source-checked PowerShell commands. The current Windows
+acceptance lane has not built or run this candidate; its requalification awaits an
+existing endpoint-security prerequisite. An unrun acceptance test does not change
+the ledger's implemented scope. Start in
+the repository root:
 
 ```powershell
 .\target\debug\keld.exe create hello-keld
@@ -79,17 +108,29 @@ one. Expected behavior:
    project checks.
 2. `dev` opens a native window titled `hello-keld`. Its content says that IPC echo runs
    in the Bun main process.
-3. Close the window to end the session (or use Ctrl-C). Captured Bun output is
-   forwarded at shutdown; do not wait for these lines before closing the window:
-
+3. After inspecting the demo, Ctrl-C requests shutdown. Captured Bun output is
+   forwarded at shutdown; do not wait for these lines while the window is open:
 
    ```text
    ipc-echo ok: message="keld" count=1
    hello-keld: main process ready (IPC echo ok)
    ```
 
-4. The host and its supervised process are cleaned up; rerunning `dev` starts a fresh
-   session.
+4. Check that the host/Bun session and its nonce directory under `.keld/dev` are gone
+   before a new run. Ctrl-C cleanup was observed on the recorded Mac and Linux devices;
+   it is a separate acceptance case from native window Close.
+
+**Normal-close acceptance is currently incomplete.** On physical Ubuntu/Wayland,
+clicking the stock app's Close button removed the renderer but left CLI, host, Bun,
+and the launch stage alive beyond an independent 20-second observation. Subsequent
+Ctrl-C cleaned them up; it did not fix normal Close. The
+[lifecycle issue](https://github.com/gyldlab/keld/issues/176) tracks the separate
+stock-app correction and its required native-close regression. The Mac
+probe exercised SIGINT rather than the Close button, and Windows was not executed.
+
+The Linux relaunch/early-interrupt probe also retained `KELD-CORE-037` during startup,
+although cleanup succeeded. Treat that as unresolved evidence; a fresh frame or
+successful cleanup alone is not a fully ready, clean relaunch result.
 
 The generated app is the canonical current example. Its `index.html` is the renderer;
 `src/main.ts` contains the app-link client and echo. It is not an Electron migration
@@ -115,9 +156,12 @@ the same output directory. A successful `doctor` alone is not a desktop acceptan
 Start with [CONTRIBUTING.md](../../CONTRIBUTING.md). Install `just`, `cargo-nextest`,
 and `cargo-deny` for the complete local gate; its Mermaid renderer also requires a
 running Docker-compatible engine. The exact gate inventory belongs to the
-[justfile](../../justfile):
+[justfile](../../justfile). Put the CI-pinned Bun 1.4.0 binary on this shell's `PATH`
+without replacing another project's global runtime, then verify the selected version:
 
 ```bash
+bun --version   # must report 1.4.0 for the full gate
+bun --revision
 just ci
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6,65 +6,143 @@
 
 ## Source: `docs/onboarding/README.md`
 
-# Keld Onboarding
+# Run and contribute to Keld
 
-Human-facing orientation for an engineer joining this repo. Narrative, not rules — the
-binding rules live in [`AGENTS.md`](../../AGENTS.md) and the normative specs live in
-[`docs/architecture/`](../architecture/). Everything here is traceable to a file in this
-tree; where something is specified but not built, it says so and names the source.
+Keld is a pre-alpha desktop framework. This guide runs its current source-built
+application slice: a native webview window, a supervised Bun main process, and an
+authenticated kipc echo. The [product-status ledger](../engineering/product-status.md)
+distinguishes this implementation from the target architecture. There is no npm
+wrapper or packaged application release to install yet.
 
-This set avoids frozen LOC/test/HEAD counts. “Current” means the checked-out source plus
-fresh gate and target-host evidence, not the date this prose was last edited.
+## Prerequisites
 
-| # | Document | Read it when |
-|---|---|---|
-| 01 | [What Keld is, and where it actually stands](01-project-summary.md) | First. The thesis, the competitive position, the perf budgets, and an honest spec-vs-code ledger. |
-| 02 | [Architecture guide](02-architecture-guide.md) | Before touching any crate. Three-principal trust model, end-to-end request flow, all 11 crates with real status. |
-| 03 | [API and CLI surface](03-api-and-cli-surface.md) | When you need to *use* Keld. Every implemented `keld` verb with real output, the public Rust surface, and what the README promises that doesn't exist yet. |
-| 04 | [Wire formats and contracts](04-wire-formats-and-contracts.md) | When you touch kipc, config files, or anything on the wire. Byte-level frame layout, handshake, codec, error taxonomy. |
-| 05 | [Development guide](05-development-guide.md) | Day one setup, and every day after. Prerequisites, the `just ci` gate and core Rust subset, review gates, PR conventions, troubleshooting. |
-| 06 | [Documentation map](06-documentation-map.md) | When you're lost. Every document in the repo, what's normative vs exploratory, and a reading order. |
-| 07 | [Use Keld from an MCP client](07-mcp-server.md) | When registering Keld's shipped local, read-only, three-tool MCP server. |
-| 08 | [Optional agent memory for Keld contributors](08-optional-agent-memory.md) | Only when evaluating the external, opt-in KEL-67 contributor pilot. It is not a Keld product feature. |
+- Git and Rust installed through rustup. The checked-in
+  [rust-toolchain.toml](../../rust-toolchain.toml) selects the compiler and components;
+  Cargo uses the committed lockfile in the commands below.
+- Bun on `PATH`. [CI](../../.github/workflows/ci.yml) pins Bun 1.4.0; record `bun --version`
+  and `bun --revision` when reporting a run with another version. The scaffold has no
+  package dependencies to install.
+- A desktop session and platform build prerequisites:
 
-## The short version
+  | Platform | Prerequisites and qualification |
+  |---|---|
+  | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
+  | Windows | Rust's MSVC build tools and the WebView2 runtime; use PowerShell commands below |
+  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and the strict-launch prerequisites in the [Linux runtime contract](../../crates/keld-runtime/src/linux_strict.rs); X11 product runs and other distributions remain unverified |
 
-Keld replaces Electron's architecture while preserving a measured API contract: a
-prebuilt Rust host owns every OS resource; the developer's JS/TS primary process and
-any named compatibility roles run as supervised Bun principals whose destination strict
-profile has zero undeclared ambient OS authority; UI runs in system webviews; and the sides talk over a
-typed binary IPC plane (kipc) behind a default-deny capability manifest.
+The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
+A desktop session and the required Linux containment primitives are separate from
+compilation. If `dev` reports an unavailable security primitive, preserve its diagnostic
+and report the unsupported environment instead of disabling the check.
 
-**It is pre-alpha and the gap between the specs and the code is large.** The architecture
-documents describe the approved destination; the current tree contains CLI/MCP, guard,
-framed-echo and three platform hello slices, while the supervisor, brokers, packages,
-compatibility and distribution systems remain incomplete. Doc 01 records the gap by
-observable behavior — read it before treating a target contract as live.
+## Run the current demo
 
-## Day one
+Clone the public repository, or start in an existing checkout. Record the exact source
+and runtime versions with a result:
 
 ```bash
-cargo build --workspace
-cargo nextest run --workspace --profile ci
-just hello                                   # launches the current platform hello backend
-cargo run -p keld-cli -- doctor
+git clone https://github.com/gyldlab/keld.git
+cd keld
+git rev-parse HEAD
+bun --version
+bun --revision
+cargo build --locked -p keld-cli -p keld-host
 ```
 
-Then the verification gate that must pass before anything is "done" — see
-[05 §3](05-development-guide.md):
+**Build both crates.** `keld dev` requires `keld-host` next to the CLI executable;
+Linux also needs the sibling `keld-role-launcher` binary built by `keld-host`.
+Building only `keld-cli` is insufficient in a fresh checkout. If using a custom Cargo
+target directory, substitute that directory for `target` in the following paths.
+
+On macOS or qualified Linux, in the repository root:
 
 ```bash
-cargo fmt --all --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo nextest run --workspace --profile ci
+./target/debug/keld create hello-keld
+cd hello-keld
+../target/debug/keld doctor
+../target/debug/keld dev
 ```
+
+On Windows, in PowerShell at the repository root:
+
+```powershell
+.\target\debug\keld.exe create hello-keld
+Set-Location hello-keld
+..\target\debug\keld.exe doctor
+..\target\debug\keld.exe dev
+```
+
+The command creates a new `hello-keld` directory; it refuses to overwrite an existing
+one. Expected behavior:
+
+1. `create` reports the new project path; `doctor` reports successful environment and
+   project checks.
+2. `dev` opens a native window titled `hello-keld`. Its content says that IPC echo runs
+   in the Bun main process.
+3. Close the window to end the session (or use Ctrl-C). Captured Bun output is
+   forwarded at shutdown; do not wait for these lines before closing the window:
+
+
+   ```text
+   ipc-echo ok: message="keld" count=1
+   hello-keld: main process ready (IPC echo ok)
+   ```
+
+4. The host and its supervised process are cleaned up; rerunning `dev` starts a fresh
+   session.
+
+The generated app is the canonical current example. Its `index.html` is the renderer;
+`src/main.ts` contains the app-link client and echo. It is not an Electron migration
+example, and changing HTML requires restarting the current dev session.
+`just hello` is a separate diagnostic backend window; it does not exercise the Bun
+application session above.
+
+## Report a run or a problem
+
+Post to a relevant [public issue](https://github.com/gyldlab/keld/issues), or open one
+with your source SHA, OS/architecture/session, Bun version/revision, exact commands,
+expected versus actual behavior, and sanitized output. State separately whether the
+build, doctor, rendered window, IPC output, normal close, and relaunch succeeded.
+Never infer other-platform acceptance from a successful local run.
+
+For `KELD-CLI-*`, `KELD-CORE-*`, or `KELD-WV-*` failures, keep the full diagnostic and
+follow its suggested correction. The [error registry](../engineering/keld-error-codes.md)
+explains the contracts. A missing host usually means both crates were not built into
+the same output directory. A successful `doctor` alone is not a desktop acceptance run.
+
+## Contribute and verify
+
+Start with [CONTRIBUTING.md](../../CONTRIBUTING.md). Install `just`, `cargo-nextest`,
+and `cargo-deny` for the complete local gate; its Mermaid renderer also requires a
+running Docker-compatible engine. The exact gate inventory belongs to the
+[justfile](../../justfile):
+
+```bash
+just ci
+```
+
+The [development guide](05-development-guide.md) explains test commands and maintainer
+procedures. Report real results and unavailable checks when opening a draft PR.
+
+## Explore the contracts
+
+| Document | Purpose |
+|---|---|
+| [Project summary](01-project-summary.md) | Product purpose and source/target distinction |
+| [Architecture guide](02-architecture-guide.md) | Crate ownership, processes, and trust boundaries |
+| [API and CLI surface](03-api-and-cli-surface.md) | Implemented command shapes and errors |
+| [Wire formats and contracts](04-wire-formats-and-contracts.md) | kipc bytes, handshake, and codec contracts |
+| [Development guide](05-development-guide.md) | Verification and maintainer coordination |
+| [Documentation map](06-documentation-map.md) | Authoritative and exploratory documentation |
+| [MCP client setup](07-mcp-server.md) | The local read-only MCP server |
+| [Optional contributor memory](08-optional-agent-memory.md) | An optional external pilot, unrelated to running Keld |
 
 ## Agent-readable documentation
 
-Tracked authoritative docs are projected into [`llms.txt`](../../llms.txt) and
-[`llms-full.txt`](../../llms-full.txt). The compact index defines the exact corpus;
+Tracked authoritative docs are projected into [llms.txt](../../llms.txt) and
+[llms-full.txt](../../llms-full.txt). The compact index defines the exact corpus;
 exploratory research and local-only material are excluded. After changing an included
-source, run `just llms` and verify it with `just llms-check`.
+source, run `just llms`, `just llms-test`, and `just llms-check`.
 
 ---
 


### PR DESCRIPTION
## Summary

Make KELD understandable to a new contributor in public: rewrite the README around **What works today → Try it → Evidence → Roadmap → Target**, add an honest source quick-start and platform matrix, publish `ROADMAP.md` and `CHANGELOG.md`, and link reproducible benchmark and Electron compatibility evidence.

Every product claim remains qualified by the generated product-status ledger. Private research is optional and no longer required to understand or contribute to the project.

## Spec refs

No boundary change. KEL-178 public onboarding; the generated [product-status ledger](docs/engineering/product-status.md) remains the status authority. `docs/architecture/06-runtime-and-tooling.md` now calls npm distribution target-only rather than claiming a shipped wrapper.

## Review gates

Unsafe: none. Public API: none. Permission model: none. Dependency addition: none. Wire protocol: none. CodeRabbit CLI reviewed the rebased exact nine-file docs diff with zero findings.

## Tests

- `just llms-test llms-check product-status-test product-status-check`: passed.
- Mermaid blocks are unchanged; no diagram render gate is claimed.
- Fresh hosted CI is required on the rebased PR tip. The current KEL-196 macOS presentation investigation remains an independent runtime prerequisite and is represented accurately in the public limitations.

## Platforms

The quick-start names its current macOS, Windows, and Ubuntu/Debian limitations. It does not claim packaged installation, npm distribution, complete migration, or release support.

## Perf impact

No performance claim. Existing OS-qualified benchmark evidence and limitations are linked; historical hello measurements are not represented as complete migrated-app performance.
