### PR TITLE
fix(core): order initial recovery admission before shutdown

### DIFF
--- a/crates/keld-core/src/app_session.rs
+++ b/crates/keld-core/src/app_session.rs
@@ -2462,11 +2462,15 @@ impl GuardianOwnerHandle {
         let _ = self.command_tx.send(GuardianOwnerCommand::DenyRecovery);
     }
 
-    fn arm_recovery(&self) -> Result<(), HostAppError> {
+    fn request_recovery_arm(&self) -> Result<Receiver<Result<(), String>>, HostAppError> {
         let (reply_tx, reply_rx) = mpsc::sync_channel(1);
         self.command_tx
             .send(GuardianOwnerCommand::ArmRecovery(reply_tx))
             .map_err(|_| app_detail("primary recovery arm", "guardian owner stopped"))?;
+        Ok(reply_rx)
+    }
+
+    fn await_recovery_arm(reply_rx: Receiver<Result<(), String>>) -> Result<(), HostAppError> {
         match reply_rx.recv_timeout(GUARDIAN_OWNER_REPLY_DEADLINE) {
             Ok(Ok(())) => Ok(()),
             Ok(Err(detail)) => Err(app_detail("primary recovery arm", detail)),
@@ -2862,11 +2866,15 @@ impl DirectPrimaryOwnerHandle {
             .send(DirectPrimaryOwnerCommand::DenyRecovery);
     }
 
-    fn arm_recovery(&self) -> Result<(), HostAppError> {
-        self.request(
+    fn request_recovery_arm(&self) -> Result<Receiver<Result<(), String>>, HostAppError> {
+        self.enqueue_request(
             DirectPrimaryOwnerCommand::ArmRecovery,
             "primary recovery arm",
         )
+    }
+
+    fn await_recovery_arm(reply_rx: Receiver<Result<(), String>>) -> Result<(), HostAppError> {
+        receive_direct_owner_reply(&reply_rx, "primary recovery arm", false)
     }
 
     fn fail_generation(&self, attempt: u32) -> Result<(), HostAppError> {
@@ -2901,11 +2909,20 @@ impl DirectPrimaryOwnerHandle {
         command: impl FnOnce(mpsc::SyncSender<Result<(), String>>) -> DirectPrimaryOwnerCommand,
         phase: &'static str,
     ) -> Result<(), HostAppError> {
+        let reply_rx = self.enqueue_request(command, phase)?;
+        receive_direct_owner_reply(&reply_rx, phase, false)
+    }
+
+    fn enqueue_request(
+        &self,
+        command: impl FnOnce(mpsc::SyncSender<Result<(), String>>) -> DirectPrimaryOwnerCommand,
+        phase: &'static str,
+    ) -> Result<Receiver<Result<(), String>>, HostAppError> {
         let (reply_tx, reply_rx) = mpsc::sync_channel(1);
         self.command_tx
             .send(command(reply_tx))
             .map_err(|_| app_detail(phase, "owner stopped"))?;
-        receive_direct_owner_reply(&reply_rx, phase, false)
+        Ok(reply_rx)
     }
 }
 
@@ -2976,20 +2993,29 @@ struct ActivePrimaryGeneration {
 #[cfg(any(target_os = "macos", target_os = "linux", windows))]
 impl PrimaryRouterHandle {
     fn signal_ready(&self) -> Result<(), HostAppError> {
-        if self.recovery_armed.load(Ordering::Acquire) {
-            self.write_event(LifecycleEvent::Ready)?;
+        let arm_reply = {
+            let _transition = self.shutdown.transition_guard();
+            if !self.shutdown.is_running() {
+                return Ok(());
+            }
+            if self.recovery_armed.load(Ordering::Acquire) {
+                self.write_event_guarded(LifecycleEvent::Ready)?;
+                self.window_ready.store(true, Ordering::Release);
+                return Ok(());
+            }
+            if let Err(error) = self.write_event_guarded(LifecycleEvent::Ready) {
+                self.guardian.deny_recovery();
+                return Err(error);
+            }
+            // Publish Ready and enqueue its arm under the same transition as
+            // accepted shutdown. A later tail cannot overtake this command.
             self.window_ready.store(true, Ordering::Release);
-            return Ok(());
-        }
-        if let Err(error) = self.write_event(LifecycleEvent::Ready) {
-            self.guardian.deny_recovery();
-            return Err(error);
-        }
-        // Ready is now externally observable. Mark that fact before waiting
-        // for the guardian-owner acknowledgment; runtime's Pending decision
-        // blocks successor preparation during this interval.
-        self.window_ready.store(true, Ordering::Release);
-        if let Err(error) = self.guardian.arm_recovery() {
+            self.guardian.request_recovery_arm()
+        };
+        // The owner can process generation updates requiring the transition
+        // guard before acknowledging. Never hold that guard across this wait.
+        let arm = arm_reply.and_then(PlatformPrimaryOwnerHandle::await_recovery_arm);
+        if let Err(error) = arm {
             self.guardian.deny_recovery();
             return Err(error);
         }
@@ -3003,8 +3029,14 @@ impl PrimaryRouterHandle {
     }
 
     fn write_event(&self, event: LifecycleEvent) -> Result<(), HostAppError> {
-        let payload = encode(&event).map_err(|source| app_ipc("lifecycle event", &source))?;
         let _transition = self.shutdown.transition_guard();
+        self.write_event_guarded(event)
+    }
+
+    // Caller retains shutdown.transition through the write and any admission
+    // command that must precede a terminal claim.
+    fn write_event_guarded(&self, event: LifecycleEvent) -> Result<(), HostAppError> {
+        let payload = encode(&event).map_err(|source| app_ipc("lifecycle event", &source))?;
         let mut current = self
             .current
             .lock()
@@ -4388,6 +4420,130 @@ mod tests {
         );
         router.shutdown().expect("Quit race router shutdown");
         guardian_thread.join().expect("Quit race guardian joins");
+    }
+
+    #[cfg(target_os = "linux")]
+    use DirectPrimaryOwnerCommand as TestPrimaryOwnerCommand;
+    #[cfg(target_os = "macos")]
+    use GuardianOwnerCommand as TestPrimaryOwnerCommand;
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn initial_ready_router() -> (
+        PrimaryRouterHandle,
+        std::os::unix::net::UnixStream,
+        Receiver<TestPrimaryOwnerCommand>,
+    ) {
+        let (server, client) = std::os::unix::net::UnixStream::pair().expect("Ready stream pair");
+        let (command_tx, command_rx) = mpsc::channel();
+        let (window_tx, _window_rx) = mpsc::channel();
+        let handle = PrimaryRouterHandle {
+            current: Arc::new(Mutex::new(Some(ActivePrimaryGeneration {
+                attempt: 1,
+                writer: server,
+            }))),
+            readers: Arc::new(Mutex::new(HashMap::new())),
+            window_ready: Arc::new(AtomicBool::new(false)),
+            last_window_closed: Arc::new(AtomicBool::new(false)),
+            recovery_armed: Arc::new(AtomicBool::new(false)),
+            last_revoked_attempt: Arc::new(AtomicU32::new(0)),
+            shutdown: SessionShutdownState::new(),
+            guardian: PlatformPrimaryOwnerHandle { command_tx },
+            window_commands: window_tx,
+        };
+        (handle, client, command_rx)
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn initial_ready_after_accepted_shutdown_does_not_arm_a_stopped_owner() {
+        use std::io::Read as _;
+
+        let (handle, mut client, command_rx) = initial_ready_router();
+        assert!(handle.shutdown.claim_cli_lease_lost());
+        drop(command_rx); // The accepted tail has already stopped its owner.
+        handle
+            .signal_ready()
+            .expect("late navigation must not restart admission");
+        assert!(!handle.window_ready.load(Ordering::Acquire));
+        assert!(!handle.recovery_armed.load(Ordering::Acquire));
+        client
+            .set_nonblocking(true)
+            .expect("observe absence without waiting");
+        let error = client
+            .read(&mut [0])
+            .expect_err("late Ready must write no bytes");
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn initial_ready_releases_transition_before_owner_acknowledgment() {
+        let (handle, mut client, command_rx) = initial_ready_router();
+        let shutdown = handle.shutdown.clone();
+        let ready = Arc::clone(&handle.window_ready);
+        let owner = thread::spawn(move || {
+            let TestPrimaryOwnerCommand::ArmRecovery(reply) =
+                command_rx.recv().expect("arm request")
+            else {
+                panic!("first owner command must arm recovery");
+            };
+            // A real owner may need this lock while applying a generation
+            // update before it can acknowledge the already-enqueued arm.
+            let _transition = shutdown.transition_guard();
+            assert!(ready.load(Ordering::Acquire));
+            reply.send(Ok(())).expect("arm acknowledgment");
+        });
+        handle
+            .signal_ready()
+            .expect("owner callback must not deadlock");
+        let (header, payload) = keld_ipc::link::read_frame(&mut client).expect("Ready bytes");
+        assert_eq!(header.kind, FrameKind::Event);
+        assert_eq!(header.channel, LIFECYCLE_CHANNEL);
+        assert_eq!(header.corr, CorrelationId(0));
+        assert_eq!(payload, [0]); // Rust lifecycle Ready postcard discriminant.
+        assert!(handle.recovery_armed.load(Ordering::Acquire));
+        owner.join().expect("owner callback joins");
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn initial_ready_preserves_unaccepted_owner_failures() {
+        let (handle, _client, command_rx) = initial_ready_router();
+        drop(command_rx);
+        let error = handle
+            .signal_ready()
+            .expect_err("a missing live-session owner is a fault");
+        assert!(error.to_string().contains("KELD-CORE-037"), "{error}");
+        assert!(
+            error.to_string().contains("primary recovery arm"),
+            "{error}"
+        );
+
+        for reject in [true, false] {
+            let (handle, _client, command_rx) = initial_ready_router();
+            let owner = thread::spawn(move || {
+                let TestPrimaryOwnerCommand::ArmRecovery(reply) =
+                    command_rx.recv().expect("arm request")
+                else {
+                    panic!("first owner command must arm recovery");
+                };
+                if reject {
+                    reply
+                        .send(Err(String::from("forced arm refusal")))
+                        .expect("refusal reply");
+                }
+                // Dropping the reply without acknowledgment remains a real error.
+            });
+            let error = handle
+                .signal_ready()
+                .expect_err("arm fault must remain visible");
+            assert!(error.to_string().contains("KELD-CORE-037"), "{error}");
+            if reject {
+                assert!(error.to_string().contains("forced arm refusal"), "{error}");
+            }
+            assert!(!handle.recovery_armed.load(Ordering::Acquire));
+            owner.join().expect("owner probe joins");
+        }
     }
 
     #[test]

--- a/crates/keld-core/src/app_session.rs
+++ b/crates/keld-core/src/app_session.rs
@@ -1312,7 +1312,7 @@ fn run_app(
     boot: AppBootSelection,
     guard_snapshot: Option<&GuardSnapshot>,
 ) -> Result<(), HostAppError> {
-    let dev_lease = DevHostLease::from_environment()?;
+    let mut dev_lease = DevHostLease::from_environment()?;
     let shutdown = SessionShutdownState::new();
     let AppBootSelection {
         root,
@@ -1353,11 +1353,15 @@ fn run_app(
         .register_guarded_primary_until(Instant::now() + APP_LINK_IO_DEADLINE)
         .map_err(|source| app_runtime("guardian registration", &source))?;
     LISTENER_ATTEMPTS.fetch_add(1, Ordering::AcqRel);
-    let initial = await_bound_generation(
+    let Some(initial) = await_bound_generation(
         &mut guardian,
+        dev_lease.as_mut(),
         Instant::now() + APP_LINK_IO_DEADLINE,
         "initial app-link authentication",
-    )?;
+    )?
+    else {
+        return Ok(());
+    };
 
     let (window_commands_tx, window_commands_rx) = mpsc::channel();
     let guardian_owner = GuardianOwner::start(
@@ -2163,10 +2167,23 @@ fn finish_guarded_session<T>(
 #[cfg(target_os = "macos")]
 fn await_bound_generation(
     guardian: &mut GuardedPrimary,
+    mut dev_lease: Option<&mut DevHostLease>,
     deadline: Instant,
     phase: &'static str,
-) -> Result<BoundPrimaryGeneration, HostAppError> {
+) -> Result<Option<BoundPrimaryGeneration>, HostAppError> {
     loop {
+        if let Some(lease) = dev_lease.as_deref_mut()
+            && lease.poll_lost()?
+        {
+            guardian.deny_recovery();
+            guardian
+                .accept_shutdown()
+                .map_err(|source| app_runtime("accepted startup cancellation", &source))?;
+            guardian
+                .shutdown()
+                .map_err(|source| app_guardian_fatal("accepted startup cancellation", &source))?;
+            return Ok(None);
+        }
         let now = Instant::now();
         if now >= deadline {
             guardian.deny_recovery();
@@ -2175,9 +2192,13 @@ fn await_bound_generation(
                 "Bun did not authenticate before the generation deadline",
             ));
         }
-        if let Some(update) = guardian.recv_update(deadline.saturating_duration_since(now)) {
+        if let Some(update) = guardian.recv_update(
+            deadline
+                .saturating_duration_since(now)
+                .min(APP_LINK_READER_POLL),
+        ) {
             match update {
-                GuardedPrimaryUpdate::Bound(bound) => return Ok(bound),
+                GuardedPrimaryUpdate::Bound(bound) => return Ok(Some(bound)),
                 GuardedPrimaryUpdate::Role(PrimaryRoleEvent::Revoked { .. }) => {
                     guardian.deny_recovery();
                     return Err(app_detail(

--- a/crates/keld-core/src/app_session.rs
+++ b/crates/keld-core/src/app_session.rs
@@ -2470,7 +2470,7 @@ impl GuardianOwnerHandle {
         Ok(reply_rx)
     }
 
-    fn await_recovery_arm(reply_rx: Receiver<Result<(), String>>) -> Result<(), HostAppError> {
+    fn await_recovery_arm(reply_rx: &Receiver<Result<(), String>>) -> Result<(), HostAppError> {
         match reply_rx.recv_timeout(GUARDIAN_OWNER_REPLY_DEADLINE) {
             Ok(Ok(())) => Ok(()),
             Ok(Err(detail)) => Err(app_detail("primary recovery arm", detail)),
@@ -2873,8 +2873,8 @@ impl DirectPrimaryOwnerHandle {
         )
     }
 
-    fn await_recovery_arm(reply_rx: Receiver<Result<(), String>>) -> Result<(), HostAppError> {
-        receive_direct_owner_reply(&reply_rx, "primary recovery arm", false)
+    fn await_recovery_arm(reply_rx: &Receiver<Result<(), String>>) -> Result<(), HostAppError> {
+        receive_direct_owner_reply(reply_rx, "primary recovery arm", false)
     }
 
     fn fail_generation(&self, attempt: u32) -> Result<(), HostAppError> {
@@ -3014,7 +3014,8 @@ impl PrimaryRouterHandle {
         };
         // The owner can process generation updates requiring the transition
         // guard before acknowledging. Never hold that guard across this wait.
-        let arm = arm_reply.and_then(PlatformPrimaryOwnerHandle::await_recovery_arm);
+        let arm =
+            arm_reply.and_then(|reply| PlatformPrimaryOwnerHandle::await_recovery_arm(&reply));
         if let Err(error) = arm {
             self.guardian.deny_recovery();
             return Err(error);

--- a/crates/keld-host/src/main.rs
+++ b/crates/keld-host/src/main.rs
@@ -232,14 +232,7 @@ fn run_supervised_guardian(args: &[String]) -> Result<(), String> {
             "KELD-CORE-037: supervised Bun guardian failed — {error}. Fix the Bun app failure and relaunch the no-flag host."
         )
     });
-    let report = match (report, cleanup) {
-        (Ok(report), Ok(())) => report,
-        (Err(primary), Ok(())) => return Err(primary),
-        (Ok(_), Err(cleanup)) => return Err(cleanup),
-        (Err(primary), Err(cleanup)) => {
-            return Err(format!("{primary} Additional cleanup failure: {cleanup}"));
-        }
-    };
+    let (report, cleanup_failure) = reconcile_guardian_result(report, cleanup)?;
     let stdout_notice = keld_runtime::CapturedOutput::elision_notice(report.stdout_dropped_bytes)
         .unwrap_or_default();
     let stderr_notice = keld_runtime::CapturedOutput::elision_notice(report.stderr_dropped_bytes)
@@ -250,7 +243,22 @@ fn run_supervised_guardian(args: &[String]) -> Result<(), String> {
         .and_then(|()| std::io::stderr().write_all(report.stderr.as_bytes()))
         .and_then(|()| std::io::stderr().write_all(stderr_notice.as_bytes()))
         .map_err(|source| format!("KELD-CORE-037: guardian stderr failed — {source}. Retry."))?;
-    Ok(())
+    cleanup_failure.map_or(Ok(()), Err)
+}
+
+#[cfg(target_os = "macos")]
+fn reconcile_guardian_result<T>(
+    report: Result<T, String>,
+    cleanup: Result<(), String>,
+) -> Result<(T, Option<String>), String> {
+    match (report, cleanup) {
+        (Ok(report), Ok(())) => Ok((report, None)),
+        (Err(primary), Ok(())) => Err(primary),
+        (Ok(report), Err(cleanup)) => Ok((report, Some(cleanup))),
+        (Err(primary), Err(cleanup)) => {
+            Err(format!("{primary} Additional cleanup failure: {cleanup}"))
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -309,7 +317,17 @@ mod tests {
     use std::fs;
     use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
 
-    use super::{dev_stage_cleanup_root_for, reopen_validated_entry};
+    use super::{dev_stage_cleanup_root_for, reconcile_guardian_result, reopen_validated_entry};
+
+    #[test]
+    fn successful_guardian_report_survives_cleanup_failure() {
+        let (report, cleanup_failure) =
+            reconcile_guardian_result(Ok("captured output"), Err(String::from("cleanup failed")))
+                .expect("successful report must remain available for diagnostics");
+
+        assert_eq!(report, "captured output");
+        assert_eq!(cleanup_failure.as_deref(), Some("cleanup failed"));
+    }
 
     #[test]
     fn dev_stage_cleanup_accepts_only_the_exact_private_nonce_layout() {

--- a/crates/keld-host/src/main.rs
+++ b/crates/keld-host/src/main.rs
@@ -17,8 +17,10 @@ use std::io::Write as _;
 use std::os::unix::fs::MetadataExt;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(target_os = "macos")]
+use std::path::Path;
 #[cfg(any(target_os = "macos", target_os = "linux", windows))]
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process;
 #[cfg(target_os = "macos")]
 use std::process::{Command, Stdio};
@@ -191,10 +193,14 @@ fn run_supervised_guardian(args: &[String]) -> Result<(), String> {
     // The guardian is the last process executing from the staged directory:
     // the host parent exits when its CLI lease closes. Re-derive the exact
     // nonce from this executable rather than trusting the role argument.
-    let cleanup_root = guardian_stage_cleanup_root(&root).ok();
+    let cleanup_root = guardian_stage_cleanup_root(&root);
+    let cleanup_validation = cleanup_root.clone();
     let report = keld_runtime::macos_guardian::run_guarded_primary(
         std::io::stdin(),
         move |app_link| {
+            cleanup_validation
+                .as_ref()
+                .map_err(|error| guardian_entry_error(error.clone()))?;
             let reopened = reopen_validated_entry(&root, &entry, expected_dev, expected_ino)?;
             // Advisory same-user dev-boundary check: retain the exact reopened
             // identity until immediately before Supervisor invokes spawn, then
@@ -213,13 +219,13 @@ fn run_supervised_guardian(args: &[String]) -> Result<(), String> {
         },
         std::io::stdout(),
     );
-    let cleanup = cleanup_root.map_or(Ok(()), |cleanup_root| {
-        fs::remove_dir_all(&cleanup_root).map_err(|source| {
-            format!(
-                "KELD-CORE-037: dev-stage cleanup failed for `{}` — {source}. Remove that owner-private nonce directory before relaunching.",
-                cleanup_root.display()
-            )
-        })
+    let cleanup = cleanup_root.and_then(|cleanup_root| match fs::remove_dir_all(&cleanup_root) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(format!(
+            "KELD-CORE-037: dev-stage cleanup failed for `{}` — {source}. Remove that owner-private nonce directory before relaunching.",
+            cleanup_root.display()
+        )),
     });
     let report = report.map_err(|error| {
         format!(

--- a/crates/keld-host/src/main.rs
+++ b/crates/keld-host/src/main.rs
@@ -18,7 +18,7 @@ use std::os::unix::fs::MetadataExt;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(any(target_os = "macos", target_os = "linux", windows))]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 #[cfg(target_os = "macos")]
 use std::process::{Command, Stdio};
@@ -101,6 +101,7 @@ fn main() {
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     if let Some(root) = dev_stage_cleanup
         && let Err(source) = fs::remove_dir_all(&root)
+        && source.kind() != std::io::ErrorKind::NotFound
     {
         eprintln!(
             "KELD-CORE-037: dev-stage cleanup failed for `{}` — {source}. Remove that owner-private nonce directory before relaunching.",
@@ -187,6 +188,10 @@ fn run_supervised_guardian(args: &[String]) -> Result<(), String> {
     let expected_ino = args[5]
         .parse::<u64>()
         .map_err(|source| format!("KELD-CORE-037: invalid private entry inode — {source}. Relaunch the validated no-flag host."))?;
+    // The guardian is the last process executing from the staged directory:
+    // the host parent exits when its CLI lease closes. Re-derive the exact
+    // nonce from this executable rather than trusting the role argument.
+    let cleanup_root = guardian_stage_cleanup_root(&root).ok();
     let report = keld_runtime::macos_guardian::run_guarded_primary(
         std::io::stdin(),
         move |app_link| {
@@ -207,12 +212,28 @@ fn run_supervised_guardian(args: &[String]) -> Result<(), String> {
             Ok(command)
         },
         std::io::stdout(),
-    )
-    .map_err(|error| {
+    );
+    let cleanup = cleanup_root.map_or(Ok(()), |cleanup_root| {
+        fs::remove_dir_all(&cleanup_root).map_err(|source| {
+            format!(
+                "KELD-CORE-037: dev-stage cleanup failed for `{}` — {source}. Remove that owner-private nonce directory before relaunching.",
+                cleanup_root.display()
+            )
+        })
+    });
+    let report = report.map_err(|error| {
         format!(
             "KELD-CORE-037: supervised Bun guardian failed — {error}. Fix the Bun app failure and relaunch the no-flag host."
         )
-    })?;
+    });
+    let report = match (report, cleanup) {
+        (Ok(report), Ok(())) => report,
+        (Err(primary), Ok(())) => return Err(primary),
+        (Ok(_), Err(cleanup)) => return Err(cleanup),
+        (Err(primary), Err(cleanup)) => {
+            return Err(format!("{primary} Additional cleanup failure: {cleanup}"));
+        }
+    };
     let stdout_notice = keld_runtime::CapturedOutput::elision_notice(report.stdout_dropped_bytes)
         .unwrap_or_default();
     let stderr_notice = keld_runtime::CapturedOutput::elision_notice(report.stderr_dropped_bytes)
@@ -224,6 +245,28 @@ fn run_supervised_guardian(args: &[String]) -> Result<(), String> {
         .and_then(|()| std::io::stderr().write_all(stderr_notice.as_bytes()))
         .map_err(|source| format!("KELD-CORE-037: guardian stderr failed — {source}. Retry."))?;
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn guardian_stage_cleanup_root(argument: &Path) -> Result<PathBuf, String> {
+    let executable = env::current_exe().map_err(|source| {
+        format!(
+            "KELD-CORE-037: guardian stage identity failed — {source}. Relaunch through `keld dev`."
+        )
+    })?;
+    let expected = dev_stage_cleanup_root_for(&executable, Some(std::ffi::OsStr::new("stdin-v1")))
+        .ok_or_else(|| String::from("KELD-CORE-037: guardian is not executing from a validated private dev stage. Relaunch through `keld dev`."))?;
+    let argument = argument.canonicalize().map_err(|source| {
+        format!(
+            "KELD-CORE-037: guardian stage identity failed — {source}. Relaunch through `keld dev`."
+        )
+    })?;
+    if argument != expected {
+        return Err(String::from(
+            "KELD-CORE-037: guardian stage argument does not match its validated executable stage. Relaunch through `keld dev`.",
+        ));
+    }
+    Ok(expected)
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

An accepted startup shutdown could be followed by native Ready handling that attempted to arm an already-stopped primary owner, emitting KELD-CORE-037 during normal cancellation. Keep the existing shutdown transition guard through the running check, Ready publication and ArmRecovery enqueue, then release it before awaiting acknowledgment. Genuine owner refusal, disappearance and disconnected replies remain typed errors.

## Spec refs

KEL-187; approved `docs/specs/kel96-no-flag-host-boot.md` lifecycle contract. No boundary change. Reuses the existing router, shutdown guard and platform owner queues.

## Review gates

None: no unsafe, public API, permission model, dependency addition or wire protocol change. GitHub updated head to `f00dfd6b2ca0315a7c26c39034019e2169c868fd` by merging main `5b756ca86af7e5c412231e531ffd6df119d16b12` into the reviewed `f8fd8502b30c64633b1811cb03fa5c61751d884f`. Only `crates/keld-core/src/app_session.rs` differs from current main. Old and new lifecycle diffs have identical SHA-256 `52c60de5156dd9ec27aa97a8ab7ca1bf0fcfe0f3a6bb4a776357c9413fe7e0ac`; the main update adds only PR201's draft spec.

## Tests

- Exact current head `f00dfd6` passed `DOCKER_CONTEXT=desktop-linux just ci`: 612 workspace tests, 2 configured skips, 41 Bun tests. Format, workspace clippy with warnings denied and all repository gates passed. Log: `/tmp/kel187-main-merge-final-ci.log`.
- Current hosted run [34437014480](https://github.com/gyldlab/keld/actions/runs/34437014480) passed all applicable checks, including Ubuntu, macOS, Windows and Linux GUI. Zero current unresolved review threads. CodeRabbit is rate-limited; the prior isolated review covers the byte-identical lifecycle diff recorded above.
- Historical physical Ubuntu evidence at `e200a5e5d1b378868561ca37b55e4b58753ef5d5`: two rendered interruption/relaunch samples with visible frame/heading, actual Bun hash, SIGINT exit, observed pidfd cleanup and no fresh nonce stage. This does not prove interruption before Ready or exhaustive descendants, and was not rerun on the rebased head.
- Immutable KEL-187 attachment `67bb6572-7f44-4e47-b235-c028be4d87b4`, SHA-256 `ced66e90d0b546d55ccfd7f6c578aee132c4ccaf0f49b74d4e0902493c59802d`, retains prior native evidence and deterministic failure-first/negative controls.
- Exact-head isolated lifecycle review passed: three focused regression tests passed; removing the shutdown check and retaining the lock across acknowledgment each failed as expected. Original source was confirmed unchanged and its tests passed again after an experiment caused a shared Cargo-cache collision and the affected package artifacts were rebuilt. CodeRabbit was manually requested because its draft-skipped status was not a review.

## Platforms

Physical macOS and admitted Windows startup-interrupt, fully-ready-interrupt, relaunch and cleanup remain unrun with KEL-177 native owners; hosted CI does not discharge those rows. Windows uses existing KEL-164 admission. User decision to defer these physical rows is pending; keep draft until acceptance is reconciled. Native Close remains separate KEL-185/KEL-136 work.

## Perf impact

No performance claim. Existing startup synchronization only; no added steady-state work or dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS app-link authentication when the development host lease is lost, allowing the app to shut down cleanly instead of entering recovery.
  - Improved shutdown and recovery coordination to prevent late readiness signals from being processed incorrectly.
  - Improved handling and reporting of guardian cleanup failures.
  - Temporary development-stage directories are now cleaned up reliably, including when already missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->