### PR TITLE
fix(wv): deny WebView2 popups before navigation

### DIFF
--- a/crates/keld-wv/AGENTS.md
+++ b/crates/keld-wv/AGENTS.md
@@ -24,11 +24,11 @@ Spec: `docs/architecture/05-webview-and-native.md`. Platform truth: `docs/resear
   - Linux (wry interim): WebKitGTK 2.52.6 and wry 0.56.1 default-deny an
     unhandled new request, but that fallback is not proof Keld evaluated the
     right principal/manifest ([source](https://webkitgtk.org/reference/webkit2gtk/stable/class.UserMediaPermissionRequest.html)); explicit callback provenance remains mandatory.
-  - Windows (direct COM, KEL-65): agents MUST register the guarded
-    `add_PermissionRequested` handler before the first navigation — WebView2's
-    fallback is a user prompt (default-ask, not default-deny). The first
-    navigation MUST present the `GuardInstalled` proof; agents MUST NOT add a
-    second navigation path that bypasses it.
+  - Windows (direct COM, KEL-65): agents MUST register guarded
+    `add_PermissionRequested` and deny-all `add_NewWindowRequested` before
+    minting `GuardInstalled`; first navigation MUST require that proof. WebView2
+    defaults to media prompts and unguarded popups. Agents MUST NOT bypass
+    either handler or the first-navigation proof (KEL-168).
   Agents MUST NOT pass `AppProcess` to inherit `/app` media grants.
 - Architecture 01 §5 **first paint** is the KEL-64 external double-rAF image
   beacon on a pre-spawn monotonic clock — not wry `PageLoadEvent::Finished`,

--- a/crates/keld-wv/src/media.rs
+++ b/crates/keld-wv/src/media.rs
@@ -397,6 +397,24 @@ fn trace_linux_policy_decision(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn webview2_installs_popup_denial_before_guard_witness() {
+        // Source ordering is a regression tripwire, not live COM-installation proof.
+        // KEL-168's Windows popup probe supplies that independent OS observable.
+        let backend = include_str!("webview2/mod.rs");
+        let installer = backend
+            .split_once("fn install_guarded_media_permissions(")
+            .expect("Windows guard installer exists")
+            .1
+            .split_once("Ok(GuardInstalled(()))")
+            .expect("guard installer returns its navigation witness")
+            .0;
+        assert!(
+            installer.contains("webview.add_NewWindowRequested("),
+            "KEL-65 direct COM must deny popups before GuardInstalled: otherwise a new WebView2 escapes the guard and lifecycle registry"
+        );
+    }
+
     use super::*;
     use keld_guard::{DenyReason, parse_manifest};
 

--- a/crates/keld-wv/src/webview2/mod.rs
+++ b/crates/keld-wv/src/webview2/mod.rs
@@ -67,7 +67,8 @@ use webview2_com::Microsoft::Web::WebView2::Win32::{
 use webview2_com::{
     CoreWebView2EnvironmentOptions, CreateCoreWebView2ControllerCompletedHandler,
     CreateCoreWebView2EnvironmentCompletedHandler, ExecuteScriptCompletedHandler,
-    NavigationCompletedEventHandler, PermissionRequestedEventHandler, wait_with_pump,
+    NavigationCompletedEventHandler, NewWindowRequestedEventHandler,
+    PermissionRequestedEventHandler, wait_with_pump,
 };
 use windows::Win32::Foundation::{E_POINTER, E_UNEXPECTED, HWND, RECT};
 use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx};
@@ -245,7 +246,7 @@ fn create_controller(
     })
 }
 
-/// Proof that the `keld-guard` permission handler is registered on a webview.
+/// Proof that media permissions and popup denial are registered on a webview.
 ///
 /// [`navigate_initial`] demands it, so "content ran before the guard existed"
 /// is a compile error rather than a review catch. Only
@@ -298,6 +299,23 @@ fn install_guarded_media_permissions(
     // events on the creating thread.
     let registered = unsafe { webview.add_PermissionRequested(&handler, &raw mut token) };
     registered.map_err(|err| WvError::Webview(format!("permission handler: {err}")))?;
+
+    // Windows WebView2 (KEL-168): an unhandled new-window request creates a
+    // popup outside Keld's principal, permission, and lifecycle accounting.
+    // v0 denies every popup; SetHandled(true) without NewWindow loads nothing.
+    // https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventargs#put_handled
+    let popup_handler = NewWindowRequestedEventHandler::create(Box::new(|_, args| {
+        let Some(args) = args else {
+            return Err(windows::core::Error::from(E_POINTER));
+        };
+        // SAFETY: WebView2 supplies live event args on the creating STA thread
+        // for this callback. SetHandled takes a BOOL by value (contract above).
+        unsafe { args.SetHandled(true) }
+    }));
+    // SAFETY: `webview` and the writable token are live on the creating STA.
+    // WebView2 retains the COM handler and invokes it on that same thread.
+    unsafe { webview.add_NewWindowRequested(&popup_handler, &raw mut token) }
+        .map_err(|err| WvError::Webview(format!("popup handler: {err}")))?;
     Ok(GuardInstalled(()))
 }
 


### PR DESCRIPTION
## Summary

Deny WebView2 `window.open` requests before the first navigation. The direct COM backend previously let WebView2 create popups outside Keld's window registry. The existing guard installer now registers `NewWindowRequested`, propagates registration failures before returning `GuardInstalled`, and marks every popup request handled without supplying a new view.

## Spec refs

`docs/architecture/03-security.md` ?1; `docs/architecture/05-webview-and-native.md` ?1; KEL-168 and the existing Windows `GuardInstalled` owner.

KEL-132's landed Linux slice removed the issue's named source test. This PR adds a narrow Windows registration-order tripwire while preserving those Linux behavioral tests. Source matching is not runtime-denial proof.

## Review gates

- unsafe and permission model: passed, independent exact-diff review/refutation [record](https://github.com/gyldlab/keld/pull/188#issuecomment-5588778763).
- public API: none; dependency addition: none; wire protocol: none.
- Instruction review passed after executed baseline/candidate tasks. Canonical UTF-8/LF nested owner: 4029?4039 bytes; tiktoken 0.14.0/o200k_base: 1035?1038 tokens. Root+wv: 16887 bytes/3896 tokens after change. No budget increase.
- CodeRabbit is rate-limited on this head (it initially skipped the draft); the isolated review substitute covers the exact final diff. Its source-tripwire limitation was independently refuted as an issue-scope blocker using the live omitted-handler negative control.

## Tests

Exact head `e79780a02dab203a754bfc312c11b6cb851de7d1`:

- **`just ci` passed, exit 0**, through Git Bash with `/usr/bin` first on PATH. Includes format, workspace Clippy with `-D warnings`, full nextest, rustdoc, cargo-deny, TypeScript, instruction/docs/hygiene/router and pinned Mermaid rendering gates.
- Workspace nextest: **582 passed (2 existing leaky), 3 skipped**. The leaky tests are runtime `drop_reaps_a_long_running_child` and `natural_exit_does_not_wait_for_descendant_capture_eof_before_restart`; this popup PR does not claim to repair them.
- Failure-first popup source regression: unfixed production **0 passed/1 failed**; fixed media suite **10/10 passed**.
- Instruction gates: agent-context **13**, atomic protocol **19**, llms **6**, checkout/freshness pass. Nine automatic prompt traces complete. Actual isolated read-only evaluations executed the same six security/path, CI, docs, research, PR and ordinary-implementation tasks on baseline/candidate; independent review passed.
- [Hosted CI run](https://github.com/gyldlab/keld/actions/runs/34253414808): **CI required passed**, including Windows/macOS/Ubuntu Clippy + tests, Linux GUI smoke, MSRV, rustfmt, hygiene and gitleaks. Metadata gatekeeper/title pass.

## Platforms

**Real Windows 11 build 26200, Ramani; WebView2 Evergreen 152.0.4191.66**, confirmed by native browser-process image paths. A generated quick-start project exercised a 1-second timer and a native mouse click whose browser event reported `isTrusted=true`.

Independent EnumWindows and loopback receipts: unfixed **3 application windows/2 popup loads**; fixed **1/0**. Corrected end-to-end probe exits **0**, with no residual windows. Raw census retains the same-PID `Tao Thread Event Target` utility; only that identified helper is excluded from application-window counts. Applying the fixed oracle to baseline receipts fails `popup loaded`.

Parent microphone request returned `NotAllowedError` with no prompt. Baseline popups also denied microphone on this machine; microphone escalation was not observed or claimed. Native Close produced CLI exit 1 in both arms, recorded separately from popup acceptance. Defender stayed enabled with no new detection.

Retained script, oracle, original raw counts, final receipts/screenshots and browser paths: `D:/WORK/kel168-artifacts/` (`popup_probe.py`, `popup_oracle.py`, `baseline/`, `fixed/`, `fixed-final/`). macOS/Linux product behavior is unchanged; their hosted validation is listed above, not claimed as local device acceptance.

## Perf impact

None claimed. One creation-time event registration; the callback performs one COM state setter without steady-state allocation.

## Linear

https://linear.app/gyldlab-keld/issue/KEL-168/wvwindows-webview2-popups-escape-the-guard-no-newwindowrequested
