### PR TITLE
ci(security): require code and dependency scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       # router falls back to all lanes when either commit is unavailable.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
@@ -84,6 +85,8 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -105,6 +108,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -245,6 +250,8 @@ jobs:
     if: needs.changes.outputs.gui == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -286,6 +293,8 @@ jobs:
     if: needs.changes.outputs.msrv == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -311,6 +320,8 @@ jobs:
     if: needs.changes.outputs.deny == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
         with:
           toolchain: 1.97.1
@@ -327,6 +338,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install gitleaks 8.30.1
         run: |
@@ -401,6 +413,74 @@ jobs:
         if: needs.changes.outputs.docs == 'true'
         run: tools/mermaid_render_check.sh
 
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            os: macos-latest
+          - language: javascript-typescript
+            os: ubuntu-latest
+          - language: actions
+            os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-08-05
+        if: matrix.language == 'rust'
+        with:
+          toolchain: 1.97.1
+      # Rust none mode still executes build.rs/proc macros. Keep this on hosted
+      # pull_request runners without secrets or repository write permission.
+      # macOS avoids another GTK apt lane; this is not all-OS containment proof.
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9, bundle 2.26.4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9, bundle 2.26.4
+        with:
+          category: /language:${{ matrix.language }}
+          wait-for-processing: true
+
+  dependency-review:
+    name: dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Reject incomplete dependency metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KELD_DEPENDENCY_REPOSITORY: ${{ github.repository }}
+          KELD_DEPENDENCY_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          KELD_DEPENDENCY_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          tools/dependency_review_metadata.sh test
+          tools/dependency_review_metadata.sh check "$KELD_DEPENDENCY_REPOSITORY" "$KELD_DEPENDENCY_BASE" "$KELD_DEPENDENCY_HEAD"
+      # GitHub's supported manifest graph is the oracle. bun.lock transitive
+      # coverage is not implied; see docs/engineering/security-ci.md.
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha || github.event.before }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fail-on-severity: low
+          fail-on-scopes: runtime, development, unknown
+          license-check: false # Cargo license policy remains owned by deny.toml.
+          comment-summary-in-pr: never
+          retry-on-snapshot-warnings: false
+          warn-only: false
+          show-openssf-scorecard: false
+
   required:
     name: CI required
     if: ${{ always() }}
@@ -414,6 +494,8 @@ jobs:
       - deny
       - secrets
       - hygiene
+      - codeql
+      - dependency-review
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -438,6 +520,8 @@ jobs:
           KELD_ROUTE_DENY: ${{ needs.changes.outputs.deny }}
           KELD_ROUTE_HYGIENE: ${{ needs.changes.outputs.hygiene }}
           KELD_ROUTE_DOCS: ${{ needs.changes.outputs.docs }}
+          KELD_RESULT_CODEQL: ${{ needs.codeql.result }}
+          KELD_RESULT_DEPENDENCY_REVIEW: ${{ needs['dependency-review'].result }}
         run: |
           tools/ci_required.sh test
           tools/ci_required.sh check \
@@ -456,4 +540,6 @@ jobs:
             "$KELD_ROUTE_MSRV" \
             "$KELD_ROUTE_DENY" \
             "$KELD_ROUTE_HYGIENE" \
-            "$KELD_ROUTE_DOCS"
+            "$KELD_ROUTE_DOCS" \
+            "$KELD_RESULT_CODEQL" \
+            "$KELD_RESULT_DEPENDENCY_REVIEW"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,13 +441,17 @@ jobs:
       # Rust none mode still executes build.rs/proc macros. Keep this on hosted
       # pull_request runners without secrets or repository write permission.
       # macOS avoids another GTK apt lane; this is not all-OS containment proof.
-      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9, bundle 2.26.4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9, bundle 2.26.4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
-      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9, bundle 2.26.4
+      - name: Analyze and upload CodeQL results
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9, bundle 2.26.4
         with:
           category: /language:${{ matrix.language }}
+          upload: always
+          skip-queries: false
           wait-for-processing: true
 
   dependency-review:
@@ -469,12 +473,14 @@ jobs:
           tools/dependency_review_metadata.sh check "$KELD_DEPENDENCY_REPOSITORY" "$KELD_DEPENDENCY_BASE" "$KELD_DEPENDENCY_HEAD"
       # GitHub's supported manifest graph is the oracle. bun.lock transitive
       # coverage is not implied; see docs/engineering/security-ci.md.
-      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+      - name: Review dependency vulnerabilities
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           base-ref: ${{ github.event.pull_request.base.sha || github.event.before }}
           head-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fail-on-severity: low
           fail-on-scopes: runtime, development, unknown
+          vulnerability-check: true
           license-check: false # Cargo license policy remains owned by deny.toml.
           comment-summary-in-pr: never
           retry-on-snapshot-warnings: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,9 @@ jobs:
         with:
           toolchain: 1.97.1
           components: rustfmt, clippy
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.4.0"
       - name: Atomic problem-solving protocol contract
         run: |
           mkdir -p target/atomic-protocol
@@ -388,6 +391,7 @@ jobs:
           mkdir -p target/ci-hygiene
           rustc --edition=2024 -D warnings --test tools/ci_hygiene.rs -o target/ci-hygiene/ci-hygiene-test
           target/ci-hygiene/ci-hygiene-test
+          bun --no-install test tools/ci_workflow_security.test.ts
       - name: Check this checkout
         if: needs.changes.outputs.hygiene == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
           components: rustfmt, clippy
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.2"
       - name: Atomic problem-solving protocol contract
         run: |
           mkdir -p target/atomic-protocol

--- a/docs/engineering/security-ci.md
+++ b/docs/engineering/security-ci.md
@@ -12,10 +12,10 @@ The CodeQL matrix must include Rust, JavaScript/TypeScript and Actions exactly
 once. Exclusions and additional matrix axes are refused so a successful job cannot
 silently represent fewer scan categories; row order does not affect admission.
 Block, flow and aliased steps are inspected as objects. Missing, malformed,
-multidocument, cyclic and unknown job/step structures are refused. Bun 1.4.0's
+multidocument, cyclic and unknown job/step structures are refused. Bun 1.4.2's
 parser uses the last value for duplicate keys; this check does not claim to reject
 duplicate-key syntax or prove full equivalence to GitHub's YAML implementation.
