### PR TITLE
test(runtime): spawn Drop fixture child directly

### DIFF
--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -2763,15 +2763,8 @@ mod tests {
 
     #[test]
     fn drop_reaps_a_long_running_child() {
-        #[cfg(unix)]
-        let long_running = "sleep 30";
-        #[cfg(windows)]
-        let long_running = "ping -n 31 127.0.0.1 >NUL";
-
-        let sup = Supervisor::start(RestartPolicy::default(), move || {
-            shell_command(long_running)
-        })
-        .expect("first spawn must succeed");
+        let sup = Supervisor::start(RestartPolicy::default(), long_running_command)
+            .expect("first spawn must succeed");
         let (pid, _) = recv_started(&sup);
         drop(sup);
 


### PR DESCRIPTION
## Summary

Use the existing direct-child fixture in `drop_reaps_a_long_running_child`. Its Windows shell wrapper left a `ping` grandchild holding inherited pipes. The test now uses `long_running_command`, which directly spawns `ping` on Windows and `sleep` on Unix. The Drop reap assertion is unchanged. Only this test changes (2 additions, 9 deletions).

Closes KEL-158. Final integration commit: `a033806cc4192633a2290479581c64b36664d7a2`, based on `678eea151fecffb9d9703b801ae531d91c25786c`. The rebased tree is identical to the previously approved `594f125`; no implementation was rewritten during integration.

## Spec refs

No boundary change. Existing supervision contract in `docs/architecture/06-runtime-and-tooling.md` section 1; KEL-118 sibling fixture is the precedent. Reuse of the shared `long_running_command` removes duplicated platform fixture construction. The separate descendant-capture/supervisor issue remains KEL-118/RT-02.

Prompt pins: Keld `43cab25dd13b3d7379e03c4662482d3f40ea1a40`, tracker parent `be8a16ebe6e5d7198ae5fb9b6f098fa1595eb1bb`, research `20eaea5eeda93473e021fa6ecd7a7f4cea22e17e`. Integration refresh fetched Keld main `678eea151fecffb9d9703b801ae531d91c25786c`, tracker main `37000678c2486ab56877761217ad65540e88a495`, research main `36786f447adf98c9b090f63b8effee9dcf7fb6d1`. Runtime-file pin delta includes #136 documentation, #145/#146 Linux integration and #153 poison recovery; the shared fixture and one-test scope remain valid. Open KEL-134/#191 is sequenced after this PR: the user confirmed its Mac session is inactive, and coordination is recorded on both Linear issues. No KEL-134 implementation or ownership was changed.

## Review gates

none

## Tests

Original Windows failure-first evidence, base `ab0d5b7`, fixed commit `466309c`:

```text
cargo nextest run --profile ci -p keld-runtime -E 'test(drop_reaps_a_long_running_child)'
Before: LEAK [0.784s], 1 passed (1 leaky), 69 skipped
After: PASS [0.403s], 1 passed, 69 skipped
Negative control (omit drop): FAIL [0.401s], exit 100
  child pid 6884 must be reaped on Drop
Restored: PASS [0.527s], 1 passed, 69 skipped, exit 0
```

These saved logs were re-read during integration. The entire `crates/keld-runtime/src/lib.rs` blob is unchanged from `466309c` to the final commit, so the original regression/negative-control evidence remains explicitly attributed to that original run.

Fresh final-commit Windows verification on Ramani, 2026-09-09:

```text
just ci                                                     exit 0
cargo fmt --all --check                                      passed
cargo clippy --workspace --all-targets -- -D warnings         exit 0 (8.87s)
cargo nextest run --workspace --profile ci                    exit 0
Summary [40.699s] 583 tests run: 583 passed (1 leaky), 3 skipped
PASS [0.686s] tests::drop_reaps_a_long_running_child
LEAK [3.498s] tests::natural_exit_does_not_wait_for_descendant_capture_eof_before_restart
cargo doc --workspace --no-deps, RUSTDOCFLAGS=-D warnings      exit 0
cargo deny check                                            exit 0
```

All remaining `just ci` gates also passed: instruction/context contracts, CI routing, checkout hooks, docs/status/index/hygiene, nine pinned Mermaid renders, TypeScript typecheck and 32 tests (10 Unix-only tests skipped). Cargo-deny emitted warnings but ended `advisories ok, bans ok, licenses ok, sources ok`.

Fresh isolated nextest command on the final commit: `PASS [0.377s]`, `1 passed, 69 skipped`, no LEAK, exit 0 (run `45422e04-062f-400a-b456-ab7b790c56cc`). Full gate run `3bb1899c-bff8-4942-bd08-497733b7b688`; retained local log `D:/WORK/kel158-ci-a033806.log`.

Historical workspace comparison: KEL-182 baseline at `9938713` recorded 581 passed with two named leaks (Drop and natural-exit); original candidate `466309c` recorded 581 passed with only natural-exit leaking. Current main has additional tests, so the fresh 583-test count is reported separately rather than treated as an identical census. The only fresh workspace leak is the natural-exit test named above.

## Platforms

Acceptance is CI-only, including the required `windows-latest` row. Real Windows local verification above is available; local Linux/macOS execution is unrun. Hosted Windows, Ubuntu and macOS Clippy/test rows, Linux GUI smoke, MSRV, rustfmt and gitleaks passed at the rebased final commit in [CI run 34311651223](https://github.com/gyldlab/keld/actions/runs/34311651223). The Windows Drop test passed in 0.381s with no LEAK; its runtime suite was 68 passed (1 leaky), 2 skipped, with only the separate natural-exit test leaking (3.039s). The macOS Drop test passed in 0.307s. Optional hosted TypeScript/cargo-deny/template lanes were skipped by the router; the full local superset exercised the applicable local gates.

Independent isolated reviewer `/root/review_kel158`, lens test contract/regression sensitivity and fixture resource ownership, reviewed exact `a033806` from repo+diff without author rationale. No findings. Independently ran the freshly built Windows test executable: `1 passed; 0 failed; 32 filtered out; 0.37s`, exit 0, and verified exact HEAD/clean tree. No reviewer edits/rebuilds; original negative-control proof is attributed above. This satisfies the workflow's current-head isolated substitute; CodeRabbit's older source review and merge carry-forward are not claimed as a fresh review. No findings required refutation and no review comments remain to resolve.

## Perf impact

none; test fixture cleanup only.