### PR TITLE
ci(bun): pin runtime validation to 1.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,10 @@ jobs:
       - name: Enable unprivileged user namespaces for Linux strict tests
         if: matrix.os == 'ubuntu-latest'
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-      # Exact pin (KEL-77): Bun 1.4.0 fixed kill-after-exit. Do not float `latest`.
+      # Exact pin (KEL-194); retain KEL-77 kill-after-exit regression coverage.
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.2"
       - name: clippy (warnings deny)
         shell: bash
         env:
@@ -212,10 +212,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # Exact pin (KEL-77): Bun 1.4.0 fixed kill-after-exit. Do not float `latest`.
+      # Exact pin (KEL-194); retain KEL-77 kill-after-exit regression coverage.
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.2"
       - name: frozen install, typecheck, and bun test
         shell: bash
         env:

--- a/crates/keld-runtime/tests/linux_strict_boundary.rs
+++ b/crates/keld-runtime/tests/linux_strict_boundary.rs
@@ -355,7 +355,7 @@ fn pinned_bun_starts_and_writes_only_inside_the_strict_role_root() {
         .output()
         .expect("Bun version");
     assert!(version.status.success());
-    assert_eq!(String::from_utf8_lossy(&version.stdout).trim(), "1.4.0");
+    assert_eq!(String::from_utf8_lossy(&version.stdout).trim(), "1.4.2");
     fs::write(
         role.path().join("main.ts"),
         "await Bun.write('/app/bun-strict-ok', 'bun-strict-ok\\n');\nconsole.log('KEL78_BUN_STRICT_PASS');\n",
@@ -387,7 +387,7 @@ fn pinned_bun_starts_and_writes_only_inside_the_strict_role_root() {
         b"bun-strict-ok\n"
     );
     eprintln!(
-        "KELD_LINUX_T4_BUN version=1.4.0 artifact_sha256={} status=passed",
+        "KELD_LINUX_T4_BUN version=1.4.2 artifact_sha256={} status=passed",
         file_sha256(&bun)
     );
 }
@@ -588,7 +588,7 @@ fn find_bun() -> std::path::PathBuf {
     std::env::split_paths(&std::env::var_os("PATH").expect("PATH"))
         .map(|directory| directory.join("bun"))
         .find(|candidate| candidate.is_file())
-        .expect("pinned Bun 1.4.0 on PATH")
+        .expect("pinned Bun 1.4.2 on PATH")
 }
 
 fn runtime_dependencies(program: &Path) -> Vec<(std::path::PathBuf, std::path::PathBuf)> {

--- a/crates/keld-runtime/tests/windows_lpac_boundary.rs
+++ b/crates/keld-runtime/tests/windows_lpac_boundary.rs
@@ -384,7 +384,7 @@ fn prove_bun_artifact_starts_under_lpac(
         .expect("read Bun LPAC output");
     assert_eq!(exit, 0, "Bun LPAC process failed; output: {observed}");
     assert!(
-        observed.contains("BUN_LPAC_OK 1.4.0"),
+        observed.contains("BUN_LPAC_OK 1.4.2"),
         "unexpected Bun LPAC output: {observed}"
     );
     print_bun_evidence(profile, &revision, &artifact_digest, census.len());

--- a/docs/onboarding/05-development-guide.md
+++ b/docs/onboarding/05-development-guide.md
@@ -25,7 +25,7 @@ For the complete verification gate, also install:
 | `cargo-deny` | Supply-chain checks (`cargo install cargo-deny --locked`) |
 | Docker-compatible engine | Runs the digest-pinned Mermaid renderer for `just ci` |
 
-Use the pinned Rust toolchain and **Bun 1.4.0 for the full workspace gate**, matching
+Use the pinned Rust toolchain and **Bun 1.4.2 for the full workspace gate**, matching
 CI and the exact Linux strict-fixture assertion. Record the selected version/revision;
 a demo observed with Bun 1.4.2 is separate evidence. The
 [quick-start prerequisites](README.md#prerequisites) also explain Linux trusted-checkout

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -11,14 +11,15 @@ wrapper or packaged application release to install yet.
 - Git and Rust installed through rustup. The checked-in
   [rust-toolchain.toml](../../rust-toolchain.toml) selects the compiler and components;
   Cargo uses the committed lockfile in the commands below.
-- Bun on `PATH`. **Use CI-pinned Bun 1.4.0 for `just ci` and the full workspace test
+- Bun on `PATH`. **Use CI-pinned Bun 1.4.2 for `just ci` and the full workspace test
   gate.** The [Linux strict fixture](../../crates/keld-runtime/tests/linux_strict_boundary.rs)
   asserts that exact version. Record `bun --version` and `bun --revision` before a
   run. Some earlier demo observations used Bun 1.4.2; the newer
   [Ubuntu](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871) and
   [Windows](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
-  quick-start observations used the pinned Bun 1.4.0. Only the pinned version satisfies
-  the current full gate. The scaffold has no package dependencies to install.
+  quick-start observations used the then-pinned Bun 1.4.0. Those dated observations
+  do not establish a current full-gate result. The scaffold has no package
+  dependencies to install.
 - A desktop session and platform build prerequisites:
 
   | Platform | Prerequisites and qualification |
@@ -161,11 +162,11 @@ the same output directory. A successful `doctor` alone is not a desktop acceptan
 Start with [CONTRIBUTING.md](../../CONTRIBUTING.md). Install `just`, `cargo-nextest`,
 and `cargo-deny` for the complete local gate; its Mermaid renderer also requires a
 running Docker-compatible engine. The exact gate inventory belongs to the
-[justfile](../../justfile). Put the CI-pinned Bun 1.4.0 binary on this shell's `PATH`
+[justfile](../../justfile). Put the CI-pinned Bun 1.4.2 binary on this shell's `PATH`
 without replacing another project's global runtime, then verify the selected version:
 
 ```bash
-bun --version   # must report 1.4.0 for the full gate
+bun --version   # must report 1.4.2 for the full gate
 bun --revision
 just ci
 ```

--- a/docs/specs/kel77-bun-child-process-differential.md
+++ b/docs/specs/kel77-bun-child-process-differential.md
@@ -3,6 +3,11 @@
 Status: approved
 Linear: KEL-77 · Owner: GYLDLAB · Updated: 2026-08-21 (Bun 1.4.0 CI pin + kill-after-exit rebaseline)
 
+Current CI pin (KEL-194, owner-approved 2026-09-08): **Bun 1.4.2**. This supersedes
+the earlier CI-pin instructions below; Bun 1.4.0 observations remain historical
+evidence. All child-process oracles, failure semantics and revision recording stay
+unchanged. [Selected release](https://bun.com/blog/bun-v1.4.2).
+
 ## 1. Goal & non-goals
 
 Keld ships a pinned Bun and supervises Bun children (architecture 06 §1), and the
@@ -27,7 +32,8 @@ Non-goals:
   is owned by KEL-74; this harness is a producer only.
 - Performance numbers of any kind. Semantic parity first (KEL-77 acceptance).
 - Any change to `keld-guard`, kipc frames, or the permission model. T1/T2 did not
-  edit CI; this follow-up pins `oven-sh/setup-bun` to exact `1.4.0` (never `latest`).
+  edit CI; the 2026-08-21 follow-up pinned `oven-sh/setup-bun` to exact `1.4.0`.
+  The current-pin note above supersedes that historical version; never use `latest`.
 - Windows and Linux *execution*. The harness is written to be OS-portable and records
   the platform it ran on; this slice claims macOS arm64 results only.
 
@@ -166,7 +172,7 @@ gates on two things that are both true on Bun 1.4.0 and both falsifiable:
 (The 1.3.x `kill()`-after-exit defect was pinned as an explicit fail until Bun 1.4
 fixed it; the fail pin was then deleted and case 5 joined the shared-pass corpus.)
 
-Deliberately *not* built: a revision-keyed baseline table. CI pins Bun to exact `1.4.0`
+Deliberately *not* built: a revision-keyed baseline table. CI pins Bun to the exact version named above
 via `oven-sh/setup-bun` `bun-version`; the Node version is still whatever the runner
 ships. A revision-keyed table for Node would spend most of its life unbaselined and
 would emit `unknown` for nearly every cell — machinery that weakens the gate instead of
@@ -339,6 +345,6 @@ Blocking human decisions before Status: approved.
 2. ~~**T2 is blocked, deliberately.**~~ **Resolved 2026-08-19:** KEL-74 merged as
    `8ff4cd6`. T2 serializes through `parse_evidence` on that freeze. `operation.kind`
    remains `primary_workflow` (named constant). No `runtime_semantics` fork.
-3. ~~**Baseline versus pinned Bun.**~~ **Resolved 2026-08-21:** CI pins
+3. ~~**Baseline versus pinned Bun.**~~ **Resolved 2026-08-21:** CI was pinned
    `oven-sh/setup-bun` to exact `1.4.0`. Do not float `latest`. Node on the runner
    still floats; revisions remain recorded per cell.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19,14 +19,15 @@ wrapper or packaged application release to install yet.
 - Git and Rust installed through rustup. The checked-in
   [rust-toolchain.toml](../../rust-toolchain.toml) selects the compiler and components;
   Cargo uses the committed lockfile in the commands below.
-- Bun on `PATH`. **Use CI-pinned Bun 1.4.0 for `just ci` and the full workspace test
+- Bun on `PATH`. **Use CI-pinned Bun 1.4.2 for `just ci` and the full workspace test
   gate.** The [Linux strict fixture](../../crates/keld-runtime/tests/linux_strict_boundary.rs)
   asserts that exact version. Record `bun --version` and `bun --revision` before a
   run. Some earlier demo observations used Bun 1.4.2; the newer
   [Ubuntu](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871) and
   [Windows](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
-  quick-start observations used the pinned Bun 1.4.0. Only the pinned version satisfies
-  the current full gate. The scaffold has no package dependencies to install.
+  quick-start observations used the then-pinned Bun 1.4.0. Those dated observations
+  do not establish a current full-gate result. The scaffold has no package
+  dependencies to install.
 - A desktop session and platform build prerequisites:
 
   | Platform | Prerequisites and qualification |
@@ -169,11 +170,11 @@ the same output directory. A successful `doctor` alone is not a desktop acceptan
 Start with [CONTRIBUTING.md](../../CONTRIBUTING.md). Install `just`, `cargo-nextest`,
 and `cargo-deny` for the complete local gate; its Mermaid renderer also requires a
 running Docker-compatible engine. The exact gate inventory belongs to the
-[justfile](../../justfile). Put the CI-pinned Bun 1.4.0 binary on this shell's `PATH`
+[justfile](../../justfile). Put the CI-pinned Bun 1.4.2 binary on this shell's `PATH`
 without replacing another project's global runtime, then verify the selected version:
 
 ```bash
-bun --version   # must report 1.4.0 for the full gate
+bun --version   # must report 1.4.2 for the full gate
 bun --revision
 just ci
 ```

--- a/packages/@keld/electron/package.json
+++ b/packages/@keld/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keld/electron",
   "version": "0.0.1",
-  "packageManager": "bun@1.4.0",
+  "packageManager": "bun@1.4.2",
   "type": "module",
   "description": "Electron API compatibility facade over kipc",
   "scripts": {

--- a/tools/ci_changes_test.sh
+++ b/tools/ci_changes_test.sh
@@ -407,7 +407,7 @@ for shape in plain.ts test.ts tests.ts; do
     shape_index=$((shape_index + 1))
     discovery_shape_case "bun skips it" "$shape" ignored "$shape_index"
 done
-echo "ok: router suite discovery matches bun 1.4.0 across all 32 patterns, 4 case variants and 3 skipped shapes"
+echo "ok: router suite discovery matches the active Bun runtime across all 32 patterns, 4 case variants and 3 skipped shapes"
 
 # A crate fixture with no Bun test consumer must not select the TypeScript
 # lane merely because it lives under tests/fixtures. The matching case below

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -866,6 +866,90 @@ fn check_msrv_avoids_apt(text: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Checks the repository's block-style direct action steps, not shell text.
+fn check_bun_setup_steps(text: &str, job: &str) -> Result<(), String> {
+    let invalid = || {
+        format!(
+            "CI-HYGIENE: `{WORKFLOW}` `{job}` must have at least one `oven-sh/setup-bun` step, and every such step must pin its own `with.bun-version` to `1.4.2`. Use direct block-style steps and inputs; unrelated job text is not a runtime pin."
+        )
+    };
+    let block = workflow_job_block(text, job).ok_or_else(invalid)?;
+    let mut steps: Vec<Vec<(usize, &str)>> = Vec::new();
+    let mut in_steps = false;
+    for (indent, content) in block.lines().filter_map(yaml_content) {
+        if indent <= 4 {
+            in_steps = indent == 4 && content == "steps:";
+            continue;
+        }
+        if !in_steps {
+            continue;
+        }
+        if indent == 6 {
+            let first = content.strip_prefix("- ").ok_or_else(invalid)?;
+            // Do not silently miss actions hidden in unsupported flow/alias syntax.
+            if first.starts_with('{') || first.starts_with('*') || first.starts_with('&') {
+                return Err(invalid());
+            }
+            steps.push(Vec::new());
+        }
+        if indent >= 6
+            && let Some(step) = steps.last_mut()
+        {
+            step.push((indent, content));
+        }
+    }
+    let mut setups = 0;
+    for step in steps {
+        let properties: Vec<_> = step
+            .iter()
+            .enumerate()
+            .filter(|(index, (indent, _))| *index == 0 || *indent == 8)
+            .filter_map(|(index, (_, content))| {
+                yaml_mapping_key(content).map(|(key, value)| (index, key, value))
+            })
+            .collect();
+        // A valid GitHub step cannot combine `run` and `uses`. In a run step,
+        // block-scalar contents must never be interpreted as action properties.
+        if properties.iter().any(|(_, key, _)| key == "run") {
+            continue;
+        }
+        let uses: Vec<_> = properties
+            .iter()
+            .filter(|(_, key, _)| key == "uses")
+            .collect();
+        if !uses.iter().any(|(_, _, value)| {
+            value
+                .trim_matches(['\'', '"'])
+                .to_ascii_lowercase()
+                .starts_with("oven-sh/setup-bun@")
+        }) {
+            continue;
+        }
+        setups += 1;
+        let with: Vec<_> = properties
+            .iter()
+            .filter(|(_, key, _)| key == "with")
+            .collect();
+        if uses.len() != 1 || with.len() != 1 || !with[0].2.is_empty() {
+            return Err(invalid());
+        }
+        let pins: Vec<_> = step[with[0].0 + 1..]
+            .iter()
+            .take_while(|(indent, _)| *indent > 8)
+            .filter(|(indent, _)| *indent == 10)
+            .filter_map(|(_, content)| yaml_mapping_key(content))
+            .filter(|(key, _)| key == "bun-version")
+            .collect();
+        if pins.len() != 1 || pins[0].1.trim_matches(['\'', '"']) != "1.4.2" {
+            return Err(invalid());
+        }
+    }
+    if setups == 0 {
+        return Err(invalid());
+    }
+    Ok(())
+}
+
 /// Asserts the `bun-test` lane's decidable properties only: that it exists, is
 /// gated on the router's own output, pins its Bun version, and does not open a
 /// second live apt lane. Each of those is a fact about the workflow text.
@@ -884,10 +968,8 @@ fn check_bun_test_job(text: &str) -> Result<(), String> {
             "CI-HYGIENE: `{WORKFLOW}` `bun-test` must be gated on `if: needs.changes.outputs.ts == 'true'`. The router owns which diffs reach this lane; an ungated job wastes runners and a gate on another output silently never runs (contexts: needs, github, vars, inputs only — never `matrix`)."
         ));
     }
-    if !uncommented_line_contains(&block, "bun-version: \"1.4.2\"") {
-        return Err(format!(
-            "CI-HYGIENE: `{WORKFLOW}` `bun-test` must pin `bun-version: \"1.4.2\"` (KEL-194; KEL-77 lifecycle oracles). A floating `latest` silently changes the runtime under the suite."
-        ));
+    for job in ["bun-test", "check"] {
+        check_bun_setup_steps(text, job)?;
     }
     // Deliberately NOT checked here: that the lane actually executes the suite
     // over the router's selection. Whether a shell script runs a command is not
@@ -1839,6 +1921,9 @@ mod tests {
             "          target/product-status/product-status check .",
             "  check:",
             "    steps:",
+            "      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
+            "        with:",
+            "          bun-version: '1.4.2'",
             "      - name: Check keld-ipc fuzz workspace",
             "        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.rust == 'true'",
             "        run: |",
@@ -2836,6 +2921,70 @@ mod tests {
                 check_bun_test_job(&changed).is_err(),
                 "unexpected runtime {version} must not satisfy the CI pin"
             );
+        }
+    }
+
+    #[test]
+    fn bun_step_pins_accept_named_actions_and_ignore_job_strategy() {
+        let workflow = valid_workflow()
+            .replace("  check:\n    steps:", "  check:\n    strategy:\n      fail-fast: false\n      matrix:\n        os: [ubuntu-latest, macos-latest]\n    steps:")
+            .replace("      - uses: oven-sh/setup-bun@", "      - name: install Bun\n        uses: oven-sh/setup-bun@");
+        let temp = complete_fixture();
+        temp.write(WORKFLOW, &workflow);
+        check(temp.path()).expect("only direct steps own action inputs");
+    }
+
+    #[test]
+    fn bun_pin_is_bound_to_the_action_input_not_job_text() {
+        let correct = "          bun-version: \"1.4.2\"\n";
+        for replacement in [
+            "          bun-version: latest\n",
+            "          # missing bun-version\n",
+            "        env:\n          bun-version: \"1.4.2\"\n",
+        ] {
+            let workflow = valid_workflow().replace(correct, replacement).replace(
+                "      - name: bun test\n",
+                "      - run: |\n          echo 'bun-version: \"1.4.2\"'\n      - name: bun test\n",
+            );
+            let temp = complete_fixture();
+            temp.write(WORKFLOW, &workflow);
+            let error = check(temp.path()).expect_err("unrelated text cannot pin an action");
+            assert!(error.contains("bun-test"), "{error}");
+            assert!(error.contains("1.4.2"), "{error}");
+        }
+    }
+
+    #[test]
+    fn every_bun_setup_in_both_jobs_requires_its_own_pin() {
+        for job in ["check", "bun-test"] {
+            let workflow = valid_workflow();
+            let block = workflow_job_block(&workflow, job).expect("fixture job");
+            for extra in [
+                "      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6\n        with:\n          bun-version: latest\n",
+                "      - name: another Bun setup\n        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6\n",
+            ] {
+                let temp = complete_fixture();
+                temp.write(
+                    WORKFLOW,
+                    &workflow.replace(&block, &format!("{block}{extra}")),
+                );
+                let error = check(temp.path()).expect_err("every actual setup must be pinned");
+                assert!(error.contains(job), "{error}");
+                assert!(error.contains("1.4.2"), "{error}");
+            }
+        }
+    }
+
+    #[test]
+    fn both_bun_jobs_require_a_setup_action() {
+        for job in ["check", "bun-test"] {
+            let workflow = valid_workflow();
+            let block = workflow_job_block(&workflow, job).expect("fixture job");
+            let changed = block.replace("oven-sh/setup-bun@", "some-other/action@");
+            let temp = complete_fixture();
+            temp.write(WORKFLOW, &workflow.replace(&block, &changed));
+            let error = check(temp.path()).expect_err("a version on another action is not Bun");
+            assert!(error.contains(job), "{error}");
         }
     }
 

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -884,9 +884,9 @@ fn check_bun_test_job(text: &str) -> Result<(), String> {
             "CI-HYGIENE: `{WORKFLOW}` `bun-test` must be gated on `if: needs.changes.outputs.ts == 'true'`. The router owns which diffs reach this lane; an ungated job wastes runners and a gate on another output silently never runs (contexts: needs, github, vars, inputs only — never `matrix`)."
         ));
     }
-    if !uncommented_line_contains(&block, "bun-version: \"1.4.0\"") {
+    if !uncommented_line_contains(&block, "bun-version: \"1.4.2\"") {
         return Err(format!(
-            "CI-HYGIENE: `{WORKFLOW}` `bun-test` must pin `bun-version: \"1.4.0\"` (KEL-77). A floating `latest` silently changes the runtime under the suite."
+            "CI-HYGIENE: `{WORKFLOW}` `bun-test` must pin `bun-version: \"1.4.2\"` (KEL-194; KEL-77 lifecycle oracles). A floating `latest` silently changes the runtime under the suite."
         ));
     }
     // Deliberately NOT checked here: that the lane actually executes the suite
@@ -1861,7 +1861,7 @@ mod tests {
             "    steps:",
             "      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0",
             "        with:",
-            "          bun-version: \"1.4.0\"",
+            "          bun-version: \"1.4.2\"",
             "      - name: bun test",
             "        shell: bash",
             "        env:",
@@ -2826,15 +2826,29 @@ mod tests {
     }
 
     #[test]
+    fn bun_ci_accepts_requested_142_and_rejects_other_versions() {
+        let requested = valid_workflow();
+        assert!(requested.contains("bun-version: \"1.4.2\""));
+        check_bun_test_job(&requested).expect("the requested stable CI pin must pass");
+        for version in ["1.4.0", "latest", "1.4.2-canary.1", "1.4.20"] {
+            let changed = requested.replace("\"1.4.2\"", &format!("\"{version}\""));
+            assert!(
+                check_bun_test_job(&changed).is_err(),
+                "unexpected runtime {version} must not satisfy the CI pin"
+            );
+        }
+    }
+
+    #[test]
     fn floating_bun_version_in_bun_lane_fails() {
         let temp = complete_fixture();
         temp.write(
             WORKFLOW,
-            &valid_workflow().replacen("bun-version: \"1.4.0\"", "bun-version: latest", 1),
+            &valid_workflow().replacen("bun-version: \"1.4.2\"", "bun-version: latest", 1),
         );
         let error = check(temp.path()).expect_err("an unpinned Bun runtime must fail");
         assert!(error.contains("bun-test"), "{error}");
-        assert!(error.contains("1.4.0"), "{error}");
+        assert!(error.contains("1.4.2"), "{error}");
     }
 
     #[test]

--- a/tools/ci_hygiene.rs
+++ b/tools/ci_hygiene.rs
@@ -873,6 +873,12 @@ fn check_bun_setup_steps(text: &str, job: &str) -> Result<(), String> {
             "CI-HYGIENE: `{WORKFLOW}` `{job}` must have at least one `oven-sh/setup-bun` step, and every such step must pin its own `with.bun-version` to `1.4.2`. Use direct block-style steps and inputs; unrelated job text is not a runtime pin."
         )
     };
+    let literal_key = |key: &str| {
+        !key.is_empty()
+            && key
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'))
+    };
     let block = workflow_job_block(text, job).ok_or_else(invalid)?;
     let mut steps: Vec<Vec<(usize, &str)>> = Vec::new();
     let mut in_steps = false;
@@ -900,11 +906,13 @@ fn check_bun_setup_steps(text: &str, job: &str) -> Result<(), String> {
     }
     let mut setups = 0;
     for step in steps {
+        let mut property_count = 0;
         let properties: Vec<_> = step
             .iter()
             .enumerate()
             .filter(|(index, (indent, _))| *index == 0 || *indent == 8)
             .filter_map(|(index, (_, content))| {
+                property_count += 1;
                 yaml_mapping_key(content).map(|(key, value)| (index, key, value))
             })
             .collect();
@@ -913,10 +921,27 @@ fn check_bun_setup_steps(text: &str, job: &str) -> Result<(), String> {
         if properties.iter().any(|(_, key, _)| key == "run") {
             continue;
         }
+        // YAML aliases, tags, escaped keys and folded/escaped action values
+        // require decoding we do not own. Reject them instead of mistaking a
+        // setup-bun action for an unrelated step under this narrow grammar.
+        if properties.len() != property_count
+            || properties.iter().any(|(_, key, _)| !literal_key(key))
+        {
+            return Err(invalid());
+        }
         let uses: Vec<_> = properties
             .iter()
             .filter(|(_, key, _)| key == "uses")
             .collect();
+        if uses.iter().any(|(_, _, value)| {
+            let literal = value.trim_matches(['\'', '"']);
+            literal.is_empty()
+                || !literal.chars().all(|c| {
+                    c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | '@' | ':')
+                })
+        }) {
+            return Err(invalid());
+        }
         if !uses.iter().any(|(_, _, value)| {
             value
                 .trim_matches(['\'', '"'])
@@ -933,11 +958,17 @@ fn check_bun_setup_steps(text: &str, job: &str) -> Result<(), String> {
         if uses.len() != 1 || with.len() != 1 || !with[0].2.is_empty() {
             return Err(invalid());
         }
-        let pins: Vec<_> = step[with[0].0 + 1..]
+        let inputs = step[with[0].0 + 1..]
             .iter()
             .take_while(|(indent, _)| *indent > 8)
             .filter(|(indent, _)| *indent == 10)
-            .filter_map(|(_, content)| yaml_mapping_key(content))
+            .map(|(_, content)| yaml_mapping_key(content).ok_or_else(invalid))
+            .collect::<Result<Vec<_>, _>>()?;
+        if inputs.iter().any(|(key, _)| !literal_key(key)) {
+            return Err(invalid());
+        }
+        let pins: Vec<_> = inputs
+            .iter()
             .filter(|(key, _)| key == "bun-version")
             .collect();
         if pins.len() != 1 || pins[0].1.trim_matches(['\'', '"']) != "1.4.2" {
@@ -2962,6 +2993,10 @@ mod tests {
             for extra in [
                 "      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6\n        with:\n          bun-version: latest\n",
                 "      - name: another Bun setup\n        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6\n",
+                "      - name: folded Bun action\n        'uses': >-\n          oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6\n        with:\n          bun-version: latest\n",
+                "      - uses: \"oven-sh/setup-b\\u0075n@0c5077e51419868618aeaa5fe8019c62421857d6\"\n        with:\n          bun-version: latest\n",
+                "      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6\n        with:\n          bun-version: '1.4.2'\n          \"bun-\\u0076ersion\": latest\n",
+                "      - ? uses\n        : oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6\n        with:\n          bun-version: latest\n",
             ] {
                 let temp = complete_fixture();
                 temp.write(


### PR DESCRIPTION
## Summary

Pin both current CI Bun setups to **1.4.2** and align package-manager metadata, Linux/Windows version attestations, current onboarding prerequisites, and the generated corpus. Strengthen the existing hygiene validator to check each actual setup action's own version input; unrelated text, missing pins, additional bad setup steps and unsupported ambiguous YAML cannot satisfy the contract.

The selected [September 5 release](https://bun.com/blog/bun-v1.4.2) is [bun-v1.4.2](https://github.com/oven-sh/bun/releases/tag/bun-v1.4.2), revision `744846f844374847c902b5e7fd59b4342a51ef99`. No dependency addition, lockfile change, production containment change or lifecycle assertion weakening. Dated Bun 1.4.0 observations remain historical.

## Spec refs

No boundary change. KEL-194 and `docs/specs/kel77-bun-child-process-differential.md`. Existing job/block/scalar helpers and the hygiene checker own version validation. This candidate is rebased onto the landed KEL-196 window-observation fixes and KEL-197 fixture correction; they remain separate PRs.

## Review gates

Five root gates: none. Isolated exact-tip review at `8d74f50e11c236e51b20410c7dee3f26c089a1ed` passed all ten files and current-base interactions. CodeRabbit CLI reviewed the same tip and raised one false finding asking to restore 1.4.0 guidance. An independent refuter verified that CI lines 142/218, Linux assertion 358, current guides and generated corpus all require 1.4.2; reverting that guidance would create drift. No valid finding remains. Earlier real validator findings were fixed and independently refuted with before/after controls.

## Tests

- Regression-first proof: the previous validator accepted wrong/missing action pins hidden by job text or additional setup steps. New tests failed before the fix and pass afterward; folded/escaped/explicit YAML-key bypasses also reject. All 86 hygiene tests and actual repository hygiene passed.
- Full local `just ci` passed on the final tip using its private target: 636 workspace tests with two existing skips, frozen install/TypeScript 41 tests, static/docs/Mermaid, format, warning-denied clippy, rustdoc and cargo-deny. Existing lockfile unchanged.
- Current documentation was regenerated with the working-tree generator and freshness tests passed. New public Ubuntu/Windows 1.4.0 observations remain explicitly dated, separate from current gate requirements.
- Fresh required hosted Linux/macOS/Windows CI passed on this final tip: [run 34297786884](https://github.com/gyldlab/keld/actions/runs/34297786884), including the final `CI required` gate.

## Platforms

Local physical macOS arm64 with Bun 1.4.2. Hosted Linux/macOS/Windows qualification passed on the final tip. This is CI/runtime qualification, not a new clean-machine or device-acceptance claim.

## Perf impact

No performance claim. Rollback is a reviewed revert of the scoped pin and version expectations to 1.4.0 while preserving behavioral oracles. Security CI PR #173 must inherit the qualified pin during later integration.