-The selected parser controls run in CI against pinned Bun 1.4.0. See
+The selected parser controls run in CI against pinned Bun 1.4.2. See
 [Bun's YAML documentation](https://bun.com/docs/runtime/yaml) for its conformance limits.
 
 | Check | Input and coverage | Limits |

--- a/docs/engineering/security-ci.md
+++ b/docs/engineering/security-ci.md
@@ -1,0 +1,53 @@
+# Security CI coverage
+
+The [CI workflow](../../.github/workflows/ci.yml) runs CodeQL and dependency review
+on every pull request and push to `main`. `CI required` rejects missing, skipped,
+failed or cancelled security jobs. A passing analysis is evidence that the tool ran;
+it is not a claim that Keld has no vulnerabilities.
+
+| Check | Input and coverage | Limits |
+| --- | --- | --- |
+| CodeQL Rust | Rust source, extracted on a GitHub-hosted macOS runner with the repository Rust pin | Static analysis; does not establish Windows/Linux containment or runtime correctness. `none` extraction still executes build scripts and procedural macros. |
+| CodeQL JavaScript/TypeScript | Repository JavaScript and TypeScript source on Ubuntu | No Bun/Node behavior or Electron conformance claim. |
+| CodeQL Actions | GitHub workflow source on Ubuntu | Does not audit organization settings, administrator bypasses or account access. |
+| Dependency review | GitHub's dependency comparison for exact base/head commits; new known vulnerabilities of every severity and scope block | Only manifests recognized by GitHub's dependency graph. No claim of complete `bun.lock` transitive coverage. Existing vulnerabilities and unknown advisories require separate review. |
+| cargo-deny | Cargo advisory, license and dependency policy in `deny.toml` | Cargo policy does not cover npm dependencies. |
+| gitleaks | Repository history | Secret detection does not establish revocation of an exposed credential. |
+
+Dependency review first checks every API response page for GitHub's incomplete
+snapshot warning. Unavailable APIs, malformed refs or incomplete snapshots fail the
+job; restore the dependency graph's base/head metadata and rerun the same head.
+The upstream dependency-review action otherwise reports snapshot warnings without
+failing. The metadata probe and action are separate reads of the same immutable refs;
+they do not prove that GitHub indexes every package ecosystem or dependency.
+
+The workflows use `pull_request` with ephemeral hosted runners, no user secrets,
+read-only repository contents and disabled checkout credential persistence. Only
+CodeQL receives `security-events: write` to upload results. This is not an assertion
+that Rust extraction is execution-free or that a writable PR workflow independently
+authenticates its own check; that trust boundary remains tracked in KEL-169.
+
+CodeQL's analysis/upload job result and its alert result are different checks.
+Maintainers must verify live scan results and configure GitHub's **Require code
+scanning results** rule for CodeQL and the chosen alert thresholds before calling
+alert-based merge blocking enabled. Repository settings are not established by this
+workflow file. Public work and outstanding acceptance are tracked in
+[issue #170](https://github.com/gyldlab/keld/issues/170).
+
+Pins verified on 2026-09-08 (Asia/Kolkata):
+
+- CodeQL action v4.37.9, commit `cdf488f595d80d6e07e03d4674febd5ab45fa938`,
+  released 2026-08-26; default CodeQL bundle 2.26.4.
+- Dependency review v5.0.0, commit `a1d282b36b6f3519aa1f3fc636f609c47dddb294`,
+  released 2026-05-08; requires a Node 24-capable Actions runner.
+
+Primary sources: [Rust extraction behavior](https://docs.github.com/en/code-security/reference/code-scanning/codeql/build-options-for-compiled-languages),
+[dependency graph formats](https://docs.github.com/en/code-security/reference/supply-chain-security/dependency-graph-supported-package-ecosystems),
+[dependency-review action](https://github.com/actions/dependency-review-action/tree/a1d282b36b6f3519aa1f3fc636f609c47dddb294),
+[CodeQL release](https://github.com/github/codeql-action/releases/tag/v4.37.9),
+and [code scanning merge protection](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/manage-your-configuration/set-merge-protection).
+
+Rollback is a reviewed revert of the security jobs and their required-result handoff
+together, plus reconciliation of any separately enabled GitHub code-scanning ruleset.
+A failing security check is investigated before any rollback; its evidence remains in
+the issue and Actions logs.

--- a/docs/engineering/security-ci.md
+++ b/docs/engineering/security-ci.md
@@ -8,6 +8,9 @@ it is not a claim that Keld has no vulnerabilities.
 `ci-hygiene check` runs the parsed workflow security check through Bun, the same
 runtime already required by `just ci`. `tools/ci_workflow_security.ts` owns checkout
 and scanner semantics; the Rust checker retains the other hygiene contracts.
+The CodeQL matrix must include Rust, JavaScript/TypeScript and Actions exactly
+once. Exclusions and additional matrix axes are refused so a successful job cannot
+silently represent fewer scan categories; row order does not affect admission.
 Block, flow and aliased steps are inspected as objects. Missing, malformed,
 multidocument, cyclic and unknown job/step structures are refused. Bun 1.4.0's
 parser uses the last value for duplicate keys; this check does not claim to reject

--- a/docs/engineering/security-ci.md
+++ b/docs/engineering/security-ci.md
@@ -5,6 +5,16 @@ on every pull request and push to `main`. `CI required` rejects missing, skipped
 failed or cancelled security jobs. A passing analysis is evidence that the tool ran;
 it is not a claim that Keld has no vulnerabilities.
 
+`ci-hygiene check` runs the parsed workflow security check through Bun, the same
+runtime already required by `just ci`. `tools/ci_workflow_security.ts` owns checkout
+and scanner semantics; the Rust checker retains the other hygiene contracts.
+Block, flow and aliased steps are inspected as objects. Missing, malformed,
+multidocument, cyclic and unknown job/step structures are refused. Bun 1.4.0's
+parser uses the last value for duplicate keys; this check does not claim to reject
+duplicate-key syntax or prove full equivalence to GitHub's YAML implementation.
+The selected parser controls run in CI against pinned Bun 1.4.0. See
+[Bun's YAML documentation](https://bun.com/docs/runtime/yaml) for its conformance limits.
+
 | Check | Input and coverage | Limits |
 | --- | --- | --- |
 | CodeQL Rust | Rust source, extracted on a GitHub-hosted macOS runner with the repository Rust pin | Static analysis; does not establish Windows/Linux containment or runtime correctness. `none` extraction still executes build scripts and procedural macros. |

--- a/justfile
+++ b/justfile
@@ -153,6 +153,7 @@ mermaid-render-check:
 
 # KEL-39: CODEOWNERS, templates, Action SHA pin, .github not gitignored.
 hygiene:
+    bun --no-install test tools/ci_workflow_security.test.ts
     mkdir -p target/ci-hygiene
     rustc --edition=2024 -D warnings --test tools/ci_hygiene.rs -o target/ci-hygiene/ci-hygiene-test
     target/ci-hygiene/ci-hygiene-test

--- a/tools/ci_changes_test.sh
+++ b/tools/ci_changes_test.sh
@@ -7,6 +7,7 @@ router="$repo_root/tools/ci_changes.sh"
 required="$repo_root/tools/ci_required.sh"
 
 "$required" test
+"$repo_root/tools/dependency_review_metadata.sh" test
 
 result_for_paths() {
     printf '%s\0' "$@" | "$router" classify

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -398,42 +398,66 @@ fn forbidden_workflow_control_key(text: &str) -> Option<String> {
 fn workflow_has_checkout_persist_credentials_false(text: &str) -> bool {
     let mut checkout_indent = None;
     let mut with_indent = None;
+    let mut with_seen = false;
+    let mut credentials_disabled = None;
+    let mut found_checkout = false;
 
     for line in text.lines() {
         let Some((indent, content)) = yaml_content(line) else {
             continue;
         };
-        if content.starts_with("- uses:") {
-            checkout_indent = content.contains("actions/checkout@").then_some(indent);
+        if checkout_indent.is_some_and(|checkout| indent <= checkout) {
+            if credentials_disabled != Some(true) {
+                return false;
+            }
+            checkout_indent = None;
             with_indent = None;
+        }
+        if uses_spec(content)
+            .is_some_and(|spec| uses_action_ref(spec).starts_with("actions/checkout@"))
+        {
+            if checkout_indent.is_some() {
+                return false;
+            }
+            // A named step places `uses` two columns below its `- name`.
+            checkout_indent = Some(if content.starts_with("- ") {
+                indent
+            } else {
+                indent.saturating_sub(2)
+            });
+            found_checkout = true;
+            credentials_disabled = None;
+            with_indent = None;
+            with_seen = false;
             continue;
         }
         let Some(checkout) = checkout_indent else {
             continue;
         };
-        if indent <= checkout {
-            checkout_indent = None;
+        if with_indent.is_some_and(|with| indent <= with) {
             with_indent = None;
-            continue;
         }
-        if content == "with:" {
+        let Some((key, value)) = yaml_mapping_key(content) else {
+            continue;
+        };
+        if indent == checkout + 2 && key == "with" {
+            if with_seen || !value.is_empty() {
+                return false;
+            }
+            with_seen = true;
             with_indent = Some(indent);
             continue;
         }
         if let Some(with) = with_indent {
-            if indent <= with {
-                with_indent = None;
-            } else if let Some(value) = content.strip_prefix("persist-credentials:") {
-                let value = value
-                    .trim()
-                    .trim_matches(|character| character == '\'' || character == '"');
-                if value == "false" {
-                    return true;
+            if indent == with + 2 && key == "persist-credentials" {
+                if credentials_disabled.is_some() {
+                    return false;
                 }
+                credentials_disabled = Some(value.trim_matches(['\'', '"']) == "false");
             }
         }
     }
-    false
+    found_checkout && (checkout_indent.is_none() || credentials_disabled == Some(true))
 }
 
 fn workflow_has_checkout_fetch_depth_zero(text: &str) -> bool {
@@ -1712,10 +1736,8 @@ fn action_uses_unpinned(workflow: &str) -> Vec<(usize, String)> {
 }
 
 fn uses_spec(trimmed: &str) -> Option<&str> {
-    let rest = trimmed
-        .strip_prefix("- uses:")
-        .or_else(|| trimmed.strip_prefix("uses:"))?;
-    Some(rest.trim())
+    let (key, value) = yaml_mapping_key(trimmed)?;
+    (key == "uses").then_some(value)
 }
 
 fn uses_action_ref(spec: &str) -> &str {
@@ -2023,7 +2045,7 @@ fn check_workflow(root: &Path) -> Result<(), String> {
     }
     if !workflow_has_checkout_persist_credentials_false(&text) {
         return Err(format!(
-            "CI-HYGIENE: `{WORKFLOW}` must set `persist-credentials: false` inside an `actions/checkout` `with:` mapping. An echoed or unrelated YAML value does not protect checkout credentials."
+            "CI-HYGIENE: `{WORKFLOW}` must set `persist-credentials: false` inside every `actions/checkout` `with:` mapping. One protected checkout or an echoed/unrelated YAML value does not protect the others."
         ));
     }
     check_change_router_job(&text)?;
@@ -2200,6 +2222,7 @@ mod tests {
             "      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
             "        with:",
             "          fetch-depth: 0",
+            "          persist-credentials: false",
             "      - name: Router contract tests",
             "        run: tools/ci_changes_test.sh",
             "      - name: Classify changed-path ownership",
@@ -2270,6 +2293,8 @@ mod tests {
             "    if: needs.changes.outputs.hygiene == 'true' || needs.changes.outputs.docs == 'true'",
             "    steps:",
             "      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
+            "        with:",
+            "          persist-credentials: false",
             "      - name: Atomic problem-solving protocol contract",
             "        run: |",
             "          mkdir -p target/atomic-protocol",
@@ -3255,8 +3280,8 @@ mod tests {
         let workflow = valid_workflow()
             .replacen("          fetch-depth: 0\n", "", 1)
             .replacen(
-                "          persist-credentials: false\n",
-                "          persist-credentials: false\n          fetch-depth: 0\n",
+                "  secrets:\n    steps:\n",
+                &format!("  secrets:\n    steps:\n{PINNED_CHECKOUT}        with:\n          persist-credentials: false\n          fetch-depth: 0\n"),
                 1,
             );
         temp.write(WORKFLOW, &workflow);
@@ -3634,6 +3659,45 @@ mod tests {
         temp.write(WORKFLOW, &workflow);
         let error = check(temp.path()).expect_err("comment must not satisfy checkout hardening");
         assert!(error.contains("persist-credentials: false"), "{error}");
+    }
+
+    #[test]
+    fn every_checkout_must_disable_credential_persistence() {
+        let secure =
+            format!("{PINNED_CHECKOUT}        with:\n          persist-credentials: false\n");
+        assert!(workflow_has_checkout_persist_credentials_false(&secure));
+        assert!(!workflow_has_checkout_persist_credentials_false("jobs:\n"));
+        for insecure in [
+            PINNED_CHECKOUT.to_owned(),
+            format!("{PINNED_CHECKOUT}        with:\n          persist-credentials: true\n"),
+            format!("{PINNED_CHECKOUT}        env:\n          persist-credentials: false\n"),
+            format!(
+                "{PINNED_CHECKOUT}        with:\n          persist-credentials: false\n          persist-credentials: true\n"
+            ),
+        ] {
+            for workflow in [format!("{secure}{insecure}"), format!("{insecure}{secure}")] {
+                assert!(
+                    !workflow_has_checkout_persist_credentials_false(&workflow),
+                    "one insecure checkout was admitted: {workflow}"
+                );
+            }
+        }
+        let named = secure
+            .replacen("- uses:", "- name: Checkout\n        'uses':", 1)
+            .replace(
+                "persist-credentials: false",
+                "'persist-credentials': 'false'",
+            );
+        assert!(workflow_has_checkout_persist_credentials_false(&format!(
+            "{secure}{named}"
+        )));
+        let named_insecure = named.replace(
+            "'persist-credentials': 'false'",
+            "'persist-credentials': 'true'",
+        );
+        assert!(!workflow_has_checkout_persist_credentials_false(&format!(
+            "{secure}{named_insecure}"
+        )));
     }
 
     #[test]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -1051,9 +1051,10 @@ fn check_bun_setup_steps(text: &str, job: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Asserts the `bun-test` lane's decidable properties only: that it exists, is
-/// gated on the router's own output, pins its Bun version, and does not open a
-/// second live apt lane. Each of those is a fact about the workflow text.
+/// Asserts the `bun-test` lane's decidable properties and the exact Bun pin for
+/// every current Bun consumer: `check`, `bun-test`, and `hygiene`. The `bun-test`
+/// lane must exist, be gated on the router's own output, and avoid a second live
+/// apt lane. Each of those is a fact about the workflow text.
 ///
 /// What this deliberately does not assert — that the lane really runs the
 /// suites the router selected — is tracked in KEL-115, because it is a
@@ -1069,7 +1070,7 @@ fn check_bun_test_job(text: &str) -> Result<(), String> {
             "CI-HYGIENE: `{WORKFLOW}` `bun-test` must be gated on `if: needs.changes.outputs.ts == 'true'`. The router owns which diffs reach this lane; an ungated job wastes runners and a gate on another output silently never runs (contexts: needs, github, vars, inputs only — never `matrix`)."
         ));
     }
-    for job in ["bun-test", "check"] {
+    for job in ["bun-test", "check", "hygiene"] {
         check_bun_setup_steps(text, job)?;
     }
     // Deliberately NOT checked here: that the lane actually executes the suite
@@ -2090,6 +2091,9 @@ mod tests {
             "      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
             "        with:",
             "          persist-credentials: false",
+            "      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0",
+            "        with:",
+            "          bun-version: \"1.4.2\"",
             "      - name: Atomic problem-solving protocol contract",
             "        run: |",
             "          mkdir -p target/atomic-protocol",
@@ -2322,7 +2326,7 @@ mod tests {
             WORKFLOW,
             &valid_workflow().replacen(
                 "      - name: Atomic problem-solving protocol contract\n",
-                "",
+                "      - name: Removed atomic step\n",
                 1,
             ),
         );
@@ -3101,8 +3105,8 @@ mod tests {
     }
 
     #[test]
-    fn every_bun_setup_in_both_jobs_requires_its_own_pin() {
-        for job in ["check", "bun-test"] {
+    fn every_bun_setup_in_each_bun_consumer_requires_its_own_pin() {
+        for job in ["check", "bun-test", "hygiene"] {
             let workflow = valid_workflow();
             let block = workflow_job_block(&workflow, job).expect("fixture job");
             for extra in [
@@ -3126,8 +3130,8 @@ mod tests {
     }
 
     #[test]
-    fn both_bun_jobs_require_a_setup_action() {
-        for job in ["check", "bun-test"] {
+    fn every_bun_consumer_requires_a_setup_action() {
+        for job in ["check", "bun-test", "hygiene"] {
             let workflow = valid_workflow();
             let block = workflow_job_block(&workflow, job).expect("fixture job");
             let changed = block.replace("oven-sh/setup-bun@", "some-other/action@");

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -641,43 +641,43 @@ fn workflow_job_sequence_values(block: &str, key: &str) -> Option<Vec<String>> {
     sequence_indent.map(|_| values)
 }
 
-fn workflow_named_step_env_value(text: &str, step_name: &str, key: &str) -> Option<String> {
-    let expected_name = format!("- name: {step_name}");
-    let expected_key = format!("{key}:");
-    let mut step_indent = None;
-    let mut env_indent = None;
-
-    for line in text.lines() {
+fn workflow_named_step_mapping(
+    text: &str,
+    step_name: &str,
+    mapping: &str,
+) -> Option<Vec<(String, String)>> {
+    let block = workflow_direct_named_step_block(text, step_name)?;
+    let mut found = false;
+    let mut entries = Vec::new();
+    for line in block.lines().skip(1) {
         let Some((indent, content)) = yaml_content(line) else {
             continue;
         };
-        if step_indent.is_none() {
-            if content == expected_name {
-                step_indent = Some(indent);
+        if !found {
+            if indent == 8 {
+                let (key, value) = yaml_mapping_key(content)?;
+                if key == mapping {
+                    if !value.is_empty() {
+                        return None;
+                    }
+                    found = true;
+                }
             }
             continue;
         }
-        let step = step_indent?;
-        if indent <= step {
+        if indent <= 8 {
             break;
         }
-        if env_indent.is_none() {
-            if content == "env:" {
-                env_indent = Some(indent);
-            }
-            continue;
-        }
-        let env = env_indent?;
-        if indent <= env {
+        if indent != 10 {
             return None;
         }
-        if indent == env + 2 {
-            if let Some(value) = content.strip_prefix(&expected_key) {
-                return Some(value.trim().to_owned());
-            }
+        let (key, value) = yaml_mapping_key(content)?;
+        if entries.iter().any(|(existing, _)| existing == &key) {
+            return None;
         }
+        entries.push((key, value.trim_matches(['\'', '"']).to_owned()));
     }
-    None
+    found.then_some(entries)
 }
 
 fn workflow_named_step_shell_commands(text: &str, step_name: &str) -> Option<Vec<String>> {
@@ -1260,9 +1260,13 @@ fn check_required_job(text: &str) -> Result<(), String> {
             "${{ needs['dependency-review'].result }}",
         ),
     ] {
-        if workflow_named_step_env_value(&block, "Verify required CI results", key).as_deref()
-            != Some(expression)
-        {
+        if !workflow_named_step_mapping(&block, "Verify required CI results", "env").is_some_and(
+            |entries| {
+                entries
+                    .iter()
+                    .any(|(name, value)| name == key && value == expression)
+            },
+        ) {
             return Err(format!(
                 "CI-HYGIENE: `{WORKFLOW}` `required` must bind `{key}: {expression}` in the evaluator step's `env` mapping. Do not let a missing or spoofed handoff erase the merge gate."
             ));
@@ -1292,6 +1296,143 @@ fn check_required_job(text: &str) -> Result<(), String> {
         return Err(format!(
             "CI-HYGIENE: `{WORKFLOW}` `required` checkout must set `persist-credentials: false`; the merge-decision job needs repository bytes, not push authority."
         ));
+    }
+    Ok(())
+}
+
+fn check_security_action_step(
+    job: &str,
+    step: &str,
+    action: &str,
+    inputs: &[(&str, &str)],
+) -> Result<(), String> {
+    if workflow_direct_named_step_count(job, step) != 1
+        || workflow_named_step_direct_keys(job, step).is_none_or(|keys| keys != ["uses", "with"])
+    {
+        return Err(format!(
+            "CI-HYGIENE: `{step}` must occur once as an unconditional action with only `uses` and `with`. A skipped scanner can leave its job successful."
+        ));
+    }
+    if !workflow_named_step_direct_value(job, step, "uses").is_some_and(|value| {
+        is_pinned_sha(&value)
+            && value
+                .trim_matches(['\'', '"'])
+                .starts_with(&format!("{action}@"))
+    }) {
+        return Err(format!(
+            "CI-HYGIENE: `{step}` must execute `{action}`; restore the required security action, not a successful substitute."
+        ));
+    }
+    let actual = workflow_named_step_mapping(job, step, "with").ok_or_else(|| {
+        format!(
+            "CI-HYGIENE: `{step}` needs one explicit action-input mapping without duplicate keys."
+        )
+    })?;
+    if actual.len() != inputs.len()
+        || inputs.iter().any(|(key, expected)| {
+            !actual.iter().any(|(name, value)| {
+                name == key
+                    && if *key == "fail-on-scopes" {
+                        let mut scopes: Vec<_> = value.split(',').map(str::trim).collect();
+                        scopes.sort_unstable();
+                        scopes == ["development", "runtime", "unknown"]
+                    } else {
+                        value == expected
+                    }
+            })
+        })
+    {
+        return Err(format!(
+            "CI-HYGIENE: `{step}` has changed security inputs. Restore extraction/upload or blocking vulnerability review; review changes to filters, bypasses and refs explicitly."
+        ));
+    }
+    Ok(())
+}
+
+fn check_security_jobs(text: &str) -> Result<(), String> {
+    let codeql = workflow_job_block(text, "codeql")
+        .ok_or_else(|| format!("CI-HYGIENE: `{WORKFLOW}` needs the CodeQL job."))?;
+    check_security_action_step(
+        &codeql,
+        "Initialize CodeQL",
+        "github/codeql-action/init",
+        &[
+            ("languages", "${{ matrix.language }}"),
+            ("build-mode", "none"),
+        ],
+    )?;
+    check_security_action_step(
+        &codeql,
+        "Analyze and upload CodeQL results",
+        "github/codeql-action/analyze",
+        &[
+            ("category", "/language:${{ matrix.language }}"),
+            ("upload", "always"),
+            ("skip-queries", "false"),
+            ("wait-for-processing", "true"),
+        ],
+    )?;
+    let dependencies = workflow_job_block(text, "dependency-review")
+        .ok_or_else(|| format!("CI-HYGIENE: `{WORKFLOW}` needs the dependency-review job."))?;
+    check_security_action_step(
+        &dependencies,
+        "Review dependency vulnerabilities",
+        "actions/dependency-review-action",
+        &[
+            (
+                "base-ref",
+                "${{ github.event.pull_request.base.sha || github.event.before }}",
+            ),
+            (
+                "head-ref",
+                "${{ github.event.pull_request.head.sha || github.sha }}",
+            ),
+            ("fail-on-severity", "low"),
+            ("fail-on-scopes", "runtime, development, unknown"),
+            ("vulnerability-check", "true"),
+            ("license-check", "false"),
+            ("comment-summary-in-pr", "never"),
+            ("retry-on-snapshot-warnings", "false"),
+            ("warn-only", "false"),
+            ("show-openssf-scorecard", "false"),
+        ],
+    )?;
+    let metadata = "Reject incomplete dependency metadata";
+    if workflow_direct_named_step_count(&dependencies, metadata) != 1
+        || workflow_named_step_direct_keys(&dependencies, metadata).is_none_or(|keys| keys != ["env", "run"])
+        || workflow_named_step_shell_commands(&dependencies, metadata).as_deref() != Some([
+            "tools/dependency_review_metadata.sh test".to_owned(),
+            "tools/dependency_review_metadata.sh check \"$KELD_DEPENDENCY_REPOSITORY\" \"$KELD_DEPENDENCY_BASE\" \"$KELD_DEPENDENCY_HEAD\"".to_owned(),
+        ].as_slice())
+    {
+        return Err(format!(
+            "CI-HYGIENE: `{metadata}` must execute its self-test and exact metadata check unconditionally, without wrappers or reassignment."
+        ));
+    }
+    let env = workflow_named_step_mapping(&dependencies, metadata, "env").ok_or_else(|| {
+        format!("CI-HYGIENE: `{metadata}` needs its explicit event-SHA environment mapping.")
+    })?;
+    for (key, value) in [
+        ("GH_TOKEN", "${{ github.token }}"),
+        ("KELD_DEPENDENCY_REPOSITORY", "${{ github.repository }}"),
+        (
+            "KELD_DEPENDENCY_BASE",
+            "${{ github.event.pull_request.base.sha || github.event.before }}",
+        ),
+        (
+            "KELD_DEPENDENCY_HEAD",
+            "${{ github.event.pull_request.head.sha || github.sha }}",
+        ),
+    ] {
+        if env.len() != 4
+            || !env
+                .iter()
+                .any(|(name, actual)| name == key && actual == value)
+        {
+            return Err(format!(
+                "CI-HYGIENE: `{metadata}` must bind `{key}` to `{value}`; restore the authenticated event handoff."
+            ));
+        }
     }
     Ok(())
 }
@@ -1893,6 +2034,7 @@ fn check_workflow(root: &Path) -> Result<(), String> {
     check_bun_test_job(&text)?;
     check_linux_media_guard_step(&text)?;
     check_required_job(&text)?;
+    check_security_jobs(&text)?;
     check_product_status_step(&text)?;
     check_product_status_windows_step(&text)?;
     check_atomic_protocol_step(&text)?;
@@ -2151,6 +2293,44 @@ mod tests {
             "      - run: rustc --edition=2024 --test tools/mermaid_docs.rs",
             "      - run: mermaid-docs check .",
             "      - run: tools/mermaid_render_check.sh # sha256:29077c6bd02f14bdfdd5fee552d9c00fe68d4fab3cd84952d21e2d1faf2fadaf",
+            "  codeql:",
+            "    steps:",
+            "      - name: Initialize CodeQL",
+            "        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938",
+            "        with:",
+            "          languages: ${{ matrix.language }}",
+            "          build-mode: none",
+            "      - name: Analyze and upload CodeQL results",
+            "        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938",
+            "        with:",
+            "          category: /language:${{ matrix.language }}",
+            "          upload: always",
+            "          skip-queries: false",
+            "          wait-for-processing: true",
+            "  dependency-review:",
+            "    steps:",
+            "      - name: Reject incomplete dependency metadata",
+            "        env:",
+            "          GH_TOKEN: ${{ github.token }}",
+            "          KELD_DEPENDENCY_REPOSITORY: ${{ github.repository }}",
+            "          KELD_DEPENDENCY_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}",
+            "          KELD_DEPENDENCY_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}",
+            "        run: |",
+            "          tools/dependency_review_metadata.sh test",
+            "          tools/dependency_review_metadata.sh check \"$KELD_DEPENDENCY_REPOSITORY\" \"$KELD_DEPENDENCY_BASE\" \"$KELD_DEPENDENCY_HEAD\"",
+            "      - name: Review dependency vulnerabilities",
+            "        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294",
+            "        with:",
+            "          base-ref: ${{ github.event.pull_request.base.sha || github.event.before }}",
+            "          head-ref: ${{ github.event.pull_request.head.sha || github.sha }}",
+            "          fail-on-severity: low",
+            "          fail-on-scopes: runtime, development, unknown",
+            "          vulnerability-check: true",
+            "          license-check: false",
+            "          comment-summary-in-pr: never",
+            "          retry-on-snapshot-warnings: false",
+            "          warn-only: false",
+            "          show-openssf-scorecard: false",
             "  required:",
             "    name: CI required",
             "    if: ${{ always() }}",
@@ -2552,6 +2732,154 @@ mod tests {
             let error = check_required_job(&workflow).expect_err("missing security job must fail");
             assert!(error.contains(job), "{error}");
         }
+    }
+
+    #[test]
+    fn required_security_actions_cannot_be_disabled_or_warn_only() {
+        let baseline = include_str!("../.github/workflows/ci.yml");
+        let temp = complete_fixture();
+        temp.write(WORKFLOW, baseline);
+        check(temp.path()).expect("unchanged workflow must pass before security mutations");
+        for action in [
+            "github/codeql-action/analyze@",
+            "actions/dependency-review-action@",
+        ] {
+            let action_start = baseline.find(action).expect("security action exists");
+            let line_end = action_start
+                + baseline[action_start..]
+                    .find('\n')
+                    .expect("action line ends");
+            let mut disabled = baseline.to_owned();
+            disabled.insert_str(line_end, "\n        if: false");
+            let temp = complete_fixture();
+            temp.write(WORKFLOW, &disabled);
+            let error =
+                check(temp.path()).expect_err("a skipped security action must fail hygiene");
+            assert!(error.contains("unconditional action"), "{action}: {error}");
+        }
+        let temp = complete_fixture();
+        temp.write(
+            WORKFLOW,
+            &baseline.replacen("warn-only: false", "warn-only: true", 1),
+        );
+        let error =
+            check(temp.path()).expect_err("nonblocking vulnerability review must fail hygiene");
+        assert!(
+            error.contains("Review dependency vulnerabilities")
+                && error.contains("changed security inputs"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn security_action_effects_and_metadata_cannot_be_replaced_with_success() {
+        let baseline = valid_workflow();
+        check_security_jobs(&baseline).expect("unchanged security actions must pass");
+        for (label, needle, replacement) in [
+            ("upload disabled", "upload: always", "upload: never"),
+            (
+                "queries skipped",
+                "skip-queries: false",
+                "skip-queries: true",
+            ),
+            (
+                "processing not awaited",
+                "wait-for-processing: true",
+                "wait-for-processing: false",
+            ),
+            (
+                "vulnerabilities unchecked",
+                "vulnerability-check: true",
+                "vulnerability-check: false",
+            ),
+            (
+                "severity narrowed",
+                "fail-on-severity: low",
+                "fail-on-severity: critical",
+            ),
+            (
+                "development scope omitted",
+                "fail-on-scopes: runtime, development, unknown",
+                "fail-on-scopes: runtime",
+            ),
+            (
+                "advisory bypass",
+                "warn-only: false",
+                "warn-only: false\n          allow-ghsas: GHSA-xxxx-yyyy-zzzz",
+            ),
+            (
+                "duplicate input",
+                "warn-only: false",
+                "warn-only: false\n          warn-only: true",
+            ),
+            (
+                "wrong action",
+                "github/codeql-action/analyze@",
+                "github/codeql-action/init@",
+            ),
+            (
+                "floating action under quoted key",
+                "uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938",
+                "'uses': github/codeql-action/analyze@main",
+            ),
+            (
+                "metadata step skipped",
+                "      - name: Reject incomplete dependency metadata\n",
+                "      - name: Reject incomplete dependency metadata\n        if: false\n",
+            ),
+            (
+                "metadata check echoed",
+                "          tools/dependency_review_metadata.sh check ",
+                "          echo tools/dependency_review_metadata.sh check ",
+            ),
+            (
+                "metadata failure swallowed",
+                "\"$KELD_DEPENDENCY_HEAD\"\n",
+                "\"$KELD_DEPENDENCY_HEAD\" || true\n",
+            ),
+            (
+                "metadata ref changed",
+                "KELD_DEPENDENCY_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}",
+                "KELD_DEPENDENCY_BASE: ${{ github.sha }}",
+            ),
+        ] {
+            assert!(baseline.contains(needle), "missing mutation input: {label}");
+            let mutated = baseline.replacen(needle, replacement, 1);
+            check_security_jobs(&mutated).expect_err(label);
+        }
+        for step in [
+            "Initialize CodeQL",
+            "Analyze and upload CodeQL results",
+            "Review dependency vulnerabilities",
+        ] {
+            let block = workflow_direct_named_step_block(&baseline, step).expect("step exists");
+            check_security_jobs(&baseline.replacen(&block, "", 1)).expect_err("removed action");
+            check_security_jobs(&baseline.replacen(&block, &format!("{block}{block}"), 1))
+                .expect_err("duplicate action");
+            let conditional = baseline.replacen(
+                &format!("      - name: {step}\n"),
+                &format!("      - name: {step}\n        'if': false\n"),
+                1,
+            );
+            check_security_jobs(&conditional).expect_err("quoted action condition");
+        }
+    }
+
+    #[test]
+    fn security_inputs_accept_equivalent_scalar_quotes_and_scope_order() {
+        let workflow = valid_workflow()
+            .replacen("warn-only: false", "'warn-only': 'false'", 1)
+            .replacen(
+                "fail-on-scopes: runtime, development, unknown",
+                "fail-on-scopes: unknown,runtime,development",
+                1,
+            )
+            .replacen(
+                "          skip-queries: false\n          wait-for-processing: true",
+                "          wait-for-processing: true\n          skip-queries: false",
+                1,
+            );
+        check_security_jobs(&workflow).expect("equivalent mappings preserve security effects");
     }
 
     #[test]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -395,71 +395,6 @@ fn forbidden_workflow_control_key(text: &str) -> Option<String> {
     None
 }
 
-fn workflow_has_checkout_persist_credentials_false(text: &str) -> bool {
-    let mut checkout_indent = None;
-    let mut with_indent = None;
-    let mut with_seen = false;
-    let mut credentials_disabled = None;
-    let mut found_checkout = false;
-
-    for line in text.lines() {
-        let Some((indent, content)) = yaml_content(line) else {
-            continue;
-        };
-        if checkout_indent.is_some_and(|checkout| indent <= checkout) {
-            if credentials_disabled != Some(true) {
-                return false;
-            }
-            checkout_indent = None;
-            with_indent = None;
-        }
-        if uses_spec(content)
-            .is_some_and(|spec| uses_action_ref(spec).starts_with("actions/checkout@"))
-        {
-            if checkout_indent.is_some() {
-                return false;
-            }
-            // A named step places `uses` two columns below its `- name`.
-            checkout_indent = Some(if content.starts_with("- ") {
-                indent
-            } else {
-                indent.saturating_sub(2)
-            });
-            found_checkout = true;
-            credentials_disabled = None;
-            with_indent = None;
-            with_seen = false;
-            continue;
-        }
-        let Some(checkout) = checkout_indent else {
-            continue;
-        };
-        if with_indent.is_some_and(|with| indent <= with) {
-            with_indent = None;
-        }
-        let Some((key, value)) = yaml_mapping_key(content) else {
-            continue;
-        };
-        if indent == checkout + 2 && key == "with" {
-            if with_seen || !value.is_empty() {
-                return false;
-            }
-            with_seen = true;
-            with_indent = Some(indent);
-            continue;
-        }
-        if let Some(with) = with_indent {
-            if indent == with + 2 && key == "persist-credentials" {
-                if credentials_disabled.is_some() {
-                    return false;
-                }
-                credentials_disabled = Some(value.trim_matches(['\'', '"']) == "false");
-            }
-        }
-    }
-    found_checkout && (checkout_indent.is_none() || credentials_disabled == Some(true))
-}
-
 fn workflow_has_checkout_fetch_depth_zero(text: &str) -> bool {
     let mut checkout_indent = None;
     let mut with_indent = None;
@@ -1316,148 +1251,7 @@ fn check_required_job(text: &str) -> Result<(), String> {
             "CI-HYGIENE: `{WORKFLOW}` `required` evaluator run block must contain only its self-test and the exact ordered 18-argument check, without control flow, reassignment, wrappers, or exit-status suppression."
         ));
     }
-    if !workflow_has_checkout_persist_credentials_false(&block) {
-        return Err(format!(
-            "CI-HYGIENE: `{WORKFLOW}` `required` checkout must set `persist-credentials: false`; the merge-decision job needs repository bytes, not push authority."
-        ));
-    }
-    Ok(())
-}
 
-fn check_security_action_step(
-    job: &str,
-    step: &str,
-    action: &str,
-    inputs: &[(&str, &str)],
-) -> Result<(), String> {
-    if workflow_direct_named_step_count(job, step) != 1
-        || workflow_named_step_direct_keys(job, step).is_none_or(|keys| keys != ["uses", "with"])
-    {
-        return Err(format!(
-            "CI-HYGIENE: `{step}` must occur once as an unconditional action with only `uses` and `with`. A skipped scanner can leave its job successful."
-        ));
-    }
-    if !workflow_named_step_direct_value(job, step, "uses").is_some_and(|value| {
-        is_pinned_sha(&value)
-            && value
-                .trim_matches(['\'', '"'])
-                .starts_with(&format!("{action}@"))
-    }) {
-        return Err(format!(
-            "CI-HYGIENE: `{step}` must execute `{action}`; restore the required security action, not a successful substitute."
-        ));
-    }
-    let actual = workflow_named_step_mapping(job, step, "with").ok_or_else(|| {
-        format!(
-            "CI-HYGIENE: `{step}` needs one explicit action-input mapping without duplicate keys."
-        )
-    })?;
-    if actual.len() != inputs.len()
-        || inputs.iter().any(|(key, expected)| {
-            !actual.iter().any(|(name, value)| {
-                name == key
-                    && if *key == "fail-on-scopes" {
-                        let mut scopes: Vec<_> = value.split(',').map(str::trim).collect();
-                        scopes.sort_unstable();
-                        scopes == ["development", "runtime", "unknown"]
-                    } else {
-                        value == expected
-                    }
-            })
-        })
-    {
-        return Err(format!(
-            "CI-HYGIENE: `{step}` has changed security inputs. Restore extraction/upload or blocking vulnerability review; review changes to filters, bypasses and refs explicitly."
-        ));
-    }
-    Ok(())
-}
-
-fn check_security_jobs(text: &str) -> Result<(), String> {
-    let codeql = workflow_job_block(text, "codeql")
-        .ok_or_else(|| format!("CI-HYGIENE: `{WORKFLOW}` needs the CodeQL job."))?;
-    check_security_action_step(
-        &codeql,
-        "Initialize CodeQL",
-        "github/codeql-action/init",
-        &[
-            ("languages", "${{ matrix.language }}"),
-            ("build-mode", "none"),
-        ],
-    )?;
-    check_security_action_step(
-        &codeql,
-        "Analyze and upload CodeQL results",
-        "github/codeql-action/analyze",
-        &[
-            ("category", "/language:${{ matrix.language }}"),
-            ("upload", "always"),
-            ("skip-queries", "false"),
-            ("wait-for-processing", "true"),
-        ],
-    )?;
-    let dependencies = workflow_job_block(text, "dependency-review")
-        .ok_or_else(|| format!("CI-HYGIENE: `{WORKFLOW}` needs the dependency-review job."))?;
-    check_security_action_step(
-        &dependencies,
-        "Review dependency vulnerabilities",
-        "actions/dependency-review-action",
-        &[
-            (
-                "base-ref",
-                "${{ github.event.pull_request.base.sha || github.event.before }}",
-            ),
-            (
-                "head-ref",
-                "${{ github.event.pull_request.head.sha || github.sha }}",
-            ),
-            ("fail-on-severity", "low"),
-            ("fail-on-scopes", "runtime, development, unknown"),
-            ("vulnerability-check", "true"),
-            ("license-check", "false"),
-            ("comment-summary-in-pr", "never"),
-            ("retry-on-snapshot-warnings", "false"),
-            ("warn-only", "false"),
-            ("show-openssf-scorecard", "false"),
-        ],
-    )?;
-    let metadata = "Reject incomplete dependency metadata";
-    if workflow_direct_named_step_count(&dependencies, metadata) != 1
-        || workflow_named_step_direct_keys(&dependencies, metadata).is_none_or(|keys| keys != ["env", "run"])
-        || workflow_named_step_shell_commands(&dependencies, metadata).as_deref() != Some([
-            "tools/dependency_review_metadata.sh test".to_owned(),
-            "tools/dependency_review_metadata.sh check \"$KELD_DEPENDENCY_REPOSITORY\" \"$KELD_DEPENDENCY_BASE\" \"$KELD_DEPENDENCY_HEAD\"".to_owned(),
-        ].as_slice())
-    {
-        return Err(format!(
-            "CI-HYGIENE: `{metadata}` must execute its self-test and exact metadata check unconditionally, without wrappers or reassignment."
-        ));
-    }
-    let env = workflow_named_step_mapping(&dependencies, metadata, "env").ok_or_else(|| {
-        format!("CI-HYGIENE: `{metadata}` needs its explicit event-SHA environment mapping.")
-    })?;
-    for (key, value) in [
-        ("GH_TOKEN", "${{ github.token }}"),
-        ("KELD_DEPENDENCY_REPOSITORY", "${{ github.repository }}"),
-        (
-            "KELD_DEPENDENCY_BASE",
-            "${{ github.event.pull_request.base.sha || github.event.before }}",
-        ),
-        (
-            "KELD_DEPENDENCY_HEAD",
-            "${{ github.event.pull_request.head.sha || github.sha }}",
-        ),
-    ] {
-        if env.len() != 4
-            || !env
-                .iter()
-                .any(|(name, actual)| name == key && actual == value)
-        {
-            return Err(format!(
-                "CI-HYGIENE: `{metadata}` must bind `{key}` to `{value}`; restore the authenticated event handoff."
-            ));
-        }
-    }
     Ok(())
 }
 
@@ -2043,11 +1837,7 @@ fn check_workflow(root: &Path) -> Result<(), String> {
             ));
         }
     }
-    if !workflow_has_checkout_persist_credentials_false(&text) {
-        return Err(format!(
-            "CI-HYGIENE: `{WORKFLOW}` must set `persist-credentials: false` inside every `actions/checkout` `with:` mapping. One protected checkout or an echoed/unrelated YAML value does not protect the others."
-        ));
-    }
+
     check_change_router_job(&text)?;
     check_package_loop_shell(&text)?;
     check_check_job_if_avoids_matrix(&text)?;
@@ -2056,7 +1846,6 @@ fn check_workflow(root: &Path) -> Result<(), String> {
     check_bun_test_job(&text)?;
     check_linux_media_guard_step(&text)?;
     check_required_job(&text)?;
-    check_security_jobs(&text)?;
     check_product_status_step(&text)?;
     check_product_status_windows_step(&text)?;
     check_atomic_protocol_step(&text)?;
@@ -2068,18 +1857,7 @@ fn check_workflow(root: &Path) -> Result<(), String> {
             ));
         }
     }
-    let unpinned = action_uses_unpinned(&text);
-    if !unpinned.is_empty() {
-        let details: Vec<String> = unpinned
-            .iter()
-            .map(|(line, spec)| format!("line {line}: {spec}"))
-            .collect();
-        return Err(format!(
-            "CI-HYGIENE: `{WORKFLOW}` has unpinned `uses:` entries (need a 40-char commit SHA). \
-             Pin each action and leave the tag in a trailing comment. Offenders: {}",
-            details.join("; ")
-        ));
-    }
+
     Ok(())
 }
 
@@ -2158,7 +1936,23 @@ fn run_cli() -> Result<(), String> {
         );
     }
     match command.as_str() {
-        "check" => check(&root),
+        "check" => {
+            check(&root)?;
+            let status = std::process::Command::new("bun")
+                .arg("--no-install")
+                .arg(root.join("tools/ci_workflow_security.ts"))
+                .arg("check")
+                .arg(&root)
+                .stdin(std::process::Stdio::null())
+                .status()
+                .map_err(|error| format!("CI-HYGIENE: cannot run workflow semantic check: {error}. Install the repository Bun prerequisite and rerun just hygiene."))?;
+            if !status.success() {
+                return Err(format!(
+                    "CI-HYGIENE: workflow semantic check failed ({status}); restore the reported security contract before rerunning."
+                ));
+            }
+            Ok(())
+        }
         _ => Err(format!(
             "CI-HYGIENE: unknown command `{command}`. Use `check` to verify KEL-39 files."
         )),
@@ -2212,6 +2006,7 @@ mod tests {
     const PINNED_CHECKOUT: &str =
         "      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0\n";
 
+    // Fixture for Rust-owned contracts; parsed security cases use the real workflow in Bun.
     fn valid_workflow() -> String {
         [
             "name: CI",
@@ -2318,44 +2113,6 @@ mod tests {
             "      - run: rustc --edition=2024 --test tools/mermaid_docs.rs",
             "      - run: mermaid-docs check .",
             "      - run: tools/mermaid_render_check.sh # sha256:29077c6bd02f14bdfdd5fee552d9c00fe68d4fab3cd84952d21e2d1faf2fadaf",
-            "  codeql:",
-            "    steps:",
-            "      - name: Initialize CodeQL",
-            "        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938",
-            "        with:",
-            "          languages: ${{ matrix.language }}",
-            "          build-mode: none",
-            "      - name: Analyze and upload CodeQL results",
-            "        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938",
-            "        with:",
-            "          category: /language:${{ matrix.language }}",
-            "          upload: always",
-            "          skip-queries: false",
-            "          wait-for-processing: true",
-            "  dependency-review:",
-            "    steps:",
-            "      - name: Reject incomplete dependency metadata",
-            "        env:",
-            "          GH_TOKEN: ${{ github.token }}",
-            "          KELD_DEPENDENCY_REPOSITORY: ${{ github.repository }}",
-            "          KELD_DEPENDENCY_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}",
-            "          KELD_DEPENDENCY_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}",
-            "        run: |",
-            "          tools/dependency_review_metadata.sh test",
-            "          tools/dependency_review_metadata.sh check \"$KELD_DEPENDENCY_REPOSITORY\" \"$KELD_DEPENDENCY_BASE\" \"$KELD_DEPENDENCY_HEAD\"",
-            "      - name: Review dependency vulnerabilities",
-            "        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294",
-            "        with:",
-            "          base-ref: ${{ github.event.pull_request.base.sha || github.event.before }}",
-            "          head-ref: ${{ github.event.pull_request.head.sha || github.sha }}",
-            "          fail-on-severity: low",
-            "          fail-on-scopes: runtime, development, unknown",
-            "          vulnerability-check: true",
-            "          license-check: false",
-            "          comment-summary-in-pr: never",
-            "          retry-on-snapshot-warnings: false",
-            "          warn-only: false",
-            "          show-openssf-scorecard: false",
             "  required:",
             "    name: CI required",
             "    if: ${{ always() }}",
@@ -2757,154 +2514,6 @@ mod tests {
             let error = check_required_job(&workflow).expect_err("missing security job must fail");
             assert!(error.contains(job), "{error}");
         }
-    }
-
-    #[test]
-    fn required_security_actions_cannot_be_disabled_or_warn_only() {
-        let baseline = include_str!("../.github/workflows/ci.yml");
-        let temp = complete_fixture();
-        temp.write(WORKFLOW, baseline);
-        check(temp.path()).expect("unchanged workflow must pass before security mutations");
-        for action in [
-            "github/codeql-action/analyze@",
-            "actions/dependency-review-action@",
-        ] {
-            let action_start = baseline.find(action).expect("security action exists");
-            let line_end = action_start
-                + baseline[action_start..]
-                    .find('\n')
-                    .expect("action line ends");
-            let mut disabled = baseline.to_owned();
-            disabled.insert_str(line_end, "\n        if: false");
-            let temp = complete_fixture();
-            temp.write(WORKFLOW, &disabled);
-            let error =
-                check(temp.path()).expect_err("a skipped security action must fail hygiene");
-            assert!(error.contains("unconditional action"), "{action}: {error}");
-        }
-        let temp = complete_fixture();
-        temp.write(
-            WORKFLOW,
-            &baseline.replacen("warn-only: false", "warn-only: true", 1),
-        );
-        let error =
-            check(temp.path()).expect_err("nonblocking vulnerability review must fail hygiene");
-        assert!(
-            error.contains("Review dependency vulnerabilities")
-                && error.contains("changed security inputs"),
-            "{error}"
-        );
-    }
-
-    #[test]
-    fn security_action_effects_and_metadata_cannot_be_replaced_with_success() {
-        let baseline = valid_workflow();
-        check_security_jobs(&baseline).expect("unchanged security actions must pass");
-        for (label, needle, replacement) in [
-            ("upload disabled", "upload: always", "upload: never"),
-            (
-                "queries skipped",
-                "skip-queries: false",
-                "skip-queries: true",
-            ),
-            (
-                "processing not awaited",
-                "wait-for-processing: true",
-                "wait-for-processing: false",
-            ),
-            (
-                "vulnerabilities unchecked",
-                "vulnerability-check: true",
-                "vulnerability-check: false",
-            ),
-            (
-                "severity narrowed",
-                "fail-on-severity: low",
-                "fail-on-severity: critical",
-            ),
-            (
-                "development scope omitted",
-                "fail-on-scopes: runtime, development, unknown",
-                "fail-on-scopes: runtime",
-            ),
-            (
-                "advisory bypass",
-                "warn-only: false",
-                "warn-only: false\n          allow-ghsas: GHSA-xxxx-yyyy-zzzz",
-            ),
-            (
-                "duplicate input",
-                "warn-only: false",
-                "warn-only: false\n          warn-only: true",
-            ),
-            (
-                "wrong action",
-                "github/codeql-action/analyze@",
-                "github/codeql-action/init@",
-            ),
-            (
-                "floating action under quoted key",
-                "uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938",
-                "'uses': github/codeql-action/analyze@main",
-            ),
-            (
-                "metadata step skipped",
-                "      - name: Reject incomplete dependency metadata\n",
-                "      - name: Reject incomplete dependency metadata\n        if: false\n",
-            ),
-            (
-                "metadata check echoed",
-                "          tools/dependency_review_metadata.sh check ",
-                "          echo tools/dependency_review_metadata.sh check ",
-            ),
-            (
-                "metadata failure swallowed",
-                "\"$KELD_DEPENDENCY_HEAD\"\n",
-                "\"$KELD_DEPENDENCY_HEAD\" || true\n",
-            ),
-            (
-                "metadata ref changed",
-                "KELD_DEPENDENCY_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}",
-                "KELD_DEPENDENCY_BASE: ${{ github.sha }}",
-            ),
-        ] {
-            assert!(baseline.contains(needle), "missing mutation input: {label}");
-            let mutated = baseline.replacen(needle, replacement, 1);
-            check_security_jobs(&mutated).expect_err(label);
-        }
-        for step in [
-            "Initialize CodeQL",
-            "Analyze and upload CodeQL results",
-            "Review dependency vulnerabilities",
-        ] {
-            let block = workflow_direct_named_step_block(&baseline, step).expect("step exists");
-            check_security_jobs(&baseline.replacen(&block, "", 1)).expect_err("removed action");
-            check_security_jobs(&baseline.replacen(&block, &format!("{block}{block}"), 1))
-                .expect_err("duplicate action");
-            let conditional = baseline.replacen(
-                &format!("      - name: {step}\n"),
-                &format!("      - name: {step}\n        'if': false\n"),
-                1,
-            );
-            check_security_jobs(&conditional).expect_err("quoted action condition");
-        }
-    }
-
-    #[test]
-    fn security_inputs_accept_equivalent_scalar_quotes_and_scope_order() {
-        let workflow = valid_workflow()
-            .replacen("warn-only: false", "'warn-only': 'false'", 1)
-            .replacen(
-                "fail-on-scopes: runtime, development, unknown",
-                "fail-on-scopes: unknown,runtime,development",
-                1,
-            )
-            .replacen(
-                "          skip-queries: false\n          wait-for-processing: true",
-                "          wait-for-processing: true\n          skip-queries: false",
-                1,
-            );
-        check_security_jobs(&workflow).expect("equivalent mappings preserve security effects");
     }
 
     #[test]
@@ -3647,57 +3256,6 @@ mod tests {
         temp.write(WORKFLOW, &workflow);
         let error = check(temp.path()).expect_err("commented gate must not satisfy hygiene");
         assert!(error.contains("executable Mermaid gate"), "{error}");
-    }
-
-    #[test]
-    fn checkout_credentials_must_be_disabled_in_its_with_mapping() {
-        let temp = complete_fixture();
-        let workflow = valid_workflow().replace(
-            "      persist-credentials: false\n",
-            "      # persist-credentials: false\n",
-        );
-        temp.write(WORKFLOW, &workflow);
-        let error = check(temp.path()).expect_err("comment must not satisfy checkout hardening");
-        assert!(error.contains("persist-credentials: false"), "{error}");
-    }
-
-    #[test]
-    fn every_checkout_must_disable_credential_persistence() {
-        let secure =
-            format!("{PINNED_CHECKOUT}        with:\n          persist-credentials: false\n");
-        assert!(workflow_has_checkout_persist_credentials_false(&secure));
-        assert!(!workflow_has_checkout_persist_credentials_false("jobs:\n"));
-        for insecure in [
-            PINNED_CHECKOUT.to_owned(),
-            format!("{PINNED_CHECKOUT}        with:\n          persist-credentials: true\n"),
-            format!("{PINNED_CHECKOUT}        env:\n          persist-credentials: false\n"),
-            format!(
-                "{PINNED_CHECKOUT}        with:\n          persist-credentials: false\n          persist-credentials: true\n"
-            ),
-        ] {
-            for workflow in [format!("{secure}{insecure}"), format!("{insecure}{secure}")] {
-                assert!(
-                    !workflow_has_checkout_persist_credentials_false(&workflow),
-                    "one insecure checkout was admitted: {workflow}"
-                );
-            }
-        }
-        let named = secure
-            .replacen("- uses:", "- name: Checkout\n        'uses':", 1)
-            .replace(
-                "persist-credentials: false",
-                "'persist-credentials': 'false'",
-            );
-        assert!(workflow_has_checkout_persist_credentials_false(&format!(
-            "{secure}{named}"
-        )));
-        let named_insecure = named.replace(
-            "'persist-credentials': 'false'",
-            "'persist-credentials': 'true'",
-        );
-        assert!(!workflow_has_checkout_persist_credentials_false(&format!(
-            "{secure}{named_insecure}"
-        )));
     }
 
     #[test]
@@ -4474,22 +4032,6 @@ foreach ($item in $items) {
         );
         let error = check(temp.path()).expect_err("workflow without gitleaks must fail");
         assert!(error.contains("gitleaks detect"), "{error}");
-    }
-
-    #[test]
-    fn unpinned_action_fails() {
-        let temp = complete_fixture();
-        let workflow = valid_workflow().replace(
-            "actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
-            "actions/checkout@v4",
-        );
-        temp.write(WORKFLOW, &workflow);
-        let error = check(temp.path()).expect_err("floating action tag must fail");
-        assert!(error.contains("unpinned"), "{error}");
-        assert!(
-            error.contains("@v4") || error.contains("checkout@v4"),
-            "{error}"
-        );
     }
 
     #[test]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -1224,6 +1224,8 @@ fn check_required_job(text: &str) -> Result<(), String> {
         "deny",
         "secrets",
         "hygiene",
+        "codeql",
+        "dependency-review",
     ];
     let actual_needs = workflow_job_sequence_values(&block, "needs").ok_or_else(|| {
         format!("CI-HYGIENE: `{WORKFLOW}` `required` must declare a structured `needs` sequence.")
@@ -1252,6 +1254,11 @@ fn check_required_job(text: &str) -> Result<(), String> {
         ("KELD_ROUTE_DENY", "${{ needs.changes.outputs.deny }}"),
         ("KELD_ROUTE_HYGIENE", "${{ needs.changes.outputs.hygiene }}"),
         ("KELD_ROUTE_DOCS", "${{ needs.changes.outputs.docs }}"),
+        ("KELD_RESULT_CODEQL", "${{ needs.codeql.result }}"),
+        (
+            "KELD_RESULT_DEPENDENCY_REVIEW",
+            "${{ needs['dependency-review'].result }}",
+        ),
     ] {
         if workflow_named_step_env_value(&block, "Verify required CI results", key).as_deref()
             != Some(expression)
@@ -1268,7 +1275,7 @@ fn check_required_job(text: &str) -> Result<(), String> {
         "\"$KELD_RESULT_DENY\" \"$KELD_RESULT_SECRETS\" \"$KELD_RESULT_HYGIENE\" ",
         "\"$KELD_ROUTE_RUST\" \"$KELD_ROUTE_TS\" \"$KELD_ROUTE_GUI\" ",
         "\"$KELD_ROUTE_MSRV\" \"$KELD_ROUTE_DENY\" \"$KELD_ROUTE_HYGIENE\" ",
-        "\"$KELD_ROUTE_DOCS\""
+        "\"$KELD_ROUTE_DOCS\" \"$KELD_RESULT_CODEQL\" \"$KELD_RESULT_DEPENDENCY_REVIEW\""
     );
     let expected_commands = [
         "tools/ci_required.sh test".to_owned(),
@@ -1278,7 +1285,7 @@ fn check_required_job(text: &str) -> Result<(), String> {
         .unwrap_or_default();
     if actual_commands != expected_commands {
         return Err(format!(
-            "CI-HYGIENE: `{WORKFLOW}` `required` evaluator run block must contain only its self-test and the exact ordered 16-argument check, without control flow, reassignment, wrappers, or exit-status suppression."
+            "CI-HYGIENE: `{WORKFLOW}` `required` evaluator run block must contain only its self-test and the exact ordered 18-argument check, without control flow, reassignment, wrappers, or exit-status suppression."
         ));
     }
     if !workflow_has_checkout_persist_credentials_false(&block) {
@@ -2157,6 +2164,8 @@ mod tests {
             "      - deny",
             "      - secrets",
             "      - hygiene",
+            "      - codeql",
+            "      - dependency-review",
             "    steps:",
             "      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
             "        with:",
@@ -2179,6 +2188,8 @@ mod tests {
             "          KELD_ROUTE_DENY: ${{ needs.changes.outputs.deny }}",
             "          KELD_ROUTE_HYGIENE: ${{ needs.changes.outputs.hygiene }}",
             "          KELD_ROUTE_DOCS: ${{ needs.changes.outputs.docs }}",
+            "          KELD_RESULT_CODEQL: ${{ needs.codeql.result }}",
+            "          KELD_RESULT_DEPENDENCY_REVIEW: ${{ needs['dependency-review'].result }}",
             "        run: |",
             "          tools/ci_required.sh test",
             "          tools/ci_required.sh check \\",
@@ -2187,7 +2198,8 @@ mod tests {
             "            \"$KELD_RESULT_DENY\" \"$KELD_RESULT_SECRETS\" \"$KELD_RESULT_HYGIENE\" \\",
             "            \"$KELD_ROUTE_RUST\" \"$KELD_ROUTE_TS\" \"$KELD_ROUTE_GUI\" \\",
             "            \"$KELD_ROUTE_MSRV\" \"$KELD_ROUTE_DENY\" \\",
-            "            \"$KELD_ROUTE_HYGIENE\" \"$KELD_ROUTE_DOCS\"",
+            "            \"$KELD_ROUTE_HYGIENE\" \"$KELD_ROUTE_DOCS\" \\",
+            "            \"$KELD_RESULT_CODEQL\" \"$KELD_RESULT_DEPENDENCY_REVIEW\"",
             "",
         ]
         .join("\n")
@@ -2530,7 +2542,36 @@ mod tests {
             &valid_workflow().replacen("\"$KELD_ROUTE_TS\"", "false", 1),
         );
         let error = check(temp.path()).expect_err("unused router output must fail");
-        assert!(error.contains("16-argument"), "{error}");
+        assert!(error.contains("18-argument"), "{error}");
+    }
+
+    #[test]
+    fn required_result_must_observe_security_jobs() {
+        for job in ["codeql", "dependency-review"] {
+            let workflow = valid_workflow().replacen(&format!("      - {job}\n"), "", 1);
+            let error = check_required_job(&workflow).expect_err("missing security job must fail");
+            assert!(error.contains(job), "{error}");
+        }
+    }
+
+    #[test]
+    fn required_result_must_receive_security_results_without_spoofing() {
+        for (key, expression) in [
+            ("KELD_RESULT_CODEQL", "${{ needs.codeql.result }}"),
+            (
+                "KELD_RESULT_DEPENDENCY_REVIEW",
+                "${{ needs['dependency-review'].result }}",
+            ),
+        ] {
+            let workflow = valid_workflow().replacen(expression, "success", 1);
+            let error =
+                check_required_job(&workflow).expect_err("spoofed security result must fail");
+            assert!(error.contains(key), "{error}");
+            let workflow = valid_workflow().replacen(&format!("\"${key}\""), "success", 1);
+            let error =
+                check_required_job(&workflow).expect_err("unused security result must fail");
+            assert!(error.contains("18-argument"), "{error}");
+        }
     }
 
     #[test]

--- a/tools/ci_required.sh
+++ b/tools/ci_required.sh
@@ -35,8 +35,8 @@ require_routed_result() {
 }
 
 check_results() {
-    if [[ "$#" -ne 16 ]]; then
-        fail "expected 9 job results plus 7 router outputs, got $#; restore the required job's complete needs and applicability handoff."
+    if [[ "$#" -ne 18 ]]; then
+        fail "expected 9 routed/core job results, 7 router outputs, and 2 security job results, got $#; restore the required job's complete needs and applicability handoff."
         return
     fi
 
@@ -60,6 +60,8 @@ check_results() {
             return 1
             ;;
     esac
+    require_success "CodeQL analysis and upload" "${17}" || return 1
+    require_success "dependency review" "${18}" || return 1
 }
 
 expect_pass() {
@@ -81,35 +83,48 @@ expect_fail() {
 self_test() {
     expect_pass "all applicable jobs succeed" \
         success success success success success success success success success \
-        true true true true true true true
+        true true true true true true true success success
     expect_pass "router-proven inapplicable jobs skip" \
         success skipped skipped skipped skipped skipped skipped success skipped \
-        false false false false false false false
+        false false false false false false false success success
 
     expect_fail "missing gitleaks is not green" \
         success skipped skipped skipped skipped skipped skipped skipped skipped \
-        false false false false false false false
+        false false false false false false false success success
     expect_fail "cancelled gitleaks is not green" \
         success skipped skipped skipped skipped skipped skipped cancelled skipped \
-        false false false false false false false
+        false false false false false false false success success
     expect_fail "failed selected test is not green" \
         success success failure skipped skipped success skipped success success \
-        true false false true false true false
+        true false false true false true false success success
     expect_fail "selected job cannot disappear as skipped" \
         success skipped skipped skipped skipped skipped skipped success skipped \
-        true false false false false false false
+        true false false false false false false success success
     expect_fail "unselected job cannot silently run" \
         success success skipped skipped skipped skipped skipped success skipped \
-        false false false false false false false
+        false false false false false false false success success
     expect_fail "invalid router output is not evidence" \
         success skipped skipped skipped skipped skipped skipped success skipped \
-        missing false false false false false false
+        missing false false false false false false success success
     expect_fail "cancelled router cannot skip everything green" \
         cancelled skipped skipped skipped skipped skipped skipped success skipped \
-        false false false false false false false
+        false false false false false false false success success
     expect_fail "missing result handoff is rejected" \
         success skipped skipped skipped skipped skipped skipped success skipped \
-        false false false false false false
+        false false false false false false success success
+
+    local result
+    for result in skipped cancelled failure missing ''; do
+        expect_fail "CodeQL '$result' is not analysis evidence" \
+            success skipped skipped skipped skipped skipped skipped success skipped \
+            false false false false false false false "$result" success
+        expect_fail "dependency review '$result' is not evidence" \
+            success skipped skipped skipped skipped skipped skipped success skipped \
+            false false false false false false false success "$result"
+    done
+    expect_fail "old handoff cannot omit both security jobs" \
+        success skipped skipped skipped skipped skipped skipped success skipped \
+        false false false false false false false
 
     echo "ci-required contract tests ok"
 }
@@ -128,7 +143,7 @@ case "${1:-}" in
         self_test
         ;;
     *)
-        fail "unknown or missing command '${1:-}'. Use 'check' with 9 job results and 7 router outputs, or 'test'."
+        fail "unknown or missing command '${1:-}'. Use 'check' with 9 core job results, 7 router outputs, and 2 security job results, or 'test'."
         exit 1
         ;;
 esac

--- a/tools/ci_workflow_security.test.ts
+++ b/tools/ci_workflow_security.test.ts
@@ -1,0 +1,196 @@
+import { expect, test } from "bun:test";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { checkWorkflowSecurity } from "./ci_workflow_security";
+
+type Step = Record<string, unknown>;
+type Fixture = { jobs: Record<string, { steps: Step[] }> };
+const source = readFileSync(join(import.meta.dir, "../.github/workflows/ci.yml"), "utf8");
+const checkout = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
+
+function fixture(): Fixture {
+  checkWorkflowSecurity(source);
+  return Bun.YAML.parse(source) as Fixture;
+}
+
+function step(f: Fixture, job: string, name: string): Step {
+  const found = f.jobs[job]!.steps.find(candidate => candidate.name === name);
+  if (!found) throw new Error(`missing fixture step: ${name}`);
+  return found;
+}
+
+function check(f: Fixture): void { checkWorkflowSecurity(Bun.YAML.stringify(f, null, 2)); }
+
+test("actual workflow passes parsed security admission", () => {
+  expect(() => checkWorkflowSecurity(source)).not.toThrow();
+});
+
+for (const style of ["block", "flow", "alias"] as const) {
+  for (const secure of [true, false]) {
+    test(`${style} checkout with persistence ${secure ? "disabled" : "enabled"}`, () => {
+      checkWorkflowSecurity(source);
+      const flag = secure ? "false" : "true";
+      const inserted = style === "block"
+        ? `      - name: Extra checkout\n        uses: ${checkout}\n        with:\n          persist-credentials: ${flag}\n`
+        : style === "flow"
+          ? `      - { uses: '${checkout}', with: { persist-credentials: ${flag} } }\n`
+          : `      - &shared_checkout { uses: '${checkout}', with: { persist-credentials: ${flag} } }\n      - *shared_checkout\n`;
+      const mutated = source.replace("      - name: Initialize CodeQL\n", inserted + "      - name: Initialize CodeQL\n");
+      if (secure) expect(() => checkWorkflowSecurity(mutated)).not.toThrow();
+      else expect(() => checkWorkflowSecurity(mutated)).toThrow("persist-credentials: false");
+    });
+  }
+}
+
+test("every checkout must be protected; one secure step cannot mask another", () => {
+  const base = fixture();
+  let checked = 0;
+  for (const [jobName, job] of Object.entries(base.jobs)) {
+    for (const [index, candidate] of job.steps.entries()) {
+      if (typeof candidate.uses !== "string" || !candidate.uses.startsWith("actions/checkout@")) continue;
+      for (const value of [true, undefined]) {
+        const f = fixture();
+        const inputs = f.jobs[jobName]!.steps[index]!.with as Step;
+        if (value === undefined) delete inputs["persist-credentials"];
+        else inputs["persist-credentials"] = value;
+        expect(() => check(f)).toThrow("persist-credentials: false");
+      }
+      checked++;
+    }
+  }
+  expect(checked).toBeGreaterThan(1);
+});
+
+for (const [job, name] of [
+  ["codeql", "Initialize CodeQL"],
+  ["codeql", "Analyze and upload CodeQL results"],
+  ["dependency-review", "Review dependency vulnerabilities"],
+  ["dependency-review", "Reject incomplete dependency metadata"],
+] as const) {
+  test(`${name} cannot be skipped, removed or duplicated`, () => {
+    for (const mutation of ["condition", "remove", "duplicate"] as const) {
+      const f = fixture();
+      const selected = step(f, job, name);
+      if (mutation === "condition") selected.if = false;
+      if (mutation === "remove") f.jobs[job]!.steps = f.jobs[job]!.steps.filter(s => s !== selected);
+      if (mutation === "duplicate") f.jobs[job]!.steps.push(selected);
+      expect(() => check(f)).toThrow();
+    }
+  });
+}
+
+for (const [job, name, key, value] of [
+  ["codeql", "Analyze and upload CodeQL results", "upload", "never"],
+  ["codeql", "Analyze and upload CodeQL results", "skip-queries", true],
+  ["codeql", "Analyze and upload CodeQL results", "wait-for-processing", false],
+  ["dependency-review", "Review dependency vulnerabilities", "vulnerability-check", false],
+  ["dependency-review", "Review dependency vulnerabilities", "warn-only", true],
+  ["dependency-review", "Review dependency vulnerabilities", "fail-on-severity", "critical"],
+  ["dependency-review", "Review dependency vulnerabilities", "fail-on-scopes", "runtime"],
+  ["dependency-review", "Review dependency vulnerabilities", "allow-ghsas", "GHSA-xxxx-yyyy-zzzz"],
+] as const) {
+  test(`required scanner input ${key} cannot bypass its effect`, () => {
+    const f = fixture();
+    (step(f, job, name).with as Step)[key] = value;
+    expect(() => check(f)).toThrow();
+  });
+}
+
+test("wrong or floating action identity fails, including flow mappings", () => {
+  for (const uses of ["github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938", "github/codeql-action/analyze@main"]) {
+    const f = fixture();
+    step(f, "codeql", "Analyze and upload CodeQL results").uses = uses;
+    expect(() => checkWorkflowSecurity(Bun.YAML.stringify(f))).toThrow();
+  }
+  const f = fixture();
+  f.jobs.codeql!.steps.push({ uses: "actions/checkout@main", with: { "persist-credentials": false } });
+  expect(() => check(f)).toThrow("immutable");
+});
+
+test("metadata admission cannot echo/swallow checks or change event refs", () => {
+  for (const mutation of ["echo", "swallow", "ref"] as const) {
+    const f = fixture();
+    const selected = step(f, "dependency-review", "Reject incomplete dependency metadata");
+    if (mutation === "ref") (selected.env as Step).KELD_DEPENDENCY_BASE = "${{ github.sha }}";
+    else selected.run = mutation === "echo" ? `echo ${selected.run}` : `${String(selected.run).trim()} || true\n`;
+    expect(() => check(f)).toThrow("metadata");
+  }
+});
+
+test("scanner prerequisites cannot be reordered", () => {
+  const f = fixture();
+  f.jobs.codeql!.steps.reverse();
+  expect(() => check(f)).toThrow("initialization must precede");
+  const d = fixture();
+  d.jobs["dependency-review"]!.steps.reverse();
+  expect(() => check(d)).toThrow("metadata admission must precede");
+});
+
+for (const invalid of ["", "jobs: [", "---\na: 1\n---\nb: 2", "jobs: {}", "jobs: []", "jobs: {x: {steps: [false]}}", "jobs: {x: {steps: [[{}]]}}", "jobs: {x: {uses: owner/reusable@main}}", "jobs: &jobs { x: *jobs }"]) {
+  test(`missing/malformed/unknown workflow shape refuses: ${JSON.stringify(invalid)}`, () => {
+    expect(() => checkWorkflowSecurity(invalid)).toThrow();
+  });
+}
+
+test("Bun duplicate-key behavior is documented, not claimed as syntax validation", () => {
+  expect(Bun.YAML.parse("x: true\nx: false")).toEqual({ x: false });
+  expect(() => checkWorkflowSecurity(source.replace("warn-only: false", "warn-only: false\n          warn-only: true"))).toThrow("warn-only");
+});
+
+test("parsing budget admits the boundary and refuses one extra byte", () => {
+  const exact = source + "\n#" + "x".repeat(1024 * 1024 - Buffer.byteLength(source) - 2);
+  expect(() => checkWorkflowSecurity(exact)).not.toThrow();
+  expect(() => checkWorkflowSecurity(exact + "x")).toThrow("1 MiB");
+});
+
+test("equivalent scalar quotes and scope order preserve effects", () => {
+  expect(() => checkWorkflowSecurity(source.replace("warn-only: false", "'warn-only': 'false'")
+    .replace("fail-on-scopes: runtime, development, unknown", "fail-on-scopes: unknown,runtime,development"))).not.toThrow();
+});
+
+test("existing Rust CLI invokes semantic admission and preserves its refusal", () => {
+  const repository = join(import.meta.dir, "..");
+  const temporary = mkdtempSync(join(tmpdir(), "keld-workflow-security-"));
+  try {
+    const checkoutRoot = join(temporary, "checkout");
+    mkdirSync(checkoutRoot);
+    const listing = Bun.spawnSync(["git", "-C", repository, "ls-files", "-z"]);
+    expect(listing.exitCode).toBe(0);
+    const files = new Set(new TextDecoder().decode(listing.stdout).split("\0").filter(Boolean));
+    files.add("tools/ci_workflow_security.ts");
+    for (const relative of files) {
+      const destination = join(checkoutRoot, relative);
+      mkdirSync(dirname(destination), { recursive: true });
+      cpSync(join(repository, relative), destination, { dereference: false });
+    }
+    const binary = join(temporary, process.platform === "win32" ? "ci-hygiene.exe" : "ci-hygiene");
+    const compilation = Bun.spawnSync(["rustc", "--edition=2024", "-D", "warnings", join(repository, "tools/ci_hygiene.rs"), "-o", binary]);
+    expect(compilation.exitCode).toBe(0);
+    // The CLI must use the same verified Bun executable as this test process.
+    const runtimeEnv = { ...process.env, PATH: `${dirname(process.execPath)}${delimiter}${process.env.PATH ?? ""}` };
+    const run = (yaml: string, env = runtimeEnv) => {
+      writeFileSync(join(checkoutRoot, ".github/workflows/ci.yml"), yaml);
+      return Bun.spawnSync([binary, "check", checkoutRoot], { cwd: repository, env });
+    };
+    const original = run(source);
+    expect(original.exitCode).toBe(0);
+    expect(new TextDecoder().decode(original.stdout)).toContain("CI workflow security semantics ok");
+    for (const insertion of [
+      `      - { uses: '${checkout}', with: { persist-credentials: true } }\n`,
+      `      - &insecure { uses: '${checkout}', with: { persist-credentials: true } }\n      - *insecure\n`,
+    ]) {
+      const result = run(source.replace("      - name: Initialize CodeQL\n", insertion + "      - name: Initialize CodeQL\n"));
+      expect(result.exitCode).not.toBe(0);
+      expect(new TextDecoder().decode(result.stderr)).toContain("persist-credentials: false");
+    }
+    const skipped = run(source.replace("      - name: Analyze and upload CodeQL results\n", "      - name: Analyze and upload CodeQL results\n        if: false\n"));
+    expect(skipped.exitCode).not.toBe(0);
+    expect(new TextDecoder().decode(skipped.stderr)).toContain("conditions or unknown controls");
+    expect(run(source, { ...runtimeEnv, PATH: temporary }).exitCode).not.toBe(0);
+    rmSync(join(checkoutRoot, "tools/ci_workflow_security.ts"));
+    expect(run(source).exitCode).not.toBe(0);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}, 30000);

--- a/tools/ci_workflow_security.test.ts
+++ b/tools/ci_workflow_security.test.ts
@@ -62,6 +62,17 @@ test("every checkout must be protected; one secure step cannot mask another", ()
   expect(checked).toBeGreaterThan(1);
 });
 
+test("checkout repository case and subpaths cannot bypass its policy", () => {
+  for (const name of ["ACTIONS/CHECKOUT", "Actions/Checkout/."]) {
+    for (const protectedCheckout of [true, false]) {
+      const f = fixture();
+      f.jobs.codeql!.steps.push({ uses: `${name}@3d3c42e5aac5ba805825da76410c181273ba90b1`, with: { "persist-credentials": !protectedCheckout } });
+      if (protectedCheckout) expect(() => check(f)).not.toThrow();
+      else expect(() => check(f)).toThrow("persist-credentials: false");
+    }
+  }
+});
+
 for (const [job, name] of [
   ["codeql", "Initialize CodeQL"],
   ["codeql", "Analyze and upload CodeQL results"],

--- a/tools/ci_workflow_security.test.ts
+++ b/tools/ci_workflow_security.test.ts
@@ -5,7 +5,12 @@ import { delimiter, dirname, join } from "node:path";
 import { checkWorkflowSecurity } from "./ci_workflow_security";
 
 type Step = Record<string, unknown>;
-type Fixture = { jobs: Record<string, { steps: Step[]; strategy?: { matrix: Record<string, unknown> } }> };
+type FixtureJob = {
+  steps: Step[];
+  permissions?: Record<string, unknown>;
+  strategy?: { matrix: Record<string, unknown> };
+};
+type Fixture = { jobs: Record<string, FixtureJob> };
 const source = readFileSync(join(import.meta.dir, "../.github/workflows/ci.yml"), "utf8");
 const checkout = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
 
@@ -51,6 +56,18 @@ test("CodeQL matrix coverage is independent of row order", () => {
   const f = fixture();
   (f.jobs.codeql!.strategy!.matrix.include as Step[]).reverse();
   expect(() => check(f)).not.toThrow();
+});
+
+test("CodeQL permissions retain only read content and SARIF-upload authority", () => {
+  for (const mutation of ["missing", "security-events-read", "contents-write", "extra"] as const) {
+    const f = fixture();
+    const permissions = f.jobs.codeql!.permissions!;
+    if (mutation === "missing") delete f.jobs.codeql!.permissions;
+    if (mutation === "security-events-read") permissions["security-events"] = "read";
+    if (mutation === "contents-write") permissions.contents = "write";
+    if (mutation === "extra") permissions.actions = "read";
+    expect(() => check(f)).toThrow("CodeQL job permissions");
+  }
 });
 
 for (const style of ["block", "flow", "alias"] as const) {
@@ -228,6 +245,9 @@ test("existing Rust CLI invokes semantic admission and preserves its refusal", (
     const skipped = run(source.replace("      - name: Analyze and upload CodeQL results\n", "      - name: Analyze and upload CodeQL results\n        if: false\n"));
     expect(skipped.exitCode).not.toBe(0);
     expect(new TextDecoder().decode(skipped.stderr)).toContain("conditions or unknown controls");
+    const weakenedUpload = run(source.replace("      security-events: write", "      security-events: read"));
+    expect(weakenedUpload.exitCode).not.toBe(0);
+    expect(new TextDecoder().decode(weakenedUpload.stderr)).toContain("CodeQL job permissions");
     expect(run(source, { ...runtimeEnv, PATH: temporary }).exitCode).not.toBe(0);
     rmSync(join(checkoutRoot, "tools/ci_workflow_security.ts"));
     expect(run(source).exitCode).not.toBe(0);

--- a/tools/ci_workflow_security.test.ts
+++ b/tools/ci_workflow_security.test.ts
@@ -5,7 +5,7 @@ import { delimiter, dirname, join } from "node:path";
 import { checkWorkflowSecurity } from "./ci_workflow_security";
 
 type Step = Record<string, unknown>;
-type Fixture = { jobs: Record<string, { steps: Step[] }> };
+type Fixture = { jobs: Record<string, { steps: Step[]; strategy?: { matrix: Record<string, unknown> } }> };
 const source = readFileSync(join(import.meta.dir, "../.github/workflows/ci.yml"), "utf8");
 const checkout = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
 
@@ -24,6 +24,33 @@ function check(f: Fixture): void { checkWorkflowSecurity(Bun.YAML.stringify(f, n
 
 test("actual workflow passes parsed security admission", () => {
   expect(() => checkWorkflowSecurity(source)).not.toThrow();
+});
+
+for (const language of ["rust", "javascript-typescript", "actions"]) {
+  test(`CodeQL matrix cannot omit ${language}`, () => {
+    const f = fixture();
+    const matrix = f.jobs.codeql!.strategy!.matrix;
+    matrix.include = (matrix.include as Step[]).filter(row => row.language !== language);
+    expect(() => check(f)).toThrow("CodeQL matrix");
+  });
+}
+
+test("CodeQL matrix rejects duplicate languages and coverage-altering axes", () => {
+  const duplicate = fixture();
+  const include = duplicate.jobs.codeql!.strategy!.matrix.include as Step[];
+  include[2] = { ...include[0] };
+  expect(() => check(duplicate)).toThrow("CodeQL matrix");
+  for (const extra of [{ exclude: [{ language: "rust" }] }, { language: ["actions"] }]) {
+    const f = fixture();
+    Object.assign(f.jobs.codeql!.strategy!.matrix, extra);
+    expect(() => check(f)).toThrow("CodeQL matrix");
+  }
+});
+
+test("CodeQL matrix coverage is independent of row order", () => {
+  const f = fixture();
+  (f.jobs.codeql!.strategy!.matrix.include as Step[]).reverse();
+  expect(() => check(f)).not.toThrow();
 });
 
 for (const style of ["block", "flow", "alias"] as const) {
@@ -187,6 +214,9 @@ test("existing Rust CLI invokes semantic admission and preserves its refusal", (
     const original = run(source);
     expect(original.exitCode).toBe(0);
     expect(new TextDecoder().decode(original.stdout)).toContain("CI workflow security semantics ok");
+    const missingLanguage = run(source.replace("          - language: actions\n            os: ubuntu-latest\n", ""));
+    expect(missingLanguage.exitCode).not.toBe(0);
+    expect(new TextDecoder().decode(missingLanguage.stderr)).toContain("CodeQL matrix");
     for (const insertion of [
       `      - { uses: '${checkout}', with: { persist-credentials: true } }\n`,
       `      - &insecure { uses: '${checkout}', with: { persist-credentials: true } }\n      - *insecure\n`,

--- a/tools/ci_workflow_security.ts
+++ b/tools/ci_workflow_security.ts
@@ -51,6 +51,12 @@ function actionRef(value: unknown, label: string): string {
   return value;
 }
 
+function actionName(reference: string): string {
+  const [owner = "", repository = "", ...path] = reference.split("@", 1)[0]!.split("/");
+  // GitHub repository identity is case-insensitive; paths within it retain case.
+  return [owner.toLowerCase(), repository.toLowerCase(), ...path].join("/");
+}
+
 function inputsMatch(actual: Mapping, expected: Record<string, string>, label: string): void {
   exactKeys(actual, Object.keys(expected), label);
   for (const [key, expectedValue] of Object.entries(expected)) {
@@ -71,7 +77,7 @@ function namedStep(steps: Mapping[], name: string): Mapping {
 function requiredAction(steps: Mapping[], name: string, action: string, expected: Record<string, string>): Mapping {
   const step = namedStep(steps, name);
   exactKeys(step, ["name", "uses", "with"], name);
-  if (!actionRef(step.uses, name).startsWith(`${action}@`)) fail(`${name} must execute ${action}.`);
+  if (actionName(actionRef(step.uses, name)) !== action) fail(`${name} must execute ${action}.`);
   inputsMatch(mapping(step.with, `${name}.with`), expected, name);
   return step;
 }
@@ -104,7 +110,8 @@ export function checkWorkflowSecurity(source: string): void {
         continue;
       }
       const action = actionRef(step.uses, label);
-      if (action.startsWith("actions/checkout@")) {
+      const identity = actionName(action);
+      if (identity === "actions/checkout" || identity.startsWith("actions/checkout/")) {
         checkouts++;
         const inputs = mapping(step.with, `${label}.with`);
         if (scalar(inputs["persist-credentials"]) !== "false") {

--- a/tools/ci_workflow_security.ts
+++ b/tools/ci_workflow_security.ts
@@ -124,6 +124,16 @@ export function checkWorkflowSecurity(source: string): void {
   const codeql = stepsByJob.get("codeql");
   const dependencies = stepsByJob.get("dependency-review");
   if (!codeql || !dependencies) fail("CodeQL and dependency-review jobs must exist.");
+  const codeqlJob = mapping(jobs.codeql, "jobs.codeql");
+  const strategy = mapping(codeqlJob.strategy, "CodeQL strategy");
+  const matrix = mapping(strategy.matrix, "CodeQL matrix");
+  exactKeys(matrix, ["include"], "CodeQL matrix");
+  const expectedLanguages = ["rust", "javascript-typescript", "actions"];
+  const languages = Array.isArray(matrix.include)
+    ? matrix.include.map(row => mapping(row, "CodeQL matrix row").language) : [];
+  if (languages.length !== expectedLanguages.length || !expectedLanguages.every(language => languages.includes(language))) {
+    fail("CodeQL matrix must include rust, javascript-typescript and actions exactly once; restore all scan categories.");
+  }
   const init = requiredAction(codeql, "Initialize CodeQL", "github/codeql-action/init", {
     languages: "${{ matrix.language }}", "build-mode": "none",
   });

--- a/tools/ci_workflow_security.ts
+++ b/tools/ci_workflow_security.ts
@@ -1,0 +1,158 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+type Mapping = Record<string, unknown>;
+const baseRef = "${{ github.event.pull_request.base.sha || github.event.before }}";
+const headRef = "${{ github.event.pull_request.head.sha || github.sha }}";
+
+function fail(message: string): never {
+  throw new Error(`CI-HYGIENE: ${message}`);
+}
+
+function mapping(value: unknown, label: string): Mapping {
+  if (value === null || typeof value !== "object" || Array.isArray(value)
+    || ![Object.prototype, null].includes(Object.getPrototypeOf(value))) {
+    fail(`${label} must be a plain mapping; this workflow shape is not admitted.`);
+  }
+  return value as Mapping;
+}
+
+function scalar(value: unknown): string | undefined {
+  return ["string", "boolean", "number"].includes(typeof value) ? String(value) : undefined;
+}
+
+function exactKeys(value: Mapping, keys: string[], label: string): void {
+  if (Object.keys(value).length !== keys.length || keys.some(key => !Object.hasOwn(value, key))) {
+    fail(`${label} must contain only ${keys.join(", ")}; conditions or unknown controls are not admitted.`);
+  }
+}
+
+function finiteGraph(value: unknown, active = new Set<object>(), seen = new Set<object>(), depth = 0): void {
+  if (value === null || typeof value !== "object") {
+    if (value !== null && !["string", "number", "boolean"].includes(typeof value)) fail("unsupported YAML value is not admitted.");
+    if (typeof value === "number" && !Number.isFinite(value)) fail("non-finite YAML numbers are not admitted.");
+    return;
+  }
+  if (active.has(value)) fail("cyclic YAML aliases are not admitted.");
+  if (seen.has(value)) return;
+  if (depth > 100 || seen.size >= 10000) fail("workflow object graph exceeds the bounded validation budget.");
+  if (!Array.isArray(value)) mapping(value, "YAML object");
+  active.add(value);
+  seen.add(value);
+  for (const child of Object.values(value)) finiteGraph(child, active, seen, depth + 1);
+  active.delete(value);
+}
+
+function actionRef(value: unknown, label: string): string {
+  if (typeof value !== "string" || (!value.startsWith("./") && !value.startsWith("docker://")
+    && !/^[^\s@]+\/[\w./-]+@[0-9a-f]{40}$/.test(value))) {
+    fail(`${label} must use an immutable 40-character action SHA or an existing local/container action reference.`);
+  }
+  return value;
+}
+
+function inputsMatch(actual: Mapping, expected: Record<string, string>, label: string): void {
+  exactKeys(actual, Object.keys(expected), label);
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    const value = scalar(actual[key]);
+    const matches = key === "fail-on-scopes"
+      ? value?.split(",").map(scope => scope.trim()).sort().join(",") === "development,runtime,unknown"
+      : value === expectedValue;
+    if (!matches) fail(`${label}.${key} must preserve ${expectedValue}; restore the blocking security input.`);
+  }
+}
+
+function namedStep(steps: Mapping[], name: string): Mapping {
+  const matches = steps.filter(step => step.name === name);
+  if (matches.length !== 1) fail(`${name} must occur exactly once in its job's actual steps.`);
+  return matches[0]!;
+}
+
+function requiredAction(steps: Mapping[], name: string, action: string, expected: Record<string, string>): Mapping {
+  const step = namedStep(steps, name);
+  exactKeys(step, ["name", "uses", "with"], name);
+  if (!actionRef(step.uses, name).startsWith(`${action}@`)) fail(`${name} must execute ${action}.`);
+  inputsMatch(mapping(step.with, `${name}.with`), expected, name);
+  return step;
+}
+
+/** Validate security effects over parsed workflow objects, never YAML line shapes. */
+export function checkWorkflowSecurity(source: string): void {
+  if (Buffer.byteLength(source) > 1024 * 1024) fail("workflow exceeds the 1 MiB parsing budget.");
+  let parsed: unknown;
+  try { parsed = Bun.YAML.parse(source); }
+  catch (error) { fail(`cannot parse workflow YAML: ${error instanceof Error ? error.message : String(error)}`); }
+  finiteGraph(parsed);
+  const workflow = mapping(parsed, "workflow (one YAML document)");
+  const jobs = mapping(workflow.jobs, "workflow.jobs");
+  if (Object.keys(jobs).length === 0) fail("workflow.jobs must not be empty.");
+  const stepsByJob = new Map<string, Mapping[]>();
+  let checkouts = 0;
+  for (const [jobName, value] of Object.entries(jobs)) {
+    const job = mapping(value, `jobs.${jobName}`);
+    if (!Array.isArray(job.steps) || job.steps.length === 0 || Object.hasOwn(job, "uses")) {
+      fail(`jobs.${jobName} requires a nonempty concrete steps array; opaque/reusable job shapes need a reviewed contract.`);
+    }
+    const steps = job.steps.map((step, index) => mapping(step, `jobs.${jobName}.steps[${index}]`));
+    stepsByJob.set(jobName, steps);
+    for (const [index, step] of steps.entries()) {
+      const label = `jobs.${jobName}.steps[${index}]`;
+      const uses = Object.hasOwn(step, "uses");
+      if (uses === Object.hasOwn(step, "run")) fail(`${label} must contain exactly one action or executable run string.`);
+      if (!uses) {
+        if (typeof step.run !== "string" || !step.run.trim()) fail(`${label}.run must be a nonempty string.`);
+        continue;
+      }
+      const action = actionRef(step.uses, label);
+      if (action.startsWith("actions/checkout@")) {
+        checkouts++;
+        const inputs = mapping(step.with, `${label}.with`);
+        if (scalar(inputs["persist-credentials"]) !== "false") {
+          fail(`${label} actions/checkout must set persist-credentials: false; every checkout is checked.`);
+        }
+      }
+    }
+  }
+  if (checkouts === 0) fail("workflow must contain its audited checkout steps.");
+  const codeql = stepsByJob.get("codeql");
+  const dependencies = stepsByJob.get("dependency-review");
+  if (!codeql || !dependencies) fail("CodeQL and dependency-review jobs must exist.");
+  const init = requiredAction(codeql, "Initialize CodeQL", "github/codeql-action/init", {
+    languages: "${{ matrix.language }}", "build-mode": "none",
+  });
+  const analyze = requiredAction(codeql, "Analyze and upload CodeQL results", "github/codeql-action/analyze", {
+    category: "/language:${{ matrix.language }}", upload: "always", "skip-queries": "false", "wait-for-processing": "true",
+  });
+  if (codeql.indexOf(init) >= codeql.indexOf(analyze)) fail("CodeQL initialization must precede analysis.");
+  const review = requiredAction(dependencies, "Review dependency vulnerabilities", "actions/dependency-review-action", {
+    "base-ref": baseRef, "head-ref": headRef, "fail-on-severity": "low",
+    "fail-on-scopes": "runtime, development, unknown", "vulnerability-check": "true",
+    "license-check": "false", "comment-summary-in-pr": "never", "retry-on-snapshot-warnings": "false",
+    "warn-only": "false", "show-openssf-scorecard": "false",
+  });
+  const metadata = namedStep(dependencies, "Reject incomplete dependency metadata");
+  exactKeys(metadata, ["name", "env", "run"], "dependency metadata admission");
+  inputsMatch(mapping(metadata.env, "dependency metadata env"), {
+    GH_TOKEN: "${{ github.token }}", KELD_DEPENDENCY_REPOSITORY: "${{ github.repository }}",
+    KELD_DEPENDENCY_BASE: baseRef, KELD_DEPENDENCY_HEAD: headRef,
+  }, "dependency metadata env");
+  const commands = typeof metadata.run === "string" ? metadata.run.trim().split(/\r?\n/).map(line => line.trim()) : [];
+  const expectedCommands = [
+    "tools/dependency_review_metadata.sh test",
+    'tools/dependency_review_metadata.sh check "$KELD_DEPENDENCY_REPOSITORY" "$KELD_DEPENDENCY_BASE" "$KELD_DEPENDENCY_HEAD"',
+  ];
+  if (JSON.stringify(commands) !== JSON.stringify(expectedCommands)) fail("dependency metadata admission must execute its exact checks without wrappers.");
+  if (dependencies.indexOf(metadata) >= dependencies.indexOf(review)) fail("metadata admission must precede dependency review.");
+}
+
+if (import.meta.main) {
+  try {
+    const [, , command, root = ".", ...extra] = process.argv;
+    if (command !== "check" || extra.length) fail("use ci_workflow_security.ts check [workspace].");
+    checkWorkflowSecurity(readFileSync(resolve(root, ".github/workflows/ci.yml"), "utf8"));
+    console.log("CI workflow security semantics ok");
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/tools/ci_workflow_security.ts
+++ b/tools/ci_workflow_security.ts
@@ -125,6 +125,9 @@ export function checkWorkflowSecurity(source: string): void {
   const dependencies = stepsByJob.get("dependency-review");
   if (!codeql || !dependencies) fail("CodeQL and dependency-review jobs must exist.");
   const codeqlJob = mapping(jobs.codeql, "jobs.codeql");
+  inputsMatch(mapping(codeqlJob.permissions, "CodeQL job permissions"), {
+    contents: "read", "security-events": "write",
+  }, "CodeQL job permissions");
   const strategy = mapping(codeqlJob.strategy, "CodeQL strategy");
   const matrix = mapping(strategy.matrix, "CodeQL matrix");
   exactKeys(matrix, ["include"], "CodeQL matrix");

--- a/tools/dependency_review_metadata.sh
+++ b/tools/dependency_review_metadata.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# GitHub dependency-review-action warns, but does not fail, on partial snapshots.
+# This boundary refuses that warning on every page before invoking the action.
+set -euo pipefail
+
+fail() {
+    echo "DEPENDENCY-METADATA: $1" >&2
+    return 1
+}
+
+check_headers() {
+    local line warning pages=0 in_headers=false body_seen=false
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        if [[ "$line" == HTTP/* ]]; then
+            if [[ "$in_headers" == true ]] || { [[ "$pages" -gt 0 ]] && [[ "$body_seen" != true ]]; }; then
+                fail "truncated API response; restore complete dependency metadata before rerunning this head."
+                return 1
+            fi
+            if [[ ! "$line" =~ ^HTTP/[0-9]+(\.[0-9]+)?[[:space:]]200([[:space:]]|$) ]]; then
+                fail "non-200 dependency API response; verify dependency graph access before rerunning this head."
+                return 1
+            fi
+            pages=$((pages + 1))
+            in_headers=true
+            body_seen=false
+        elif [[ "$in_headers" == true ]]; then
+            if [[ -z "$line" ]]; then
+                in_headers=false
+            elif [[ "$line" =~ ^[Xx]-[Gg][Ii][Tt][Hh][Uu][Bb]-[Dd][Ee][Pp][Ee][Nn][Dd][Ee][Nn][Cc][Yy]-[Gg][Rr][Aa][Pp][Hh]-[Ss][Nn][Aa][Pp][Ss][Hh][Oo][Tt]-[Ww][Aa][Rr][Nn][Ii][Nn][Gg][Ss]: ]]; then
+                warning="${line#*:}"
+                if [[ -n "${warning//[[:space:]]/}" ]]; then
+                    fail "GitHub reports incomplete dependency snapshots; restore the missing base/head metadata before rerunning. No partial result is admitted."
+                    return 1
+                fi
+            fi
+        elif [[ -n "$line" ]]; then
+            if [[ "$pages" -eq 0 ]]; then
+                fail "missing API response headers; use gh api --include --paginate."
+                return 1
+            fi
+            body_seen=true
+        fi
+    done
+    if [[ "$pages" -eq 0 || "$in_headers" == true || "$body_seen" != true ]]; then
+        fail "empty or truncated dependency API response; no metadata was admitted."
+        return 1
+    fi
+    echo "dependency metadata headers ok ($pages pages; supported GitHub manifests only)"
+}
+
+check_refs() {
+    local ref
+    for ref in "$@"; do
+        if [[ ! "$ref" =~ ^[0-9a-f]{40}$ || "$ref" == 0000000000000000000000000000000000000000 ]]; then
+            fail "base/head must be nonzero immutable commit SHAs; restore the event SHA handoff."
+            return 1
+        fi
+    done
+}
+
+self_test() {
+    local complete=$'HTTP/2.0 200 OK\r\nContent-Type: application/json\r\n\r\n[]\n'
+    local bad
+    printf '%s' "$complete" | check_headers >/dev/null
+    printf '%s%s' "$complete" "$complete" | check_headers >/dev/null
+    # GitHub sends an empty warning header for complete comparisons.
+    printf '%s' $'HTTP/2.0 200 OK\nX-Github-Dependency-Graph-Snapshot-Warnings: \n\n[]\n' | check_headers >/dev/null
+    for bad in \
+        '' \
+        '[]' \
+        $'HTTP/2.0 403 Forbidden\n\n{}\n' \
+        $'HTTP/2.0 200 OK\nContent-Type: application/json\n' \
+        $'HTTP/2.0 200 OK\n\n' \
+        $'HTTP/2.0 200 OK\nx-github-dependency-graph-snapshot-warnings: e30=\n\n[]\n' \
+        $'HTTP/2.0 200 OK\nX-Github-Dependency-Graph-Snapshot-Warnings: e30=\n\n[]\n'; do
+        if printf '%s' "$bad" | check_headers >/dev/null 2>&1; then
+            fail "self-test admitted missing, failed or incomplete metadata."
+            return 1
+        fi
+    done
+    if printf '%s%s' "$complete" $'HTTP/2.0 200 OK\nx-github-dependency-graph-snapshot-warnings: e30=\n\n[]\n' | check_headers >/dev/null 2>&1; then
+        fail "self-test ignored an incomplete later page."
+        return 1
+    fi
+    check_refs aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    for bad in '' main 0000000000000000000000000000000000000000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 'abc?per_page=1'; do
+        if check_refs "$bad" >/dev/null 2>&1; then
+            fail "self-test admitted a mutable, missing or malformed ref."
+            return 1
+        fi
+    done
+    echo "dependency metadata contract tests ok"
+}
+
+case "${1:-}" in
+    test)
+        [[ "$#" -eq 1 ]] || { fail "test takes no arguments."; exit 1; }
+        self_test
+        ;;
+    check)
+        [[ "$#" -eq 4 ]] || { fail "use check OWNER/REPO BASE_SHA HEAD_SHA."; exit 1; }
+        [[ "$2" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || { fail "invalid repository locator."; exit 1; }
+        check_refs "$3" "$4"
+        gh api --include --paginate \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/$2/dependency-graph/compare/$3...$4?per_page=100" | check_headers
+        ;;
+    *)
+        fail "use test, or check OWNER/REPO BASE_SHA HEAD_SHA."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Add CodeQL for Rust, JavaScript/TypeScript and Actions, plus dependency review, to the existing required CI decision. Missing, skipped, cancelled or failed security jobs are rejected. Dependency review refuses incomplete GitHub snapshot warnings before checking introduced known vulnerabilities across all scopes. All 12 CI checkouts disable credential persistence.

The existing `ci-hygiene check` entrypoint invokes one parsed-YAML security owner using Bun's existing built-in parser. It checks actual block, flow and aliased steps, normalizes checkout repository identity, and requires enabled scanner actions, blocking inputs and executable metadata admission. Its matrix must retain exactly Rust, JavaScript/TypeScript and Actions; missing/duplicate languages and coverage-altering matrix controls are refused. Missing runtime/script, malformed or unsupported structures, cycles and violated controls fail closed. Unrelated Rust hygiene checks remain intact. Refs #170; human approval remains required.

## Spec refs

No product boundary change. User-approved operational controls in #170 and the existing CI credential/admission contract. Reuse the current router/result checker and existing Bun runtime. The previous line-based checkout/scanner validators could not represent valid flow/alias steps and were removed; policies and regression tests moved to the parsed owner. The public security coverage document states parser limitations, including last-key-wins duplicate behavior and no claim of full GitHub YAML equivalence.

## Review gates

- unsafe: none
- public API: none (internal CI tooling)
- permission model: hosted CI token and checkout boundary; parent public-CLI refusal controls and CodeRabbit review recorded below
- dependency addition: SHA-pinned CodeQL action v4.37.9 (`cdf488f595d80d6e07e03d4674febd5ab45fa938`, bundle 2.26.4) and dependency-review action v5.0.0 (`a1d282b36b6f3519aa1f3fc636f609c47dddb294`). Bun's existing 1.4.0 runtime supplies YAML parsing; no Cargo/npm dependency added.
- wire protocol: none

CodeRabbit reviewed the earlier nine-file candidate against its exact base with zero findings. It then reviewed all three changed files in the current matrix correction, also with zero findings. The parent separately exercised the public CLI against checkout flow/alias/case controls and reproduced the matrix-coverage gap before fixing it. This does not replace human approval or authenticate a PR's own writable workflow; the latter remains a separate concern.

## Tests

Current-head local `just ci` passed at `ef83d90ffc25ddc0c271eee0651ade2dfd1bd99c` with Bun `1.4.2+744846f84`: 630 workspace Rust tests passed, 2 skipped; 41 product Bun tests, 79 Rust hygiene tests and 42 parsed-security/CLI tests passed. Formatting, workspace Clippy with warnings denied, docs/router and dependency gates passed. The changed TypeScript implementation and tests also passed strict no-emit compilation.

The added matrix regression failed before the fix: dropping each language and replacing one with a duplicate passed the old semantic checker; the actual public Rust CLI also returned exit0 after dropping Actions. All controls now pass with the correct rejection, including matrix exclusions/additional axes; reversed rows remain accepted. No workflow language was actually removed from the PR.

Actual compiled old/new CLI comparison: the previous checker admitted insecure flow and aliased checkouts; the new public CLI rejected them while preserving secure counterparts. Tests preserve disabled-scanner, warning-only, upload/query/vulnerability, metadata and every-checkout witnesses; add missing runtime/script, malformed/multidocument/cyclic/unknown structures, parsing-budget boundary, and repository-case controls. The CLI child uses the same tested Bun executable.

Predecessor hosted [CI run 34168826675](https://github.com/gyldlab/keld/actions/runs/34168826675) and `CI required` passed on `7d868beb70fe0e2ce3455c361bea38df53a794a3`, including all selected OS lanes, the 37 parsed-security/CLI tests, dependency review and all three CodeQL analyses. Current `ef83d90` hosted checks are pending and are not represented by this older green run.

Independent GitHub dependency comparison exactly matched 320 root Cargo registry dependencies, 53 fuzz-workspace dependencies and both direct npm development dependencies at baseline `dcc4676a`. Bun transitive-lockfile coverage remains unverified; the separate empty default-branch SBOM was not used as a proxy for comparison coverage.

## Platforms

Local: macOS 26.5.1 arm64, Rust 1.97.1. The predecessor parser passed verified Bun1.4.0; the current matrix correction/full gate passed installed Bun1.4.2. CI retains Bun 1.4.0 and adds that existing setup to hygiene. Rust CodeQL uses hosted macOS; JS/TS and Actions use Ubuntu. Rust extraction can execute build scripts/macros. No all-platform containment or Electron compatibility claim follows from static analysis.

## Perf impact

No product runtime change. Added hosted scans and cold workflow-validation tests increase CI work. Job durations and scan records are available in the linked runs; no product performance claim is made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added CodeQL analysis for Rust, JavaScript/TypeScript, and GitHub Actions.
  * Added strict dependency review checks for pull requests and changes to the main branch.
  * CI now requires security checks to pass before reporting success.
  * Strengthened workflow protections by preventing checkout credential persistence and enforcing approved, immutable actions.
  * Improved validation to reject incomplete dependency metadata and unsuccessful security results.

* **Documentation**
  * Added guidance covering security checks, coverage, limitations, and rollback procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->