### PR TITLE
fix(ci): keep Mermaid output inside shared checkout

### DIFF
--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -173,7 +173,7 @@ fn check_mermaid_msys_structure(renderer: &str) -> Result<(), String> {
         "running_under_msys() {",
         "docker_host_path() {",
         "prepare_docker_output_dir() {",
-        "render_dir=$(mktemp -d /tmp/keld-mermaid-render.XXXXXX)",
+        "render_dir=$(mktemp -d \"$render_parent/keld-mermaid-render.XXXXXX\")",
         "prepare_docker_output_dir \"$render_dir\"",
         "docker_render_dir=$(docker_host_path \"$render_dir\")",
         "export MSYS2_ARG_CONV_EXCL='*'",
@@ -1707,7 +1707,11 @@ fn check_mermaid_gate_files(root: &Path) -> Result<(), String> {
         "docker_host_path",
         "MSYS2_ARG_CONV_EXCL='*'",
         "trap cleanup EXIT",
-        "/tmp/keld-mermaid-render.",
+        r#"workspace=$(cd "$workspace" && pwd -P)"#,
+        r#"if [[ -L "$workspace/target" ]]; then"#,
+        r#"render_parent=$(cd "$workspace/target" && pwd -P)"#,
+        r#"[[ "$render_parent" == "$workspace/target" ]] || {"#,
+        r#""$render_parent"/keld-mermaid-render.*) rm -rf -- "$render_dir" ;;"#,
     ] {
         if !uncommented_line_contains(&renderer, needle) {
             return Err(format!(
@@ -2024,10 +2028,7 @@ mod tests {
         temp.write(AGENT_CONTEXT_CHECKER, "fn main() {}\n");
         temp.write(MERMAID_CHECKER, "fn main() {}\n");
         temp.write(NEXTEST_CONFIG, "[profile.ci]\n");
-        temp.write(
-            MERMAID_RENDERER,
-            "sha256:29077c6bd02f14bdfdd5fee552d9c00fe68d4fab3cd84952d21e2d1faf2fadaf\n--network none\n--read-only\n--cap-drop ALL\n--security-opt no-new-privileges\n--memory 2g\n--pids-limit 256\nrun_with_timeout 300 docker pull\n--pull never\n--jobs 2\n:/input/source.md:ro\ndocker_host_path\ntrap cleanup EXIT\n/tmp/keld-mermaid-render.\nrunning_under_msys() {\ncase \"$(uname -s 2>/dev/null || true)\" in\n}\ndocker_host_path() {\nif running_under_msys; then\ncygpath -am \"$path\"\n}\nprepare_docker_output_dir() {\nif running_under_msys; then\nchmod 0777 -- \"$path\" || {\n}\nrender_dir=$(mktemp -d /tmp/keld-mermaid-render.XXXXXX)\nprepare_docker_output_dir \"$render_dir\"\ndocker_render_dir=$(docker_host_path \"$render_dir\")\nexport MSYS2_ARG_CONV_EXCL='*'\nrun_with_timeout 120 docker run\n",
-        );
+        temp.write(MERMAID_RENDERER, include_str!("mermaid_render_check.sh"));
         temp.write(
             MERMAID_CONFIG,
             "{\"securityLevel\": \"strict\", \"maxTextSize\": 50000, \"maxEdges\": 500, \"deterministicIds\": true}\n",
@@ -3161,6 +3162,83 @@ mod tests {
         assert!(error.contains("--network none"), "{error}");
     }
 
+    #[test]
+    #[cfg(unix)]
+    fn mermaid_renderer_rejects_target_symlink_before_creating_output() {
+        use std::os::unix::fs::{PermissionsExt as _, symlink};
+        use std::process::Command;
+
+        let temp = TempDir::new();
+        let checkout = temp.path().join("checkout with spaces");
+        let external = temp.path().join("external");
+        fs::create_dir(&checkout).expect("checkout directory");
+        fs::create_dir(&external).expect("external directory");
+        symlink(&external, checkout.join("target")).expect("escaping target symlink");
+        assert!(
+            Command::new("git")
+                .args(["init", "--quiet"])
+                .arg(&checkout)
+                .status()
+                .expect("initialize fixture")
+                .success()
+        );
+        fs::write(
+            checkout.join("diagram.md"),
+            "```mermaid\nflowchart LR\n A-->B\n```\n",
+        )
+        .expect("tracked diagram");
+        assert!(
+            Command::new("git")
+                .args(["add", "diagram.md"])
+                .current_dir(&checkout)
+                .status()
+                .expect("track diagram")
+                .success()
+        );
+        fs::create_dir(checkout.join("tools")).expect("fixture tools");
+        fs::write(checkout.join(MERMAID_CONFIG), "{}").expect("config fixture");
+        temp.write("renderer.sh", include_str!("mermaid_render_check.sh"));
+        temp.write("bin/docker", "#!/usr/bin/env bash\ncase \"$1\" in\ninfo|image) exit 0 ;;\ncontext) printf 'unix:///unused-kel188.sock\\n' ;;\n*) exit 42 ;;\nesac\n");
+        let docker = temp.path().join("bin/docker");
+        fs::set_permissions(&docker, fs::Permissions::from_mode(0o700)).expect("driver executable");
+        let mut paths = vec![temp.path().join("bin")];
+        paths.extend(env::split_paths(&env::var_os("PATH").expect("tool PATH")));
+        let output = Command::new("bash")
+            .arg(temp.path().join("renderer.sh"))
+            .current_dir(&checkout)
+            .env("PATH", env::join_paths(paths).expect("fixture PATH"))
+            .output()
+            .expect("execute real renderer script");
+        assert!(!output.status.success());
+        assert!(
+            fs::read_dir(&external)
+                .expect("external observation")
+                .next()
+                .is_none(),
+            "renderer created output outside its checkout"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("non-symlink directory"),
+            "wrong failure boundary: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn mermaid_output_outside_the_shared_checkout_fails() {
+        let temp = complete_fixture();
+        temp.write(
+            MERMAID_RENDERER,
+            &read(temp.path(), MERMAID_RENDERER)
+                .expect("renderer fixture")
+                .replace(
+                    "$render_parent/keld-mermaid-render.",
+                    "/tmp/keld-mermaid-render.",
+                ),
+        );
+        let error = check(temp.path()).expect_err("output must share the checkout mount boundary");
+        assert!(error.contains("render_dir"), "{error}");
+    }
     #[test]
     fn missing_mermaid_msys_path_exclusion_fails() {
         let temp = complete_fixture();

--- a/tools/mermaid_render_check.sh
+++ b/tools/mermaid_render_check.sh
@@ -99,6 +99,7 @@ workspace=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo 'KELD-DOCS006: not inside the Keld Git checkout. Change to the repository root, then rerun `just mermaid-render-check`.' >&2
   exit 1
 }
+workspace=$(cd "$workspace" && pwd -P)
 readonly workspace
 readonly render_config="$workspace/tools/mermaid-render-config.json"
 [[ -f "$render_config" ]] || {
@@ -141,7 +142,7 @@ cleanup() {
   fi
   if [[ "$render_succeeded" == 1 && "$keep_output" == 0 && -n "$render_dir" ]]; then
     case "$render_dir" in
-      /tmp/keld-mermaid-render.*) rm -rf -- "$render_dir" ;;
+      "$render_parent"/keld-mermaid-render.*) rm -rf -- "$render_dir" ;;
       *)
         echo "KELD-DOCS006: refused to clean unexpected render path '$render_dir'. Remove it manually after inspection." >&2
         ;;
@@ -152,7 +153,20 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 130' INT TERM HUP
 
-render_dir=$(mktemp -d /tmp/keld-mermaid-render.XXXXXX)
+# Keep the writable bind alongside the already-shared checkout. Docker Desktop
+# on Linux may share the checkout while rejecting the host /tmp directory.
+if [[ -L "$workspace/target" ]]; then
+  echo 'KELD-DOCS006: renderer target must be a non-symlink directory inside the checkout. Use a regular target directory, then rerun.' >&2
+  exit 1
+fi
+mkdir -p "$workspace/target"
+render_parent=$(cd "$workspace/target" && pwd -P)
+[[ "$render_parent" == "$workspace/target" ]] || {
+  echo 'KELD-DOCS006: renderer target must be a non-symlink directory inside the checkout. Restore its checkout-local path, then rerun.' >&2
+  exit 1
+}
+readonly render_parent
+render_dir=$(mktemp -d "$render_parent/keld-mermaid-render.XXXXXX")
 readonly render_dir
 prepare_docker_output_dir "$render_dir"
 docker_render_dir=$(docker_host_path "$render_dir")


### PR DESCRIPTION
## Summary
Docker Desktop on Linux can read a shared checkout while rejecting the renderer's hardcoded `/tmp` output bind. Allocate the private output under the checkout's canonical `target` directory, reject symlink/escaping target paths before creating output, and use that validated path for cleanup. The renderer image, non-root user and isolation flags are unchanged. The hygiene fixture now consumes the owning script instead of mirroring it.

## Spec refs
KEL-188, acceptance evidence KEL-183. No boundary change. Existing documentation renderer contract in `.agents/docs.md` and `tools/mermaid_render_check.sh`.

## Review gates
None. Independent path-containment/failure-preservation refuter verified the final diff SHA256 `5f45012f56daedc3d830d51ed8849f2ff41b636459dc77b84f2d60164d386101`. Fresh CodeRabbit CLI review: zero findings. Independent isolated reviewer `/root/renderer_review` passed real shell/filesystem containment, failure, retention, deletion and symlink negatives on this exact diff; probe/report archived with refreshed evidence. Its initial symlink finding was independently reproduced and fixed.

## Tests
Refreshed exact head `f8abe5b5fe15a4aeda6b4a64887f4cd97c8d8d24`, tree `d4a376795cbb17db66f2bd010ccb633c512d63c1`, on main `9938713`. Full gate rerun 2026-09-08: exit 0, 577/577 workspace tests plus 2 configured skips. Original proof remains attached to KEL-188.

- Exact `just ci` exits 0 on the final tree with issue-local Bun 1.4.0+34cbb9a40 and `DOCKER_CONTEXT=desktop-linux`: format, warning-denied workspace Clippy, 577 workspace tests passed / 2 skipped, TypeScript 41/41, rustdoc, deny and every local conditional gate.
- Failure-first real-script regression with `target -> external` failed on the initial patch and now passes; external directory stays unchanged. Hygiene: 81 tests pass.
- Actual immutable Mermaid CLI 11.16.0 render: 9 accessible SVGs, success cleanup verified. Malformed-diagram negative exits 1 and retains mode-0700 diagnostics; original source restored. Pinned PNG export inspected for readable labels and relationships.
- Renderer digest: `sha256:29077c6bd02f14bdfdd5fee552d9c00fe68d4fab3cd84952d21e2d1faf2fadaf`.

## Platforms
Physical Ubuntu 26.04.1 x86_64 GNOME Wayland; Docker Desktop 4.89.0. No new Docker shares, privileges or permission changes. Mac/Windows behavior is not inferred from this run. KEL-152/#166 separately owns retained-output MSYS permission restoration; both its restore/removal `/tmp` allowlists and matching hygiene predicates must rebase to `"$render_parent"/keld-mermaid-render.*`, preserving this real-script fixture and symlink negatives. Independent integration fixture confirms its old restoration rejects the new path. Windows acceptance remains with KEL-152; no cleanup commit is imported here.

## Perf impact
No product performance claim; only cold documentation temporary-file placement changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mermaid rendering now stores temporary output within the workspace instead of the system temporary directory.
  * Added validation to reject symlinked or externally located output directories.
  * Cleanup is restricted to workspace-local render directories.

* **Tests**
  * Expanded coverage for symlinked target directories and output paths outside the checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->