### PR TITLE
fix(runtime): bound supervised child output without losing lifecycle ordering (KEL-134/T1)

### DIFF
--- a/crates/keld-cli/src/dev.rs
+++ b/crates/keld-cli/src/dev.rs
@@ -131,7 +131,8 @@ impl From<keld_core::HelloSessionError> for DevError {
             keld_core::HelloSessionError::WindowPhase { .. } => Self::WindowPhase(rendered),
             keld_core::HelloSessionError::Io(_)
             | keld_core::HelloSessionError::Runtime(_)
-            | keld_core::HelloSessionError::Timeout { .. } => Self::Runtime(rendered),
+            | keld_core::HelloSessionError::Timeout { .. }
+            | keld_core::HelloSessionError::MarkerPossiblyElided { .. } => Self::Runtime(rendered),
         }
     }
 }
@@ -274,10 +275,21 @@ pub fn run_dev_echo(project_root: &Path) -> Result<DevEchoResult, DevError> {
     // fixtures may only print `ipc-echo ok:`, so the second wait stays optional.
     session.wait_until_output_contains("ipc-echo ok:", Duration::from_secs(30))?;
     let _ = session.wait_until_output_contains("main process ready", Duration::from_secs(5));
-    let stdout = session.output().stdout;
-    let stderr = session.output().stderr;
+    let captured = session.output();
+    let stdout = captured.stdout.clone();
+    let stderr = captured.stderr.clone();
     io::stdout().write_all(stdout.as_bytes())?;
+    if let Some(notice) =
+        keld_runtime::CapturedOutput::elision_notice(captured.stdout_dropped_bytes)
+    {
+        io::stdout().write_all(notice.as_bytes())?;
+    }
     io::stderr().write_all(stderr.as_bytes())?;
+    if let Some(notice) =
+        keld_runtime::CapturedOutput::elision_notice(captured.stderr_dropped_bytes)
+    {
+        io::stderr().write_all(notice.as_bytes())?;
+    }
     let link = session.link().to_owned();
     // The windowless echo contract is complete once the observable reply was
     // captured. A child that then ends itself with status zero is still
@@ -589,10 +601,21 @@ where
         hello_title_for_project(project_root)
     );
     session.wait_until_output_contains(&ready, Duration::from_secs(30))?;
-    let stdout = session.output().stdout;
-    let stderr = session.output().stderr;
+    let captured = session.output();
+    let stdout = captured.stdout.clone();
+    let stderr = captured.stderr.clone();
     io::stdout().write_all(stdout.as_bytes())?;
+    if let Some(notice) =
+        keld_runtime::CapturedOutput::elision_notice(captured.stdout_dropped_bytes)
+    {
+        io::stdout().write_all(notice.as_bytes())?;
+    }
     io::stderr().write_all(stderr.as_bytes())?;
+    if let Some(notice) =
+        keld_runtime::CapturedOutput::elision_notice(captured.stderr_dropped_bytes)
+    {
+        io::stderr().write_all(notice.as_bytes())?;
+    }
 
     // Window phase while echo listener + Bun are still live.
     let title = hello_title_for_project(project_root);

--- a/crates/keld-cli/src/dev.rs
+++ b/crates/keld-cli/src/dev.rs
@@ -265,10 +265,11 @@ fn staged_host_launch_error(
 /// ready marker never appears.
 pub fn run_dev_echo(project_root: &Path) -> Result<DevEchoResult, DevError> {
     doctor_or_err(project_root)?;
-    let session = HostOwnedHelloSession::start(
+    let session = HostOwnedHelloSession::start_with_stdout_markers(
         project_root,
         project_root.join("src/main.ts"),
         RestartPolicy::default(),
+        &["ipc-echo ok:", "main process ready"],
     )?;
     // Observable wire contract: HELLO + CALL/REPLY printed by the child.
     // Stock template also prints `{name}: main process ready`; crash-recovery
@@ -591,15 +592,16 @@ where
     W: FnOnce(&str, &str) -> Result<(), DevError>,
 {
     doctor_or_err(project_root)?;
-    let session = HostOwnedHelloSession::start(
-        project_root,
-        project_root.join("src/main.ts"),
-        RestartPolicy::default(),
-    )?;
     let ready = format!(
         "{}: main process ready (IPC echo ok)",
         hello_title_for_project(project_root)
     );
+    let session = HostOwnedHelloSession::start_with_stdout_markers(
+        project_root,
+        project_root.join("src/main.ts"),
+        RestartPolicy::default(),
+        &[&ready],
+    )?;
     session.wait_until_output_contains(&ready, Duration::from_secs(30))?;
     let captured = session.output();
     let stdout = captured.stdout.clone();
@@ -656,11 +658,23 @@ fn window_phase_outcome(
 ///
 /// Returns [`DevError`] when doctor checks fail or the session cannot start.
 pub fn start_dev_session(project_root: &Path) -> Result<HostOwnedHelloSession, DevError> {
+    start_dev_session_with_stdout_markers(project_root, &[])
+}
+
+/// Starts a diagnostic session with known stdout markers observed before truncation.
+///
+/// # Errors
+/// Returns [`DevError`] if doctor, marker registration or session setup fails.
+pub fn start_dev_session_with_stdout_markers(
+    project_root: &Path,
+    markers: &[&str],
+) -> Result<HostOwnedHelloSession, DevError> {
     doctor_or_err(project_root)?;
-    HostOwnedHelloSession::start(
+    HostOwnedHelloSession::start_with_stdout_markers(
         project_root,
         project_root.join("src/main.ts"),
         RestartPolicy::default(),
+        markers,
     )
     .map_err(DevError::from)
 }

--- a/crates/keld-cli/tests/concurrent_hello.rs
+++ b/crates/keld-cli/tests/concurrent_hello.rs
@@ -10,7 +10,12 @@ use std::process::Command;
 use std::time::Duration;
 
 use keld_cli::create::create_project;
-use keld_cli::dev::start_dev_session;
+use keld_cli::dev::start_dev_session_with_stdout_markers;
+
+const MARKERS: &[&str] = &[
+    "concurrent-ready",
+    "ipc-echo ok: message=\"after-window\" count=2",
+];
 
 const KIPC_TS: &str = include_str!("../templates/hello/src/kipc.ts");
 
@@ -68,7 +73,8 @@ try {{
     let main = [KIPC_TS, body.as_str()].concat();
     fs::write(root.join("src/main.ts"), main).expect("overwrite main");
 
-    let session = start_dev_session(&root).expect("start host-owned session");
+    let session =
+        start_dev_session_with_stdout_markers(&root, MARKERS).expect("start host-owned session");
     session
         .wait_until_output_contains("concurrent-ready", Duration::from_secs(30))
         .expect("first HELLO+CALL ready");

--- a/crates/keld-cli/tests/window_phase_crash.rs
+++ b/crates/keld-cli/tests/window_phase_crash.rs
@@ -64,7 +64,7 @@ use std::fs;
 use std::process::Command;
 
 use keld_cli::create::create_project;
-use keld_cli::dev::{run_dev_with_window, start_dev_session};
+use keld_cli::dev::{run_dev_with_window, start_dev_session_with_stdout_markers};
 use std::time::{Duration, Instant};
 
 /// Stderr the fixture emits before it is killed, so the assertion that the
@@ -298,8 +298,9 @@ fn a_later_readiness_wait_does_not_forgive_a_post_ready_crash() {
     )
     .expect("write generation-aware fixture");
 
-    let session = start_dev_session(&root).expect("start host-owned session");
     let ready = format!("{name}: main process ready (IPC echo ok)");
+    let session = start_dev_session_with_stdout_markers(&root, &[&ready, "kel105-generation-2"])
+        .expect("start host-owned session");
     session
         .wait_until_output_contains(&ready, Duration::from_secs(30))
         .expect("the stock template must complete HELLO + CALL");
@@ -372,7 +373,9 @@ fn an_app_that_dies_after_reporting_ready_fails_the_run() {
     )
     .expect("write die-after-ready fixture");
 
-    let session = start_dev_session(&root).expect("start host-owned session");
+    let ready = format!("{name}: main process ready (IPC echo ok)");
+    let session = start_dev_session_with_stdout_markers(&root, &[&ready, "kel105-generation-2"])
+        .expect("start host-owned session");
 
     // Await generation 2 WITHOUT `wait_until_output_contains`: that call is the
     // thing under test, and using it here would record the baseline early and
@@ -384,7 +387,6 @@ fn an_app_that_dies_after_reporting_ready_fails_the_run() {
     // Now the host looks for the ready marker for the first time — exactly the
     // ordering the product hits when an app dies immediately after reporting
     // ready.
-    let ready = format!("{name}: main process ready (IPC echo ok)");
     session
         .wait_until_output_contains(&ready, Duration::from_secs(30))
         .expect("generation 1's ready line is still in captured stdout");

--- a/crates/keld-core/src/app_session.rs
+++ b/crates/keld-core/src/app_session.rs
@@ -2792,9 +2792,22 @@ fn forward_direct_primary_output(supervisor: &PrimaryRoleSupervisor) -> Result<(
     io::stdout()
         .write_all(output.stdout.as_bytes())
         .map_err(|source| app_io("primary stdout forwarding", &source))?;
+    if let Some(notice) = keld_runtime::CapturedOutput::elision_notice(output.stdout_dropped_bytes)
+    {
+        io::stdout()
+            .write_all(notice.as_bytes())
+            .map_err(|source| app_io("primary stdout forwarding", &source))?;
+    }
     io::stderr()
         .write_all(output.stderr.as_bytes())
-        .map_err(|source| app_io("primary stderr forwarding", &source))
+        .map_err(|source| app_io("primary stderr forwarding", &source))?;
+    if let Some(notice) = keld_runtime::CapturedOutput::elision_notice(output.stderr_dropped_bytes)
+    {
+        io::stderr()
+            .write_all(notice.as_bytes())
+            .map_err(|source| app_io("primary stderr forwarding", &source))?;
+    }
+    Ok(())
 }
 
 #[cfg(any(target_os = "linux", windows))]

--- a/crates/keld-core/src/hello_session.rs
+++ b/crates/keld-core/src/hello_session.rs
@@ -200,7 +200,12 @@ impl HostOwnedHelloSession {
         loop {
             let captured = supervisor.output();
             if captured.stdout.contains(needle) {
-                self.mark_ready(supervisor, &captured.stdout, needle);
+                self.mark_ready(
+                    supervisor,
+                    &captured.stdout,
+                    captured.stdout_dropped_bytes,
+                    needle,
+                );
                 return Ok(());
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -231,7 +236,12 @@ impl HostOwnedHelloSession {
                 Some(SupervisorEvent::Stopped) => {
                     let captured = supervisor.output();
                     if captured.stdout.contains(needle) {
-                        self.mark_ready(supervisor, &captured.stdout, needle);
+                        self.mark_ready(
+                            supervisor,
+                            &captured.stdout,
+                            captured.stdout_dropped_bytes,
+                            needle,
+                        );
                         return Ok(());
                     }
                     return Err(HelloSessionError::Runtime(
@@ -353,11 +363,12 @@ impl HostOwnedHelloSession {
     /// `stdout` is the exact buffer the marker was found in, and it is read
     /// *before* the ledger on purpose: the ledger only grows, so a termination
     /// that lands in between makes the comparison stricter, never looser.
-    fn mark_ready(&self, supervisor: &Supervisor, stdout: &str, needle: &str) {
+    fn mark_ready(&self, supervisor: &Supervisor, stdout: &str, dropped: usize, needle: &str) {
         if self.ready_recorded.swap(true, Ordering::SeqCst) {
             return;
         }
-        let recovered = recovered_termination_baseline(stdout, needle, &supervisor.crash_ledger());
+        let recovered =
+            recovered_termination_baseline(stdout, dropped, needle, &supervisor.crash_ledger());
         self.recovered_crashes
             .store(recovered.crashes, Ordering::SeqCst);
         self.recovered_self_terminations
@@ -383,9 +394,19 @@ impl HostOwnedHelloSession {
 /// (`docs/architecture/02-ipc.md`), so the earlier death is the honest verdict.
 fn recovered_termination_baseline(
     stdout: &str,
+    dropped: usize,
     needle: &str,
     ledger: &CrashLedger,
 ) -> RecoveredTerminations {
+    // Once the supervisor has elided output to honour its retention bound
+    // (KEL-134), a byte index into the retained transcript is no longer a
+    // stream offset, so it cannot be ordered against the ledger's
+    // total-written offsets. Baseline nothing rather than compare two
+    // coordinate systems: that can only surface a termination, never excuse
+    // one, which is the direction KEL-105/KEL-116 require.
+    if dropped > 0 {
+        return RecoveredTerminations::default();
+    }
     let Some(marker_end) = stdout.find(needle).map(|start| start + needle.len()) else {
         return RecoveredTerminations::default();
     };
@@ -679,8 +700,30 @@ mod ready_baseline_tests {
     fn no_crash_yet_forgives_nothing_and_claims_nothing() {
         let stdout = format!("booting\n{READY}\n");
         assert_eq!(
-            recovered_termination_baseline(&stdout, READY, &ledger_at(0, 0)),
+            recovered_termination_baseline(&stdout, 0, READY, &ledger_at(0, 0)),
             RecoveredTerminations::default()
+        );
+    }
+
+    #[test]
+    fn an_elided_transcript_forgives_nothing() {
+        // KEL-134: once the supervisor elides output, a byte index into the
+        // retained transcript is not a stream offset. The same inputs that
+        // would forgive a crash with an intact transcript must forgive nothing
+        // once bytes have been dropped, because the safe direction is to
+        // surface a termination rather than excuse it (KEL-105/KEL-116).
+        let crashed = "gen1 booting\n";
+        let stdout = format!("{crashed}{READY}\n");
+        let ledger = ledger_at(1, crashed.len());
+        assert_eq!(
+            recovered_termination_baseline(&stdout, 0, READY, &ledger),
+            RecoveredTerminations { crashes: 1, all: 1 },
+            "control: with an intact transcript this crash is forgiven"
+        );
+        assert_eq!(
+            recovered_termination_baseline(&stdout, 1, READY, &ledger),
+            RecoveredTerminations::default(),
+            "one elided byte is enough to make the offsets incomparable"
         );
     }
 
@@ -691,7 +734,7 @@ mod ready_baseline_tests {
         let crashed = "gen1 booting\n";
         let stdout = format!("{crashed}{READY}\n");
         assert_eq!(
-            recovered_termination_baseline(&stdout, READY, &ledger_at(1, crashed.len())),
+            recovered_termination_baseline(&stdout, 0, READY, &ledger_at(1, crashed.len())),
             RecoveredTerminations { crashes: 1, all: 1 },
             "a crash the supervisor recovered from before ready must be forgiven"
         );
@@ -705,7 +748,7 @@ mod ready_baseline_tests {
         // them.
         let stdout = format!("{READY}\ndying now\n");
         assert_eq!(
-            recovered_termination_baseline(&stdout, READY, &ledger_at(1, stdout.len())),
+            recovered_termination_baseline(&stdout, 0, READY, &ledger_at(1, stdout.len())),
             RecoveredTerminations::default(),
             "a death after the app was live must not be reported as recovered"
         );
@@ -717,7 +760,7 @@ mod ready_baseline_tests {
         // already written when the crash was recorded, so it is post-ready.
         let stdout = READY.to_owned();
         assert_eq!(
-            recovered_termination_baseline(&stdout, READY, &ledger_at(1, stdout.len())),
+            recovered_termination_baseline(&stdout, 0, READY, &ledger_at(1, stdout.len())),
             RecoveredTerminations::default()
         );
     }
@@ -728,7 +771,7 @@ mod ready_baseline_tests {
         let pre = "gen1 booting\n";
         let stdout = format!("{pre}{READY}\nlate output\n");
         assert_eq!(
-            recovered_termination_baseline(&stdout, READY, &ledger_at(2, stdout.len())),
+            recovered_termination_baseline(&stdout, 0, READY, &ledger_at(2, stdout.len())),
             RecoveredTerminations::default(),
             "the later death is post-ready, so the run must fail"
         );
@@ -754,7 +797,7 @@ mod ready_baseline_tests {
             }),
         };
         assert_eq!(
-            recovered_termination_baseline(&stdout, READY, &ledger),
+            recovered_termination_baseline(&stdout, 0, READY, &ledger),
             RecoveredTerminations { crashes: 1, all: 0 },
             "the recovered non-zero exit must remain distinguishable from the later zero exit"
         );
@@ -763,7 +806,7 @@ mod ready_baseline_tests {
     #[test]
     fn an_absent_marker_forgives_nothing() {
         assert_eq!(
-            recovered_termination_baseline("nothing here", READY, &ledger_at(3, 0)),
+            recovered_termination_baseline("nothing here", 0, READY, &ledger_at(3, 0)),
             RecoveredTerminations::default()
         );
     }
@@ -776,7 +819,7 @@ mod ready_baseline_tests {
         let first = format!("{READY}\n");
         let stdout = format!("{first}gen2\n{READY}\n");
         assert_eq!(
-            recovered_termination_baseline(&stdout, READY, &ledger_at(1, first.len() + 5)),
+            recovered_termination_baseline(&stdout, 0, READY, &ledger_at(1, first.len() + 5)),
             RecoveredTerminations::default(),
             "a re-printed marker must not forgive the earlier post-ready death"
         );

--- a/crates/keld-core/src/hello_session.rs
+++ b/crates/keld-core/src/hello_session.rs
@@ -152,6 +152,21 @@ impl HostOwnedHelloSession {
         bun_main: PathBuf,
         policy: RestartPolicy,
     ) -> Result<Self, HelloSessionError> {
+        Self::start_with_stdout_markers(project_root, bun_main, policy, &[])
+    }
+
+    /// Starts a diagnostic session with stdout markers registered before spawn.
+    /// Registered markers retain their first raw-byte match across transcript
+    /// truncation and restarts; unregistered waits inspect retained text only.
+    ///
+    /// # Errors
+    /// Returns an error if marker registration, listener setup or spawning fails.
+    pub fn start_with_stdout_markers(
+        project_root: &Path,
+        bun_main: PathBuf,
+        policy: RestartPolicy,
+        markers: &[&str],
+    ) -> Result<Self, HelloSessionError> {
         let (ready_tx, ready_rx) = std::sync::mpsc::channel();
         let server = EchoServer::start(&ready_tx)?;
         ready_rx
@@ -161,7 +176,7 @@ impl HostOwnedHelloSession {
         let link_for_child = link.clone();
         let project_root = project_root.to_path_buf();
 
-        let supervisor = Supervisor::start(policy, move || {
+        let supervisor = Supervisor::start_with_stdout_markers(policy, markers, move || {
             let mut cmd = Command::new("bun");
             cmd.arg("run")
                 .arg(&bun_main)
@@ -206,10 +221,10 @@ impl HostOwnedHelloSession {
     /// Drains supervisor events so a crash-loop surfaces as
     /// [`HelloSessionError::Runtime`] instead of a hang.
     ///
-    /// Matches against the supervisor's retained transcript, which is bounded
-    /// (KEL-134). A marker printed within the pinned head stays findable for
-    /// the life of the session; one printed after the app's bulk output can be
-    /// elided before any poll observes it.
+    /// Markers registered by [`Self::start_with_stdout_markers`] are observed
+    /// as raw UTF-8 bytes before truncation and retain their first match. A partial
+    /// match cannot span child generations. Other needles search only the bounded,
+    /// lossy retained transcript and may have been elided before this wait.
     ///
     /// # Errors
     ///
@@ -230,13 +245,7 @@ impl HostOwnedHelloSession {
         let deadline = Instant::now() + timeout;
         loop {
             let captured = supervisor.output();
-            if captured.stdout.contains(needle) {
-                self.mark_ready(
-                    supervisor,
-                    &captured.stdout,
-                    captured.stdout_dropped_bytes,
-                    needle,
-                );
+            if self.mark_ready(supervisor, &captured, needle) {
                 return Ok(());
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -246,7 +255,9 @@ impl HostOwnedHelloSession {
                 // marker either landed in the elided span or has not been
                 // printed yet (KEL-134). Report both possibilities rather than
                 // blaming the deadline alone, which hides the first one.
-                if captured.stdout_dropped_bytes > 0 {
+                if captured.stdout_dropped_bytes > 0
+                    && supervisor.stdout_marker_offset(needle).is_none()
+                {
                     return Err(HelloSessionError::MarkerPossiblyElided {
                         waiting_for: "Bun stdout ready marker",
                         elided_bytes: captured.stdout_dropped_bytes,
@@ -277,13 +288,7 @@ impl HostOwnedHelloSession {
                 }
                 Some(SupervisorEvent::Stopped) => {
                     let captured = supervisor.output();
-                    if captured.stdout.contains(needle) {
-                        self.mark_ready(
-                            supervisor,
-                            &captured.stdout,
-                            captured.stdout_dropped_bytes,
-                            needle,
-                        );
+                    if self.mark_ready(supervisor, &captured, needle) {
                         return Ok(());
                     }
                     return Err(HelloSessionError::Runtime(
@@ -396,26 +401,41 @@ impl HostOwnedHelloSession {
     /// recovered crash (KEL-70 AC1/AC3) from an app that ended after becoming
     /// live (KEL-105/KEL-116).
     ///
-    /// First transition only. [`Self::wait_until_output_contains`] matches
-    /// against the retained transcript, whose pinned head keeps an early
-    /// marker findable for the life of the session, so a later call for a
-    /// marker the app already printed returns immediately — re-baselining there would absorb a
-    /// self-termination that happened after the app was live and report it as
-    /// recovered.
-    ///
-    /// `stdout` is the exact buffer the marker was found in, and it is read
-    /// *before* the ledger on purpose: the ledger only grows, so a termination
-    /// that lands in between makes the comparison stricter, never looser.
-    fn mark_ready(&self, supervisor: &Supervisor, stdout: &str, dropped: usize, needle: &str) {
-        if self.ready_recorded.swap(true, Ordering::SeqCst) {
-            return;
+    /// First successful wait only. Registered markers use immutable first-match
+    /// raw offsets; other needles use the retained transcript conservatively.
+    /// A later wait must not absorb a post-ready death into a new baseline.
+    /// The observed offset/transcript is read before the monotonically growing
+    /// ledger so a concurrent termination cannot earn extra recovery credit.
+    fn mark_ready(
+        &self,
+        supervisor: &Supervisor,
+        captured: &keld_runtime::CapturedOutput,
+        needle: &str,
+    ) -> bool {
+        let recovered = match supervisor.stdout_marker_offset(needle) {
+            Some(Some(offset)) => {
+                recovered_termination_baseline_at(offset, &supervisor.crash_ledger())
+            }
+            Some(None) => return false,
+            None => {
+                if !captured.stdout.contains(needle) {
+                    return false;
+                }
+                recovered_termination_baseline(
+                    &captured.stdout,
+                    captured.stdout_dropped_bytes,
+                    needle,
+                    &supervisor.crash_ledger(),
+                )
+            }
+        };
+        if !self.ready_recorded.swap(true, Ordering::SeqCst) {
+            self.recovered_crashes
+                .store(recovered.crashes, Ordering::SeqCst);
+            self.recovered_self_terminations
+                .store(recovered.all, Ordering::SeqCst);
         }
-        let recovered =
-            recovered_termination_baseline(stdout, dropped, needle, &supervisor.crash_ledger());
-        self.recovered_crashes
-            .store(recovered.crashes, Ordering::SeqCst);
-        self.recovered_self_terminations
-            .store(recovered.all, Ordering::SeqCst);
+        true
     }
 }
 
@@ -456,7 +476,13 @@ fn recovered_termination_baseline(
     if dropped > 0 && marker_end > keld_runtime::CAPTURE_HEAD_BYTES {
         return RecoveredTerminations::default();
     }
-    let marker_offset = marker_end;
+    recovered_termination_baseline_at(marker_end, ledger)
+}
+
+fn recovered_termination_baseline_at(
+    marker_offset: usize,
+    ledger: &CrashLedger,
+) -> RecoveredTerminations {
     RecoveredTerminations {
         crashes: if marker_offset > ledger.stdout_len_at_last_crash {
             ledger.count
@@ -574,6 +600,50 @@ mod tests {
                 stdout_len,
             }),
         }
+    }
+
+    #[test]
+    fn registered_marker_survives_flood_before_first_wait() {
+        use super::HostOwnedHelloSession;
+        use keld_runtime::{RestartPolicy, Supervisor};
+        use std::process::Command;
+        use std::sync::atomic::{AtomicBool, AtomicU32};
+        use std::time::Duration;
+
+        let supervisor = Supervisor::start_with_stdout_markers(
+            RestartPolicy::default(), &["first-marker", "second-marker"], || {
+                let mut command = Command::new("bun");
+                command.args(["-e", "const {writeSync}=require('node:fs'); writeSync(1,'x'.repeat(131072)); writeSync(1,'first-marker'); writeSync(1,'y'.repeat(2097152)); writeSync(1,'second-marker');"]);
+                command
+            },
+        ).expect("start marker flood child");
+        assert!(matches!(
+            supervisor.wait_for_outcome(),
+            SupervisorOutcome::Stopped
+        ));
+        let captured = supervisor.output();
+        assert!(captured.stdout_dropped_bytes > 0);
+        assert!(
+            !captured.stdout.contains("first-marker"),
+            "marker must actually be elided"
+        );
+        let session = HostOwnedHelloSession {
+            server: None,
+            supervisor: Some(supervisor),
+            link: String::new(),
+            ready_recorded: AtomicBool::new(false),
+            recovered_self_terminations: AtomicU32::new(0),
+            recovered_crashes: AtomicU32::new(0),
+        };
+        session
+            .wait_until_output_contains("first-marker", Duration::from_secs(1))
+            .expect("registered marker survives completed flood before first wait");
+        session
+            .wait_until_output_contains("second-marker", Duration::from_secs(1))
+            .expect("secondary registered marker is observable");
+        session
+            .wait_until_output_contains("first-marker", Duration::from_secs(1))
+            .expect("original marker remains observable after secondary wait");
     }
 
     #[test]

--- a/crates/keld-core/src/hello_session.rs
+++ b/crates/keld-core/src/hello_session.rs
@@ -432,11 +432,19 @@ fn recovered_termination_baseline(
     let Some(marker_end) = stdout.find(needle).map(|start| start + needle.len()) else {
         return RecoveredTerminations::default();
     };
-    // The ledger publishes total-written offsets, so the marker's index in the
-    // retained transcript has to be lifted into the same coordinate system
-    // once the supervisor has elided output (KEL-134). The head is pinned, so
-    // a marker inside it is already at its stream offset.
-    let marker_offset = keld_runtime::CapturedOutput::stream_offset(marker_end, dropped);
+    // The pinned head is the literal start of the stream and is never elided
+    // (KEL-134), so a match ending inside it is provably the *first*
+    // occurrence and already sits at its true stream offset — which is what
+    // the doc above requires and what the ledger's offsets are measured in.
+    //
+    // A match beyond the head, once anything has been elided, may be a later
+    // repeat printed by a restarted generation whose earlier twin was dropped.
+    // Crediting it would order the crash against the wrong marker and excuse a
+    // post-ready death, so no recovery credit is granted there.
+    if dropped > 0 && marker_end > keld_runtime::CAPTURE_HEAD_BYTES {
+        return RecoveredTerminations::default();
+    }
+    let marker_offset = marker_end;
     RecoveredTerminations {
         crashes: if marker_offset > ledger.stdout_len_at_last_crash {
             ledger.count
@@ -754,21 +762,41 @@ mod ready_baseline_tests {
     }
 
     #[test]
-    fn a_marker_past_the_pinned_head_is_shifted_by_the_elided_count() {
-        // A marker found beyond the pinned head really sits `dropped` bytes
-        // further into the stream than its retained index says. Ordering must
-        // use the shifted offset, or a post-ready crash reads as pre-ready.
+    fn a_marker_past_the_pinned_head_earns_no_credit_once_output_was_elided() {
+        // Beyond the pinned head the retained match may be a *repeat* printed
+        // by a restarted generation, with the real first marker elided. The
+        // ordering doc above depends on using the first occurrence, so an
+        // ambiguous match must not forgive anything.
         let filler = "f".repeat(keld_runtime::CAPTURE_HEAD_BYTES + 16);
         let stdout = format!("{filler}{READY}\n");
-        let marker_offset = filler.len() + READY.len();
-        let dropped = 4096;
-        // Crash recorded between the retained index and the true offset: only
-        // the shifted comparison places the marker after it.
-        let ledger = ledger_at(1, marker_offset + 1);
+        let ledger = ledger_at(1, 8);
         assert_eq!(
-            recovered_termination_baseline(&stdout, dropped, READY, &ledger),
+            recovered_termination_baseline(&stdout, 0, READY, &ledger),
             RecoveredTerminations { crashes: 1, all: 1 },
-            "the shifted offset must place the marker after the crash"
+            "control: with nothing elided the match is the first occurrence"
+        );
+        assert_eq!(
+            recovered_termination_baseline(&stdout, 4096, READY, &ledger),
+            RecoveredTerminations::default(),
+            "an ambiguous match must not excuse a termination"
+        );
+    }
+
+    #[test]
+    fn an_elided_first_marker_cannot_be_impersonated_by_a_retained_repeat() {
+        // The hazard in full: generation 1 printed the marker and then died,
+        // that marker was elided, and generation 2 printed it again. Crediting
+        // the retained repeat would order the crash against the wrong marker
+        // and report success over an app that died after it was ready.
+        let filler = "f".repeat(keld_runtime::CAPTURE_HEAD_BYTES + 16);
+        let stdout = format!("{filler}{READY}\n");
+        // The crash is recorded far into the stream — after the elided first
+        // marker — so a naive shifted comparison would call it pre-ready.
+        let ledger = ledger_at(1, 4096);
+        assert_eq!(
+            recovered_termination_baseline(&stdout, 512 * 1024, READY, &ledger),
+            RecoveredTerminations::default(),
+            "a post-ready death must not be laundered by a repeated marker"
         );
     }
 

--- a/crates/keld-core/src/hello_session.rs
+++ b/crates/keld-core/src/hello_session.rs
@@ -421,12 +421,31 @@ impl HostOwnedHelloSession {
                 if !captured.stdout.contains(needle) {
                     return false;
                 }
-                recovered_termination_baseline(
-                    &captured.stdout,
-                    captured.stdout_dropped_bytes,
-                    needle,
-                    &supervisor.crash_ledger(),
-                )
+                // Lossy decoding can expand byte offsets, including when a
+                // valid UTF-8 scalar crosses capture reads. Elision accounting
+                // preserves the cumulative decoded size, so equality proves
+                // that no expansion occurred. Otherwise grant no recovery
+                // credit, even if only output after the marker was lossy.
+                let offsets_preserved = captured
+                    .stdout_total_bytes
+                    .checked_add(captured.stdout_separator_bytes)
+                    .zip(
+                        captured
+                            .stdout
+                            .len()
+                            .checked_add(captured.stdout_dropped_bytes),
+                    )
+                    .is_some_and(|(raw, decoded)| raw == decoded);
+                if offsets_preserved {
+                    recovered_termination_baseline(
+                        &captured.stdout,
+                        captured.stdout_dropped_bytes,
+                        needle,
+                        &supervisor.crash_ledger(),
+                    )
+                } else {
+                    RecoveredTerminations::default()
+                }
             }
         };
         if !self.ready_recorded.swap(true, Ordering::SeqCst) {
@@ -600,6 +619,47 @@ mod tests {
                 stdout_len,
             }),
         }
+    }
+
+    #[test]
+    fn unregistered_lossy_marker_does_not_forgive_post_ready_exit() {
+        use super::HostOwnedHelloSession;
+        use keld_runtime::{RestartPolicy, Supervisor};
+        use std::process::Command;
+        use std::sync::atomic::{AtomicBool, AtomicU32};
+        use std::time::Duration;
+
+        let supervisor = Supervisor::start(RestartPolicy::default(), || {
+            let mut command = Command::new("bun");
+            command.args([
+                "-e",
+                "require('node:fs').writeSync(1, Buffer.from([255,82,69,65,68,89]));",
+            ]);
+            command
+        })
+        .expect("start invalid-UTF8 diagnostic child");
+        assert!(matches!(
+            supervisor.wait_for_outcome(),
+            SupervisorOutcome::Stopped
+        ));
+        let captured = supervisor.output();
+        assert_eq!(captured.stdout, "\u{fffd}READY");
+        assert_eq!(captured.stdout_total_bytes, 6);
+        let session = HostOwnedHelloSession {
+            server: None,
+            supervisor: Some(supervisor),
+            link: String::new(),
+            ready_recorded: AtomicBool::new(false),
+            recovered_self_terminations: AtomicU32::new(0),
+            recovered_crashes: AtomicU32::new(0),
+        };
+        session
+            .wait_until_output_contains("READY", Duration::from_secs(1))
+            .expect("legacy retained-text observation still works");
+        assert!(
+            session.shutdown().is_err(),
+            "decoded offset must not forgive post-ready exit"
+        );
     }
 
     #[test]

--- a/crates/keld-core/src/hello_session.rs
+++ b/crates/keld-core/src/hello_session.rs
@@ -27,10 +27,12 @@ pub enum HelloSessionError {
         /// What the caller was waiting for.
         waiting_for: &'static str,
     },
-    /// The marker was never observed and the supervisor had elided output, so
-    /// the child may have printed it into the span that was dropped. Distinct
-    /// from [`Self::Timeout`] because the remedy is different: the marker must
-    /// move earlier, not the deadline later (KEL-134).
+    /// The marker was never observed within the deadline while the supervisor
+    /// had elided output. Ambiguous by construction: the child may have
+    /// printed the marker into the dropped span, or may simply not have
+    /// printed it yet. Distinct from [`Self::Timeout`] only so the caller
+    /// learns that elision is in play and that moving the marker earlier is a
+    /// remedy a longer deadline cannot supply (KEL-134).
     MarkerPossiblyElided {
         /// What the caller was waiting for.
         waiting_for: &'static str,
@@ -71,10 +73,12 @@ impl std::fmt::Display for HelloSessionError {
                 elided_bytes,
             } => write!(
                 f,
-                "KELD-CORE-034: never observed {waiting_for}, and the supervisor \
-                 elided {elided_bytes} bytes of child output to stay within its \
-                 capture bound. Print the marker before the app's bulk output, \
-                 or reduce that output; raising the timeout will not help."
+                "KELD-CORE-034: never observed {waiting_for} within the deadline, \
+                 and the supervisor elided {elided_bytes} bytes of child output to \
+                 stay within its capture bound. The marker may have been printed \
+                 into the elided span, or may not have been printed yet. Print it \
+                 before the app's bulk output, or reduce that output; if the app is \
+                 merely slow, a longer deadline may still succeed."
             ),
             Self::WindowPhase { cause } => write!(
                 f,
@@ -232,8 +236,9 @@ impl HostOwnedHelloSession {
             if remaining.is_zero() {
                 // A marker printed inside the pinned head can never be elided,
                 // so an absent marker plus a non-zero drop count means the
-                // child printed it too late to survive the capture bound
-                // (KEL-134). Say so instead of blaming the deadline.
+                // marker either landed in the elided span or has not been
+                // printed yet (KEL-134). Report both possibilities rather than
+                // blaming the deadline alone, which hides the first one.
                 if captured.stdout_dropped_bytes > 0 {
                     return Err(HelloSessionError::MarkerPossiblyElided {
                         waiting_for: "Bun stdout ready marker",

--- a/crates/keld-core/src/hello_session.rs
+++ b/crates/keld-core/src/hello_session.rs
@@ -27,6 +27,16 @@ pub enum HelloSessionError {
         /// What the caller was waiting for.
         waiting_for: &'static str,
     },
+    /// The marker was never observed and the supervisor had elided output, so
+    /// the child may have printed it into the span that was dropped. Distinct
+    /// from [`Self::Timeout`] because the remedy is different: the marker must
+    /// move earlier, not the deadline later (KEL-134).
+    MarkerPossiblyElided {
+        /// What the caller was waiting for.
+        waiting_for: &'static str,
+        /// Bytes the supervisor dropped from the middle of the transcript.
+        elided_bytes: usize,
+    },
     /// Supervision reached a terminal failure while the host owned this
     /// session — the `keld dev` window phase (KEL-105). The app process is
     /// gone; any window the caller opened is still on screen, but its app
@@ -55,6 +65,16 @@ impl std::fmt::Display for HelloSessionError {
                 f,
                 "KELD-CORE-032: timed out waiting for {waiting_for}. \
                  Confirm Bun is on PATH and the project entry speaks kipc."
+            ),
+            Self::MarkerPossiblyElided {
+                waiting_for,
+                elided_bytes,
+            } => write!(
+                f,
+                "KELD-CORE-034: never observed {waiting_for}, and the supervisor \
+                 elided {elided_bytes} bytes of child output to stay within its \
+                 capture bound. Print the marker before the app's bulk output, \
+                 or reduce that output; raising the timeout will not help."
             ),
             Self::WindowPhase { cause } => write!(
                 f,
@@ -210,6 +230,16 @@ impl HostOwnedHelloSession {
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
+                // A marker printed inside the pinned head can never be elided,
+                // so an absent marker plus a non-zero drop count means the
+                // child printed it too late to survive the capture bound
+                // (KEL-134). Say so instead of blaming the deadline.
+                if captured.stdout_dropped_bytes > 0 {
+                    return Err(HelloSessionError::MarkerPossiblyElided {
+                        waiting_for: "Bun stdout ready marker",
+                        elided_bytes: captured.stdout_dropped_bytes,
+                    });
+                }
                 return Err(HelloSessionError::Timeout {
                     waiting_for: "Bun stdout ready marker",
                 });
@@ -355,8 +385,9 @@ impl HostOwnedHelloSession {
     /// live (KEL-105/KEL-116).
     ///
     /// First transition only. [`Self::wait_until_output_contains`] matches
-    /// against cumulative stdout, so a later call for a marker the app already
-    /// printed returns immediately — re-baselining there would absorb a
+    /// against the retained transcript, whose pinned head keeps an early
+    /// marker findable for the life of the session, so a later call for a
+    /// marker the app already printed returns immediately — re-baselining there would absorb a
     /// self-termination that happened after the app was live and report it as
     /// recovered.
     ///
@@ -398,27 +429,23 @@ fn recovered_termination_baseline(
     needle: &str,
     ledger: &CrashLedger,
 ) -> RecoveredTerminations {
-    // Once the supervisor has elided output to honour its retention bound
-    // (KEL-134), a byte index into the retained transcript is no longer a
-    // stream offset, so it cannot be ordered against the ledger's
-    // total-written offsets. Baseline nothing rather than compare two
-    // coordinate systems: that can only surface a termination, never excuse
-    // one, which is the direction KEL-105/KEL-116 require.
-    if dropped > 0 {
-        return RecoveredTerminations::default();
-    }
     let Some(marker_end) = stdout.find(needle).map(|start| start + needle.len()) else {
         return RecoveredTerminations::default();
     };
+    // The ledger publishes total-written offsets, so the marker's index in the
+    // retained transcript has to be lifted into the same coordinate system
+    // once the supervisor has elided output (KEL-134). The head is pinned, so
+    // a marker inside it is already at its stream offset.
+    let marker_offset = keld_runtime::CapturedOutput::stream_offset(marker_end, dropped);
     RecoveredTerminations {
-        crashes: if marker_end > ledger.stdout_len_at_last_crash {
+        crashes: if marker_offset > ledger.stdout_len_at_last_crash {
             ledger.count
         } else {
             0
         },
         all: ledger
             .last_self_termination
-            .filter(|termination| marker_end > termination.stdout_len)
+            .filter(|termination| marker_offset > termination.stdout_len)
             .map_or(0, |_| ledger.self_termination_count),
     }
 }
@@ -706,12 +733,11 @@ mod ready_baseline_tests {
     }
 
     #[test]
-    fn an_elided_transcript_forgives_nothing() {
-        // KEL-134: once the supervisor elides output, a byte index into the
-        // retained transcript is not a stream offset. The same inputs that
-        // would forgive a crash with an intact transcript must forgive nothing
-        // once bytes have been dropped, because the safe direction is to
-        // surface a termination rather than excuse it (KEL-105/KEL-116).
+    fn a_marker_in_the_pinned_head_is_still_ordered_after_elision() {
+        // KEL-134: the head is pinned, so a marker inside it keeps its true
+        // stream offset even after the middle has been elided. Refusing to
+        // compare there would turn a crash the supervisor already recovered
+        // from into a fatal window-phase error over a healthy app.
         let crashed = "gen1 booting\n";
         let stdout = format!("{crashed}{READY}\n");
         let ledger = ledger_at(1, crashed.len());
@@ -721,9 +747,28 @@ mod ready_baseline_tests {
             "control: with an intact transcript this crash is forgiven"
         );
         assert_eq!(
-            recovered_termination_baseline(&stdout, 1, READY, &ledger),
-            RecoveredTerminations::default(),
-            "one elided byte is enough to make the offsets incomparable"
+            recovered_termination_baseline(&stdout, 512 * 1024, READY, &ledger),
+            RecoveredTerminations { crashes: 1, all: 1 },
+            "the marker sits in the pinned head, so elision cannot change the verdict"
+        );
+    }
+
+    #[test]
+    fn a_marker_past_the_pinned_head_is_shifted_by_the_elided_count() {
+        // A marker found beyond the pinned head really sits `dropped` bytes
+        // further into the stream than its retained index says. Ordering must
+        // use the shifted offset, or a post-ready crash reads as pre-ready.
+        let filler = "f".repeat(keld_runtime::CAPTURE_HEAD_BYTES + 16);
+        let stdout = format!("{filler}{READY}\n");
+        let marker_offset = filler.len() + READY.len();
+        let dropped = 4096;
+        // Crash recorded between the retained index and the true offset: only
+        // the shifted comparison places the marker after it.
+        let ledger = ledger_at(1, marker_offset + 1);
+        assert_eq!(
+            recovered_termination_baseline(&stdout, dropped, READY, &ledger),
+            RecoveredTerminations { crashes: 1, all: 1 },
+            "the shifted offset must place the marker after the crash"
         );
     }
 

--- a/crates/keld-core/src/hello_session.rs
+++ b/crates/keld-core/src/hello_session.rs
@@ -206,9 +206,16 @@ impl HostOwnedHelloSession {
     /// Drains supervisor events so a crash-loop surfaces as
     /// [`HelloSessionError::Runtime`] instead of a hang.
     ///
+    /// Matches against the supervisor's retained transcript, which is bounded
+    /// (KEL-134). A marker printed within the pinned head stays findable for
+    /// the life of the session; one printed after the app's bulk output can be
+    /// elided before any poll observes it.
+    ///
     /// # Errors
     ///
-    /// Returns [`HelloSessionError::Timeout`] when `timeout` elapses, or
+    /// Returns [`HelloSessionError::Timeout`] when `timeout` elapses with no
+    /// output elided, [`HelloSessionError::MarkerPossiblyElided`] when it
+    /// elapses after the supervisor dropped output, or
     /// [`HelloSessionError::Runtime`] if supervision ends before the marker.
     pub fn wait_until_output_contains(
         &self,

--- a/crates/keld-host/src/main.rs
+++ b/crates/keld-host/src/main.rs
@@ -213,9 +213,15 @@ fn run_supervised_guardian(args: &[String]) -> Result<(), String> {
             "KELD-CORE-037: supervised Bun guardian failed — {error}. Fix the Bun app failure and relaunch the no-flag host."
         )
     })?;
+    let stdout_notice = keld_runtime::CapturedOutput::elision_notice(report.stdout_dropped_bytes)
+        .unwrap_or_default();
+    let stderr_notice = keld_runtime::CapturedOutput::elision_notice(report.stderr_dropped_bytes)
+        .unwrap_or_default();
     std::io::stderr()
         .write_all(report.stdout.as_bytes())
+        .and_then(|()| std::io::stderr().write_all(stdout_notice.as_bytes()))
         .and_then(|()| std::io::stderr().write_all(report.stderr.as_bytes()))
+        .and_then(|()| std::io::stderr().write_all(stderr_notice.as_bytes()))
         .map_err(|source| format!("KELD-CORE-037: guardian stderr failed — {source}. Retry."))?;
     Ok(())
 }

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -348,8 +348,8 @@ impl CapturedOutput {
     }
 
     /// Appends `chunk`, counts `raw_len` bytes against the total, and elides
-    /// the middle back to [`CAPTURE_RETENTION_BYTES`] once the buffer exceeds
-    /// the slack ceiling.
+    /// the middle within [`CAPTURE_MAX_RETAINED_BYTES`] once the buffer exceeds
+    /// that ceiling. Line-boundary preservation may consume compaction slack.
     ///
     /// `raw_len` is the byte count the child actually wrote. It is passed
     /// separately because `chunk` has already been through
@@ -386,15 +386,9 @@ impl CapturedOutput {
         }
         let (head_end, head_is_line_aligned) = Self::head_cut(stream);
         let tail_start = Self::tail_cut(stream);
-        // Reachable when the retained region holds no newline after the head
-        // position and the character-boundary walk pushes the head cut past the
-        // tail cut — a single line longer than the retained region. Skipping
-        // compaction there would let that line defeat the ceiling, so the cut
-        // is taken at the character boundary instead and the separator below
-        // keeps the fragments distinct.
-        if tail_start <= head_end {
-            return;
-        }
+        // The head search is capped at MAX - TAIL. Since compaction only
+        // runs above MAX, tail_cut starts strictly after that cap; these cuts
+        // cannot overlap. A line-free head falls back to its UTF-8 boundary.
         stream.drain(head_end..tail_start);
         *dropped = dropped.saturating_add(tail_start - head_end);
         if !head_is_line_aligned {
@@ -409,19 +403,26 @@ impl CapturedOutput {
     /// can land inside a multi-byte character, and slicing there panics.
     fn head_cut(stream: &str) -> (usize, bool) {
         let from = Self::boundary_at_or_after(stream, CAPTURE_HEAD_BYTES);
-        stream[from..]
-            .find('\n')
+        let limit = CAPTURE_MAX_RETAINED_BYTES - CAPTURE_TAIL_BYTES;
+        // Search bytes so the upper bound need not be a UTF-8 boundary. A
+        // newline is ASCII; its following byte is always a character boundary.
+        stream.as_bytes()[from..limit]
+            .iter()
+            .position(|byte| *byte == b'\n')
             .map_or((from, false), |offset| (from + offset + 1, true))
     }
 
-    /// Start of the sliding tail: the byte after the first newline at or after
-    /// the tail window, else the character boundary there. Same boundary-first
+    /// Start of the sliding tail: the byte after the first nonterminal newline
+    /// at or after the tail window, else the character boundary there. Same boundary-first
     /// rule as [`Self::head_cut`].
     fn tail_cut(stream: &str) -> usize {
         let from =
             Self::boundary_at_or_after(stream, stream.len().saturating_sub(CAPTURE_TAIL_BYTES));
         stream[from..]
             .find('\n')
+            // Cutting after an EOF newline would discard the entire recent
+            // tail. Preserve its character-aligned suffix in that case.
+            .filter(|offset| from + offset + 1 < stream.len())
             .map_or(from, |offset| from + offset + 1)
     }
 
@@ -2853,6 +2854,46 @@ mod tests {
             captured.stdout.len() >= CAPTURE_RETENTION_BYTES,
             "compaction must keep the retention target, not empty the tail"
         );
+    }
+
+    #[test]
+    fn capture_late_newline_cannot_defeat_the_retention_ceiling() {
+        for is_stdout in [true, false] {
+            let mut captured = CapturedOutput::default();
+            let chunk = "x".repeat(4096);
+            for _ in 0..(CAPTURE_MAX_RETAINED_BYTES / chunk.len()) {
+                captured.push_chunk(&chunk, chunk.len(), is_stdout);
+            }
+            let terminated = format!("{}\n", "y".repeat(4095));
+            for _ in 0..100 {
+                captured.push_chunk(&terminated, terminated.len(), is_stdout);
+                let (stream, total, dropped, separators) = if is_stdout {
+                    (
+                        &captured.stdout,
+                        captured.stdout_total_bytes,
+                        captured.stdout_dropped_bytes,
+                        captured.stdout_separator_bytes,
+                    )
+                } else {
+                    (
+                        &captured.stderr,
+                        captured.stderr_total_bytes,
+                        captured.stderr_dropped_bytes,
+                        captured.stderr_separator_bytes,
+                    )
+                };
+                assert!(
+                    stream.len() <= CAPTURE_MAX_RETAINED_BYTES,
+                    "retained {} exceeds {}",
+                    stream.len(),
+                    CAPTURE_MAX_RETAINED_BYTES
+                );
+                assert_eq!(total - dropped + separators, stream.len());
+                assert!(stream.starts_with(&"x".repeat(CAPTURE_HEAD_BYTES)));
+                assert!(stream.ends_with(&terminated));
+                assert!(dropped > 0);
+            }
+        }
     }
 
     /// Splicing the head's trailing partial line onto the tail's leading

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -321,10 +321,12 @@ pub struct CapturedOutput {
     /// longer retained. Never reset by a restart; monotonic non-decreasing.
     pub stderr_total_bytes: usize,
     /// Stdout bytes elided from the middle to honour the retention bound.
-    /// Invariant: `stdout_total_bytes - stdout_dropped_bytes == stdout.len()`.
+    /// Invariant while the child writes valid UTF-8:
+    /// `stdout_total_bytes - stdout_dropped_bytes == stdout.len()`.
     pub stdout_dropped_bytes: usize,
     /// Stderr bytes elided from the middle to honour the retention bound.
-    /// Invariant: `stderr_total_bytes - stderr_dropped_bytes == stderr.len()`.
+    /// Invariant while the child writes valid UTF-8:
+    /// `stderr_total_bytes - stderr_dropped_bytes == stderr.len()`.
     pub stderr_dropped_bytes: usize,
 }
 
@@ -339,29 +341,72 @@ impl CapturedOutput {
         Self::tail(&self.stderr, max_chars)
     }
 
-    /// Appends `chunk`, counts every byte, and elides the middle back to
-    /// [`CAPTURE_RETENTION_BYTES`] once the buffer exceeds the slack ceiling.
+    /// Appends `chunk`, counts `raw_len` bytes against the total, and elides
+    /// the middle back to [`CAPTURE_RETENTION_BYTES`] once the buffer exceeds
+    /// the slack ceiling.
+    ///
+    /// `raw_len` is the byte count the child actually wrote. It is passed
+    /// separately because `chunk` has already been through
+    /// `String::from_utf8_lossy`, which expands each invalid byte into a
+    /// three-byte replacement character; counting the decoded length would
+    /// overstate every ordering offset the ledger publishes.
+    ///
+    /// Both cut points land on a **line** boundary where one exists within the
+    /// elided span, so the pinned head never has its trailing partial line
+    /// concatenated onto the tail's leading partial line — that would render a
+    /// line the child never printed. Where the span contains no newline the
+    /// cut falls back to a UTF-8 character boundary, which keeps the retained
+    /// transcript valid at the cost of splitting one very long line.
     ///
     /// The pinned head is never evicted, so output a child printed before a
-    /// flood still reaches the host. Both cut points land on UTF-8 character
-    /// boundaries, so the retained transcript stays valid UTF-8 and the drop
-    /// count is exactly the bytes removed.
-    fn append(stream: &mut String, total: &mut usize, dropped: &mut usize, chunk: &str) {
-        *total = total.saturating_add(chunk.len());
+    /// flood still reaches the host.
+    fn append(
+        stream: &mut String,
+        total: &mut usize,
+        dropped: &mut usize,
+        chunk: &str,
+        raw_len: usize,
+    ) {
+        *total = total.saturating_add(raw_len);
         stream.push_str(chunk);
         if stream.len() <= CAPTURE_MAX_RETAINED_BYTES {
             return;
         }
-        // First boundary at or after the pinned head.
-        let head_end = Self::boundary_at_or_after(stream, CAPTURE_HEAD_BYTES);
-        // First boundary at or after the start of the sliding tail.
-        let tail_start =
-            Self::boundary_at_or_after(stream, stream.len().saturating_sub(CAPTURE_TAIL_BYTES));
+        let head_end = Self::head_cut(stream);
+        let tail_start = Self::tail_cut(stream);
+        // Reachable when the elided span holds no newline and the byte-boundary
+        // walk pushes the head cut past the tail cut — a single line longer
+        // than the retained region. Skipping compaction there is deliberate:
+        // the alternative is splitting that line, and the ceiling is restored
+        // on the next chunk that introduces a boundary.
         if tail_start <= head_end {
             return;
         }
         stream.drain(head_end..tail_start);
         *dropped = dropped.saturating_add(tail_start - head_end);
+    }
+
+    /// End of the pinned head: the byte after the first newline at or after
+    /// [`CAPTURE_HEAD_BYTES`], else the character boundary there.
+    ///
+    /// The character boundary is resolved *before* slicing: `CAPTURE_HEAD_BYTES`
+    /// can land inside a multi-byte character, and slicing there panics.
+    fn head_cut(stream: &str) -> usize {
+        let from = Self::boundary_at_or_after(stream, CAPTURE_HEAD_BYTES);
+        stream[from..]
+            .find('\n')
+            .map_or(from, |offset| from + offset + 1)
+    }
+
+    /// Start of the sliding tail: the byte after the first newline at or after
+    /// the tail window, else the character boundary there. Same boundary-first
+    /// rule as [`Self::head_cut`].
+    fn tail_cut(stream: &str) -> usize {
+        let from =
+            Self::boundary_at_or_after(stream, stream.len().saturating_sub(CAPTURE_TAIL_BYTES));
+        stream[from..]
+            .find('\n')
+            .map_or(from, |offset| from + offset + 1)
     }
 
     /// Smallest UTF-8 character boundary at or after `index`, clamped to the
@@ -377,14 +422,45 @@ impl CapturedOutput {
         boundary
     }
 
+    /// Stream offset of the byte at `retained_index` in a transcript that has
+    /// elided `dropped` bytes.
+    ///
+    /// The head is pinned, so an index at or below [`CAPTURE_HEAD_BYTES`] is
+    /// already its own stream offset; everything after the elision is shifted
+    /// by the elided count. Indices in the few bytes between
+    /// [`CAPTURE_HEAD_BYTES`] and the actual head cut are treated as head
+    /// indices, which under-reports the offset rather than over-reports it —
+    /// the direction that surfaces a termination instead of excusing one.
+    #[must_use]
+    pub fn stream_offset(retained_index: usize, dropped: usize) -> usize {
+        if dropped == 0 || retained_index <= CAPTURE_HEAD_BYTES {
+            retained_index
+        } else {
+            retained_index.saturating_add(dropped)
+        }
+    }
+
+    /// One line naming how much output was elided, for a consumer that renders
+    /// the transcript to a human. `None` when nothing was dropped.
+    #[must_use]
+    pub fn elision_notice(dropped: usize) -> Option<String> {
+        (dropped > 0).then(|| {
+            format!("[keld: {dropped} bytes of child output elided between the retained head and tail (KELD-RUNTIME capture bound)]\n")
+        })
+    }
+
     /// Records a captured chunk against the stream `is_stdout` selects.
-    fn push_chunk(&mut self, chunk: &str, is_stdout: bool) {
+    ///
+    /// `raw_len` is the number of bytes read from the child, before lossy
+    /// UTF-8 decoding.
+    fn push_chunk(&mut self, chunk: &str, raw_len: usize, is_stdout: bool) {
         if is_stdout {
             Self::append(
                 &mut self.stdout,
                 &mut self.stdout_total_bytes,
                 &mut self.stdout_dropped_bytes,
                 chunk,
+                raw_len,
             );
         } else {
             Self::append(
@@ -392,6 +468,7 @@ impl CapturedOutput {
                 &mut self.stderr_total_bytes,
                 &mut self.stderr_dropped_bytes,
                 chunk,
+                raw_len,
             );
         }
     }
@@ -1689,7 +1766,7 @@ fn spawn_capture_thread(
                     Ok(n) => {
                         let chunk = String::from_utf8_lossy(&buf[..n]);
                         let mut guard = output.lock().unwrap_or_else(PoisonError::into_inner);
-                        guard.push_chunk(&chunk, is_stdout);
+                        guard.push_chunk(&chunk, n, is_stdout);
                     }
                 }
             }
@@ -1748,7 +1825,7 @@ fn spawn_capture_thread(
                     Ok(n) => {
                         let chunk = String::from_utf8_lossy(&buf[..n]);
                         let mut guard = output.lock().unwrap_or_else(PoisonError::into_inner);
-                        guard.push_chunk(&chunk, is_stdout);
+                        guard.push_chunk(&chunk, n, is_stdout);
                         let _ =
                             budget.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
                                 (current != u64::MAX).then_some(current.saturating_sub(n as u64))
@@ -2735,8 +2812,8 @@ mod tests {
         let chunk = "x".repeat(4096);
         let chunks = (CAPTURE_MAX_RETAINED_BYTES / chunk.len()) * 4;
         for _ in 0..chunks {
-            captured.push_chunk(&chunk, true);
-            captured.push_chunk(&chunk, false);
+            captured.push_chunk(&chunk, chunk.len(), true);
+            captured.push_chunk(&chunk, chunk.len(), false);
         }
         let written = chunk.len() * chunks;
 
@@ -2776,6 +2853,69 @@ mod tests {
         );
     }
 
+    /// Splicing the head's trailing partial line onto the tail's leading
+    /// partial line would render a line the child never printed. Every
+    /// retained line must be one the child actually wrote.
+    #[test]
+    fn elision_never_fabricates_a_line() {
+        let mut captured = CapturedOutput::default();
+        // Distinct, self-identifying lines: any concatenation of two halves is
+        // detectable because a well-formed line has exactly one "|end" marker.
+        for index in 0..40_000 {
+            captured.push_chunk(&format!("line-{index:06}-payload|end\n"), 28, true);
+        }
+        assert!(captured.stdout_dropped_bytes > 0, "the test must elide");
+        for line in captured.stdout.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            assert_eq!(
+                line.matches("|end").count(),
+                1,
+                "a spliced line was fabricated: {line:?}"
+            );
+            assert!(
+                line.starts_with("line-") && line.ends_with("|end"),
+                "retained line is not one the child wrote: {line:?}"
+            );
+        }
+    }
+
+    /// The total counts bytes the child wrote, not the length of the lossy
+    /// UTF-8 decoding. An invalid byte expands to a three-byte replacement
+    /// character, which would otherwise inflate every published offset.
+    #[test]
+    fn totals_count_raw_bytes_not_lossy_decoded_length() {
+        let mut captured = CapturedOutput::default();
+        let decoded = String::from_utf8_lossy(&[0xff, 0xfe, 0xfd]).into_owned();
+        assert!(
+            decoded.len() > 3,
+            "precondition: lossy decoding must expand these bytes"
+        );
+        captured.push_chunk(&decoded, 3, true);
+        assert_eq!(
+            captured.stdout_total_bytes, 3,
+            "the child wrote three bytes, whatever the decoding cost"
+        );
+    }
+
+    /// `stream_offset` lifts a retained index into the stream coordinate the
+    /// ledger publishes.
+    #[test]
+    fn stream_offset_pins_the_head_and_shifts_the_tail() {
+        assert_eq!(CapturedOutput::stream_offset(10, 0), 10, "no elision");
+        assert_eq!(
+            CapturedOutput::stream_offset(10, 4096),
+            10,
+            "an index inside the pinned head is already a stream offset"
+        );
+        assert_eq!(
+            CapturedOutput::stream_offset(CAPTURE_HEAD_BYTES + 1, 4096),
+            CAPTURE_HEAD_BYTES + 1 + 4096,
+            "an index past the head is shifted by the elided count"
+        );
+    }
+
     /// A child announces itself before it floods. `keld-host` forwards the
     /// retained transcript, so evicting the pinned head would lose the ready
     /// marker that `no_flag_macos`/`no_flag_linux` assert is forwarded after
@@ -2784,10 +2924,10 @@ mod tests {
     fn bounded_capture_pins_the_head_against_a_later_flood() {
         let mut captured = CapturedOutput::default();
         let marker = "KELD_EARLY_MARKER\n";
-        captured.push_chunk(marker, true);
+        captured.push_chunk(marker, marker.len(), true);
         let noise = "x".repeat(4096);
         for _ in 0..((CAPTURE_MAX_RETAINED_BYTES / noise.len()) * 8) {
-            captured.push_chunk(&noise, true);
+            captured.push_chunk(&noise, noise.len(), true);
         }
         assert!(
             captured.stdout_dropped_bytes > 0,
@@ -2818,7 +2958,7 @@ mod tests {
         let chunk = "\u{20ac}".repeat(4096);
         let chunks = (CAPTURE_MAX_RETAINED_BYTES / chunk.len()) * 4;
         for _ in 0..chunks {
-            captured.push_chunk(&chunk, true);
+            captured.push_chunk(&chunk, chunk.len(), true);
         }
         assert!(captured.stdout_dropped_bytes > 0, "the test must truncate");
         assert!(

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -3142,6 +3142,124 @@ mod tests {
         command
     }
 
+    /// Resident set size of this process in bytes.
+    ///
+    /// `ps` is used rather than a memory-info crate so the soak below needs no
+    /// dependency addition. Nextest runs each test in its own process, so the
+    /// reading is not polluted by sibling tests.
+    #[cfg(unix)]
+    fn process_rss_bytes() -> Option<usize> {
+        let output = Command::new("ps")
+            .args(["-o", "rss=", "-p"])
+            .arg(std::process::id().to_string())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        // `ps` reports kibibytes on both macOS and Linux.
+        String::from_utf8(output.stdout)
+            .ok()?
+            .trim()
+            .parse::<usize>()
+            .ok()
+            .map(|kib| kib * 1024)
+    }
+
+    /// Windows has no dependency-free RSS reading here, so the soak relies on
+    /// its per-sample retained-byte ceiling on that row. Adding a memory-info
+    /// crate for one assertion would be a dependency-addition review gate.
+    #[cfg(windows)]
+    fn process_rss_bytes() -> Option<usize> {
+        None
+    }
+
+    /// KEL-134 bounded soak: a child printing continuously must not grow the
+    /// supervisor's retained memory, sampled *throughout* the run rather than
+    /// only at the end — growth over time is the defect, and a single final
+    /// reading cannot see it.
+    ///
+    /// The negative control is the same one the rest of the suite uses:
+    /// deleting the compaction branch retains everything the child wrote, so
+    /// both the per-sample ceiling and the RSS ceiling below fail by a wide
+    /// margin.
+    #[test]
+    fn continuous_output_soak_keeps_memory_bounded() {
+        // Two orders of magnitude past the retention ceiling, still ~1s of pipe
+        // traffic. Large enough that unbounded retention is unmistakable.
+        let target_bytes = CAPTURE_MAX_RETAINED_BYTES * 200;
+        let rss_growth_ceiling = 32 * 1024 * 1024;
+        let baseline_rss = process_rss_bytes();
+
+        let sup = Supervisor::start(RestartPolicy::default(), move || {
+            chatty_helper_command(target_bytes)
+        })
+        .expect("first spawn must succeed");
+
+        let deadline = Instant::now() + Duration::from_mins(1);
+        let mut samples = 0_usize;
+        let mut peak_retained = 0_usize;
+        let mut peak_rss_growth = 0_usize;
+        loop {
+            let captured = sup.output();
+            peak_retained = peak_retained.max(captured.stdout.len());
+            assert!(
+                captured.stdout.len()
+                    <= CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes,
+                "retained stdout exceeded the ceiling mid-soak at sample {samples}: {} > {}",
+                captured.stdout.len(),
+                CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes
+            );
+            if let (Some(baseline), Some(now)) = (baseline_rss, process_rss_bytes()) {
+                peak_rss_growth = peak_rss_growth.max(now.saturating_sub(baseline));
+            }
+            samples += 1;
+            if captured.stdout_total_bytes >= target_bytes {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the chatty child did not reach {target_bytes} bytes within the soak deadline; \
+                 wrote {} over {samples} samples",
+                captured.stdout_total_bytes
+            );
+            thread::yield_now();
+        }
+
+        match sup.wait_for_outcome() {
+            SupervisorOutcome::Stopped => {}
+            other => panic!("soak child should exit zero and stop, got {other:?}"),
+        }
+
+        let captured = sup.output();
+        assert!(
+            captured.stdout_total_bytes >= target_bytes,
+            "the soak must actually have written past the ceiling: {} < {target_bytes}",
+            captured.stdout_total_bytes
+        );
+        assert!(
+            samples > 1,
+            "the soak must sample while the child is live, not once at the end"
+        );
+        assert!(
+            peak_retained <= CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes,
+            "peak retained stdout exceeded the ceiling: {peak_retained}"
+        );
+        assert!(
+            captured.stdout_dropped_bytes > 0,
+            "a soak past the ceiling must have elided output: {captured:?}"
+        );
+
+        if baseline_rss.is_some() {
+            assert!(
+                peak_rss_growth <= rss_growth_ceiling,
+                "resident memory grew {peak_rss_growth} bytes while the child wrote {} — \
+                 the capture bound is not holding",
+                captured.stdout_total_bytes
+            );
+        }
+    }
+
     #[test]
     fn chatty_helper_process() {
         let Some(target) = std::env::var_os("KELD_RUNTIME_CHATTY_BYTES") else {

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -2863,8 +2863,12 @@ mod tests {
         let mut captured = CapturedOutput::default();
         // Distinct, self-identifying lines: any concatenation of two halves is
         // detectable because a well-formed line has exactly one "|end" marker.
+        let mut written = 0_usize;
         for index in 0..40_000 {
-            captured.push_chunk(&format!("line-{index:06}-payload|end\n"), 28, true);
+            let line = format!("line-{index:06}-payload|end\n");
+            let raw_len = line.len();
+            written += raw_len;
+            captured.push_chunk(&line, raw_len, true);
         }
         assert!(captured.stdout_dropped_bytes > 0, "the test must elide");
         for line in captured.stdout.lines() {
@@ -2881,6 +2885,17 @@ mod tests {
                 "retained line is not one the child wrote: {line:?}"
             );
         }
+        assert_eq!(
+            captured.stdout_total_bytes, written,
+            "the total must equal what this test actually wrote, or the \
+             accounting under test is being measured against a fiction"
+        );
+        assert_eq!(
+            captured.stdout_total_bytes - captured.stdout_dropped_bytes
+                + captured.stdout_separator_bytes,
+            captured.stdout.len(),
+            "total, dropped, separators and retained must describe one stream"
+        );
     }
 
     /// Output with no newline in range has no line structure to cut on, so the

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -292,8 +292,9 @@ pub const CAPTURE_MAX_RETAINED_BYTES: usize =
 /// `stdout` and `stderr` are **bounded transcripts**, not whole streams: at
 /// most [`CAPTURE_MAX_RETAINED_BYTES`] per stream is retained, as a pinned
 /// head of [`CAPTURE_HEAD_BYTES`] followed by a sliding tail. Only the middle
-/// is elided, so an early ready marker or first error survives an arbitrarily
-/// long later flood.
+/// is elided. Text wholly inside the pinned head survives later floods, but
+/// arbitrary markers may be dropped. Use [`Supervisor::start_with_stdout_markers`]
+/// for diagnostic markers whose first observation must survive elision.
 ///
 /// The `*_total_bytes` counters record everything the child wrote and never
 /// reset across restart generations, so an ordering fact taken from them stays
@@ -703,7 +704,7 @@ fn shutdown_was_accepted(state: &AtomicBool) -> bool {
 #[derive(Debug)]
 pub struct Supervisor {
     events_rx: Receiver<SupervisorEvent>,
-    output: Arc<Mutex<CapturedOutput>>,
+    output: Arc<Mutex<CaptureState>>,
     current_pid: Arc<Mutex<Option<u32>>>,
     crash_loop_error: Arc<Mutex<Option<RuntimeError>>>,
     crashes: Arc<Mutex<CrashLedger>>,
@@ -714,6 +715,107 @@ pub struct Supervisor {
     #[cfg(any(target_os = "linux", windows))]
     restart_attempt: Arc<AtomicU32>,
     thread: Option<JoinHandle<()>>,
+}
+
+/// Capture-owned marker state shares the transcript lock and raw-byte clock.
+#[derive(Debug)]
+struct CaptureState {
+    transcript: CapturedOutput,
+    markers: Vec<StdoutMarker>,
+}
+
+#[derive(Debug)]
+struct StdoutMarker {
+    bytes: Vec<u8>,
+    prefix: Vec<usize>,
+    matched: usize,
+    first_end: Option<usize>,
+}
+
+impl CaptureState {
+    fn new(markers: &[&str]) -> Result<Self, RuntimeError> {
+        if markers.len() > 32
+            || markers
+                .iter()
+                .map(|marker| marker.len())
+                .try_fold(0_usize, usize::checked_add)
+                .is_none_or(|total| total > 4096)
+            || markers
+                .iter()
+                .enumerate()
+                .any(|(index, marker)| marker.is_empty() || markers[..index].contains(marker))
+        {
+            return Err(RuntimeError::Lifecycle {
+                phase: "stdout marker registration",
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "register at most 32 unique nonempty stdout markers totaling at most 4096 UTF-8 bytes",
+                ),
+            });
+        }
+        let markers = markers
+            .iter()
+            .map(|marker| {
+                let bytes = marker.as_bytes().to_vec();
+                let mut prefix = vec![0; bytes.len()];
+                let mut matched = 0;
+                for index in 1..bytes.len() {
+                    while matched > 0 && bytes[index] != bytes[matched] {
+                        matched = prefix[matched - 1];
+                    }
+                    if bytes[index] == bytes[matched] {
+                        matched += 1;
+                    }
+                    prefix[index] = matched;
+                }
+                StdoutMarker {
+                    bytes,
+                    prefix,
+                    matched: 0,
+                    first_end: None,
+                }
+            })
+            .collect();
+        Ok(Self {
+            transcript: CapturedOutput::default(),
+            markers,
+        })
+    }
+
+    fn begin_generation(&mut self) {
+        for marker in &mut self.markers {
+            marker.matched = 0;
+        }
+    }
+
+    fn push_raw(&mut self, bytes: &[u8], is_stdout: bool) {
+        if is_stdout {
+            for marker in &mut self.markers {
+                if marker.first_end.is_some() {
+                    continue;
+                }
+                for (index, byte) in bytes.iter().enumerate() {
+                    while marker.matched > 0 && *byte != marker.bytes[marker.matched] {
+                        marker.matched = marker.prefix[marker.matched - 1];
+                    }
+                    if *byte == marker.bytes[marker.matched] {
+                        marker.matched += 1;
+                    }
+                    if marker.matched == marker.bytes.len() {
+                        marker.first_end = Some(
+                            self.transcript
+                                .stdout_total_bytes
+                                .saturating_add(index)
+                                .saturating_add(1),
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+        self.transcript
+            .push_chunk(&String::from_utf8_lossy(bytes), bytes.len(), is_stdout);
+    }
 }
 
 impl Supervisor {
@@ -729,16 +831,55 @@ impl Supervisor {
     /// # Errors
     ///
     /// Returns [`RuntimeError::Spawn`] if the very first spawn attempt fails.
-    pub fn start<F>(policy: RestartPolicy, mut command_factory: F) -> Result<Self, RuntimeError>
+    pub fn start<F>(policy: RestartPolicy, command_factory: F) -> Result<Self, RuntimeError>
     where
         F: FnMut() -> Command + Send + 'static,
     {
-        Self::start_prepared(
+        Self::start_with_stdout_markers(policy, &[], command_factory)
+    }
+
+    /// Starts supervision with raw stdout markers registered before the first spawn.
+    ///
+    /// Accepts at most 32 unique, nonempty markers totaling at most 4096 UTF-8
+    /// bytes. Matches span reads, but never child generations. First-match raw
+    /// byte end offsets survive transcript elision and restarts. Registration
+    /// allocates bounded matcher state; matching adds no per-read allocation.
+    ///
+    /// # Errors
+    /// Returns [`RuntimeError::Lifecycle`] with phase `stdout marker registration`
+    /// and an `InvalidInput` source for invalid markers, before calling the factory.
+    /// First-spawn failures are returned as [`RuntimeError::Spawn`].
+    pub fn start_with_stdout_markers<F>(
+        policy: RestartPolicy,
+        markers: &[&str],
+        mut command_factory: F,
+    ) -> Result<Self, RuntimeError>
+    where
+        F: FnMut() -> Command + Send + 'static,
+    {
+        Self::start_prepared_with_capture(
             policy,
             CommandPreparer {
                 factory: move || command_factory(),
             },
+            CaptureState::new(markers)?,
         )
+    }
+
+    /// Returns the immutable first raw-byte end offset of a registered marker.
+    ///
+    /// Outer `None` means unregistered; `Some(None)` means not yet observed.
+    /// Offsets share [`CrashLedger::stdout_len_at_last_crash`]'s coordinate,
+    /// not indices into the retained or lossily decoded transcript.
+    #[must_use]
+    pub fn stdout_marker_offset(&self, marker: &str) -> Option<Option<usize>> {
+        self.output
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .markers
+            .iter()
+            .find(|entry| entry.bytes == marker.as_bytes())
+            .map(|entry| entry.first_end)
     }
 
     /// Starts supervision from a fresh prepared-child factory.
@@ -753,10 +894,21 @@ impl Supervisor {
     where
         P: ChildPreparer,
     {
+        Self::start_prepared_with_capture(policy, preparer, CaptureState::new(&[])?)
+    }
+
+    fn start_prepared_with_capture<P>(
+        policy: RestartPolicy,
+        preparer: P,
+        capture: CaptureState,
+    ) -> Result<Self, RuntimeError>
+    where
+        P: ChildPreparer,
+    {
         let (events_tx, events_rx) = mpsc::channel();
         let (preparer_tx, preparer_rx) = mpsc::sync_channel::<P>(0);
         let (startup_tx, startup_rx) = mpsc::sync_channel::<Result<(), RuntimeError>>(0);
-        let output = Arc::new(Mutex::new(CapturedOutput::default()));
+        let output = Arc::new(Mutex::new(capture));
         let current_pid = Arc::new(Mutex::new(None));
         let crash_loop_error = Arc::new(Mutex::new(None));
         let crashes = Arc::new(Mutex::new(CrashLedger::default()));
@@ -995,6 +1147,7 @@ impl Supervisor {
         self.output
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
+            .transcript
             .clone()
     }
 
@@ -1080,7 +1233,7 @@ fn supervise<P>(
     mut child: Child,
     mut lease: P::Lease,
     events_tx: &Sender<SupervisorEvent>,
-    output: &Arc<Mutex<CapturedOutput>>,
+    output: &Arc<Mutex<CaptureState>>,
     current_pid: &Arc<Mutex<Option<u32>>>,
     crash_loop_error: &Arc<Mutex<Option<RuntimeError>>>,
     crash_ledger: &Arc<Mutex<CrashLedger>>,
@@ -1302,6 +1455,7 @@ fn supervise<P>(
                 stderr_tail: output
                     .lock()
                     .unwrap_or_else(PoisonError::into_inner)
+                    .transcript
                     .stderr_tail(2000),
             };
             *crash_loop_error
@@ -1417,7 +1571,7 @@ struct CaptureStartError {
 #[allow(clippy::too_many_lines)] // one transaction must return every partial thread/handle/budget when the second capture spawn fails
 fn start_capture_threads(
     child: &mut Child,
-    output: &Arc<Mutex<CapturedOutput>>,
+    output: &Arc<Mutex<CaptureState>>,
 ) -> Result<CaptureThreads, CaptureStartError> {
     #[cfg(windows)]
     let stdout_budget = Arc::new(AtomicU64::new(u64::MAX));
@@ -1427,6 +1581,10 @@ fn start_capture_threads(
     let stdout_lock = Arc::new(Mutex::new(()));
     #[cfg(windows)]
     let stderr_lock = Arc::new(Mutex::new(()));
+    output
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .begin_generation();
     let stdout = child.stdout.take();
     let stderr = child.stderr.take();
     #[cfg(windows)]
@@ -1715,7 +1873,7 @@ fn wait_for_self_termination(child: &mut Child) -> Option<std::process::ExitStat
 /// disagree.
 fn record_self_termination(
     crash_ledger: &Arc<Mutex<CrashLedger>>,
-    output: &Arc<Mutex<CapturedOutput>>,
+    output: &Arc<Mutex<CaptureState>>,
     pid: u32,
     exit_code: Option<i32>,
 ) {
@@ -1728,8 +1886,8 @@ fn record_self_termination(
             // Total bytes written, not the retained tail: the retained tail is
             // bounded (KEL-134) and would make this ordering point go backwards
             // once older output is dropped.
-            captured.stdout_total_bytes,
-            (exit_code != Some(0)).then(|| captured.stderr_tail(2000)),
+            captured.transcript.stdout_total_bytes,
+            (exit_code != Some(0)).then(|| captured.transcript.stderr_tail(2000)),
         )
     };
     let mut ledger = crash_ledger.lock().unwrap_or_else(PoisonError::into_inner);
@@ -1753,7 +1911,7 @@ fn record_self_termination(
 #[cfg(not(windows))]
 fn spawn_capture_thread(
     mut reader: impl Read + Send + 'static,
-    output: Arc<Mutex<CapturedOutput>>,
+    output: Arc<Mutex<CaptureState>>,
     name: &'static str,
     is_stdout: bool,
 ) -> std::io::Result<JoinHandle<()>> {
@@ -1765,9 +1923,8 @@ fn spawn_capture_thread(
                 match reader.read(&mut buf) {
                     Ok(0) | Err(_) => return,
                     Ok(n) => {
-                        let chunk = String::from_utf8_lossy(&buf[..n]);
                         let mut guard = output.lock().unwrap_or_else(PoisonError::into_inner);
-                        guard.push_chunk(&chunk, n, is_stdout);
+                        guard.push_raw(&buf[..n], is_stdout);
                     }
                 }
             }
@@ -1777,7 +1934,7 @@ fn spawn_capture_thread(
 #[cfg(windows)]
 fn spawn_capture_thread(
     mut reader: impl Read + Send + 'static,
-    output: Arc<Mutex<CapturedOutput>>,
+    output: Arc<Mutex<CaptureState>>,
     name: &'static str,
     is_stdout: bool,
     handle: Arc<AtomicUsize>,
@@ -1824,9 +1981,8 @@ fn spawn_capture_thread(
                 match reader.read(&mut buf[..read_len]) {
                     Ok(0) | Err(_) => return,
                     Ok(n) => {
-                        let chunk = String::from_utf8_lossy(&buf[..n]);
                         let mut guard = output.lock().unwrap_or_else(PoisonError::into_inner);
-                        guard.push_chunk(&chunk, n, is_stdout);
+                        guard.push_raw(&buf[..n], is_stdout);
                         let _ =
                             budget.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
                                 (current != u64::MAX).then_some(current.saturating_sub(n as u64))
@@ -1891,6 +2047,145 @@ fn wait_backoff_or_stop(
 mod tests {
     use super::*;
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn stdout_markers_match_raw_splits_overlap_and_keep_first_end() {
+        let mut state = CaptureState::new(&["ababac", "é", "pending"]).expect("valid markers");
+        state.push_raw(b"ababab", true);
+        state.push_raw(&[b'a', b'c', 0xc3], true);
+        state.push_raw(&[0xa9], true);
+        state.push_raw(b"ababac", true);
+        assert_eq!(state.markers[0].first_end, Some(8));
+        assert_eq!(state.markers[1].first_end, Some(10));
+        assert_eq!(state.markers[2].first_end, None);
+        assert_eq!(state.transcript.stdout_total_bytes, 16);
+        assert!(
+            !state.transcript.stdout.contains('é'),
+            "lossy transcript is not the matching oracle"
+        );
+    }
+
+    #[test]
+    fn stdout_markers_survive_elision_but_never_join_generations() {
+        let mut state = CaptureState::new(&["READY", "split"]).expect("valid markers");
+        let padding = vec![b'x'; 4096];
+        for _ in 0..32 {
+            state.push_raw(&padding, true);
+        }
+        state.push_raw(b"READYspli", true);
+        state.begin_generation();
+        state.push_raw(b"t", true);
+        for _ in 0..256 {
+            state.push_raw(&padding, true);
+        }
+        assert!(
+            !state.transcript.stdout.contains("READY"),
+            "regression must actually elide marker"
+        );
+        assert_eq!(state.markers[0].first_end, Some(131_077));
+        assert_eq!(state.markers[1].first_end, None);
+        state.push_raw(b"split", false);
+        assert_eq!(
+            state.markers[1].first_end, None,
+            "stderr cannot satisfy stdout"
+        );
+        state.push_raw(b"split", true);
+        assert_eq!(state.markers[1].first_end, Some(1_179_663));
+    }
+
+    #[test]
+    fn stdout_marker_registration_rejects_invalid_input_before_factory() {
+        let oversized = "x".repeat(4097);
+        for markers in [
+            vec![""],
+            vec!["a", "a"],
+            vec!["x"; 33],
+            vec![oversized.as_str()],
+        ] {
+            let error =
+                Supervisor::start_with_stdout_markers(RestartPolicy::default(), &markers, || {
+                    panic!("invalid registration must not invoke command factory")
+                })
+                .expect_err("invalid markers");
+            assert!(
+                matches!(error, RuntimeError::Lifecycle { phase: "stdout marker registration", source } if source.kind() == std::io::ErrorKind::InvalidInput)
+            );
+        }
+        assert!(CaptureState::new(&[&"x".repeat(4096)]).is_ok());
+        let names: Vec<String> = (0..32).map(|index| format!("marker-{index}")).collect();
+        let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+        assert!(CaptureState::new(&refs).is_ok());
+    }
+
+    #[test]
+    fn stdout_marker_cannot_span_real_child_generations() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let factory_calls = Arc::clone(&calls);
+        let sup = Supervisor::start_with_stdout_markers(
+            RestartPolicy::default(),
+            &["prefixsuffix", "prefix"],
+            move || {
+                let first = factory_calls.fetch_add(1, Ordering::SeqCst) == 0;
+                #[cfg(unix)]
+                let write = if first {
+                    "printf prefix"
+                } else {
+                    "printf suffix"
+                };
+                #[cfg(windows)]
+                let write = if first {
+                    "<nul set /p \"=prefix\""
+                } else {
+                    "<nul set /p \"=suffix\""
+                };
+                shell_command(&joined_steps(&[
+                    write,
+                    if first { "exit 1" } else { "exit 0" },
+                ]))
+            },
+        )
+        .expect("spawn first generation");
+        assert!(matches!(sup.wait_for_outcome(), SupervisorOutcome::Stopped));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            sup.output().stdout,
+            "prefixsuffix",
+            "both real children must write exact raw fragments"
+        );
+        assert_eq!(sup.crash_ledger().self_termination_count, 2);
+        assert_eq!(sup.crash_ledger().count, 1);
+        assert_eq!(
+            sup.stdout_marker_offset("prefix"),
+            Some(Some(6)),
+            "first-generation evidence must survive restart"
+        );
+        assert_eq!(
+            sup.stdout_marker_offset("prefixsuffix"),
+            Some(None),
+            "distinct child streams must not form a marker"
+        );
+    }
+
+    #[test]
+    fn stdout_marker_public_api_observes_real_child_and_crash_clock() {
+        let sup = Supervisor::start_with_stdout_markers(
+            RestartPolicy::default(),
+            &["out-marker", "absent"],
+            || shell_command("echo out-marker"),
+        )
+        .expect("spawn marker child");
+        assert!(matches!(sup.wait_for_outcome(), SupervisorOutcome::Stopped));
+        assert_eq!(sup.stdout_marker_offset("out-marker"), Some(Some(10)));
+        assert_eq!(sup.stdout_marker_offset("absent"), Some(None));
+        assert_eq!(sup.stdout_marker_offset("unregistered"), None);
+        assert!(
+            sup.crash_ledger()
+                .last_self_termination
+                .expect("child exited")
+                .stdout_len
+                >= 10
+        );
+    }
 
     #[derive(Clone)]
     struct RecordingLease {

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -322,12 +322,18 @@ pub struct CapturedOutput {
     pub stderr_total_bytes: usize,
     /// Stdout bytes elided from the middle to honour the retention bound.
     /// Invariant while the child writes valid UTF-8:
-    /// `stdout_total_bytes - stdout_dropped_bytes == stdout.len()`.
+    /// `stdout_total_bytes - stdout_dropped_bytes + stdout_separator_bytes == stdout.len()`.
     pub stdout_dropped_bytes: usize,
     /// Stderr bytes elided from the middle to honour the retention bound.
     /// Invariant while the child writes valid UTF-8:
-    /// `stderr_total_bytes - stderr_dropped_bytes == stderr.len()`.
+    /// `stderr_total_bytes - stderr_dropped_bytes + stderr_separator_bytes == stderr.len()`.
     pub stderr_dropped_bytes: usize,
+    /// `\n` separators inserted into `stdout` at an elision whose span held no
+    /// newline, so two line fragments cannot merge into one apparent line.
+    pub stdout_separator_bytes: usize,
+    /// `\n` separators inserted into `stderr` at an elision whose span held no
+    /// newline, so two line fragments cannot merge into one apparent line.
+    pub stderr_separator_bytes: usize,
 }
 
 impl CapturedOutput {
@@ -351,12 +357,17 @@ impl CapturedOutput {
     /// three-byte replacement character; counting the decoded length would
     /// overstate every ordering offset the ledger publishes.
     ///
-    /// Both cut points land on a **line** boundary where one exists within the
-    /// elided span, so the pinned head never has its trailing partial line
-    /// concatenated onto the tail's leading partial line — that would render a
-    /// line the child never printed. Where the span contains no newline the
-    /// cut falls back to a UTF-8 character boundary, which keeps the retained
-    /// transcript valid at the cost of splitting one very long line.
+    /// Both cut points land on a **line** boundary where one exists in range,
+    /// so the pinned head never has its trailing partial line concatenated
+    /// onto the tail's leading partial line — that would render a line the
+    /// child never printed.
+    ///
+    /// Output with no newline in range (a single very long line, or `\r`-only
+    /// progress output) has no line structure to cut on. There the cut falls
+    /// back to a UTF-8 character boundary and a single `\n` separator is
+    /// inserted, so the two fragments still cannot merge into one apparent
+    /// line. Separator bytes are counted in `separators` and are the only
+    /// reason `stream.len()` can exceed `total - dropped`.
     ///
     /// The pinned head is never evicted, so output a child printed before a
     /// flood still reaches the host.
@@ -364,6 +375,7 @@ impl CapturedOutput {
         stream: &mut String,
         total: &mut usize,
         dropped: &mut usize,
+        separators: &mut usize,
         chunk: &str,
         raw_len: usize,
     ) {
@@ -372,30 +384,34 @@ impl CapturedOutput {
         if stream.len() <= CAPTURE_MAX_RETAINED_BYTES {
             return;
         }
-        let head_end = Self::head_cut(stream);
+        let (head_end, head_is_line_aligned) = Self::head_cut(stream);
         let tail_start = Self::tail_cut(stream);
-        // Reachable when the elided span holds no newline and the byte-boundary
-        // walk pushes the head cut past the tail cut — a single line longer
-        // than the retained region. Skipping compaction there is deliberate:
-        // the alternative is splitting that line, and the ceiling is restored
-        // on the next chunk that introduces a boundary.
+        // Reachable when the retained region holds no newline after the head
+        // position and the character-boundary walk pushes the head cut past the
+        // tail cut — a single line longer than the retained region. Skipping
+        // compaction there would let that line defeat the ceiling, so the cut
+        // is taken at the character boundary instead and the separator below
+        // keeps the fragments distinct.
         if tail_start <= head_end {
             return;
         }
         stream.drain(head_end..tail_start);
         *dropped = dropped.saturating_add(tail_start - head_end);
+        if !head_is_line_aligned {
+            stream.insert(head_end, '\n');
+            *separators = separators.saturating_add(1);
+        }
     }
 
-    /// End of the pinned head: the byte after the first newline at or after
-    /// [`CAPTURE_HEAD_BYTES`], else the character boundary there.
+    /// End of the pinned head, and whether it lands just after a newline.
     ///
     /// The character boundary is resolved *before* slicing: `CAPTURE_HEAD_BYTES`
     /// can land inside a multi-byte character, and slicing there panics.
-    fn head_cut(stream: &str) -> usize {
+    fn head_cut(stream: &str) -> (usize, bool) {
         let from = Self::boundary_at_or_after(stream, CAPTURE_HEAD_BYTES);
         stream[from..]
             .find('\n')
-            .map_or(from, |offset| from + offset + 1)
+            .map_or((from, false), |offset| (from + offset + 1, true))
     }
 
     /// Start of the sliding tail: the byte after the first newline at or after
@@ -441,6 +457,7 @@ impl CapturedOutput {
                 &mut self.stdout,
                 &mut self.stdout_total_bytes,
                 &mut self.stdout_dropped_bytes,
+                &mut self.stdout_separator_bytes,
                 chunk,
                 raw_len,
             );
@@ -449,6 +466,7 @@ impl CapturedOutput {
                 &mut self.stderr,
                 &mut self.stderr_total_bytes,
                 &mut self.stderr_dropped_bytes,
+                &mut self.stderr_separator_bytes,
                 chunk,
                 raw_len,
             );
@@ -2821,12 +2839,14 @@ mod tests {
             "dropping output must be disclosed, not silent"
         );
         assert_eq!(
-            captured.stdout_total_bytes - captured.stdout_dropped_bytes,
+            captured.stdout_total_bytes - captured.stdout_dropped_bytes
+                + captured.stdout_separator_bytes,
             captured.stdout.len(),
-            "total, dropped and retained must describe one stream"
+            "total, dropped, separators and retained must describe one stream"
         );
         assert_eq!(
-            captured.stderr_total_bytes - captured.stderr_dropped_bytes,
+            captured.stderr_total_bytes - captured.stderr_dropped_bytes
+                + captured.stderr_separator_bytes,
             captured.stderr.len()
         );
         assert!(
@@ -2861,6 +2881,85 @@ mod tests {
                 "retained line is not one the child wrote: {line:?}"
             );
         }
+    }
+
+    /// Output with no newline in range has no line structure to cut on, so the
+    /// character-boundary fallback would splice two fragments into one
+    /// apparent line. A separator must keep them distinct. The realistic
+    /// trigger is a single huge `console.log(JSON.stringify(...))`.
+    #[test]
+    fn newline_free_output_is_separated_rather_than_spliced() {
+        let mut captured = CapturedOutput::default();
+        // One continuous line, far larger than the retained region.
+        let head_mark = "HEADSTART";
+        captured.push_chunk(head_mark, head_mark.len(), true);
+        let chunk = "a".repeat(4096);
+        for _ in 0..((CAPTURE_MAX_RETAINED_BYTES / chunk.len()) * 4) {
+            captured.push_chunk(&chunk, chunk.len(), true);
+        }
+        assert!(captured.stdout_dropped_bytes > 0, "the test must elide");
+        assert!(
+            captured.stdout_separator_bytes > 0,
+            "a newline-free elision must insert a separator: {captured:?}"
+        );
+        assert!(
+            captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes,
+            "separators must not defeat the ceiling: {}",
+            captured.stdout.len()
+        );
+        assert!(
+            captured.stdout.starts_with(head_mark),
+            "the pinned head must survive"
+        );
+        assert_eq!(
+            captured.stdout_total_bytes - captured.stdout_dropped_bytes
+                + captured.stdout_separator_bytes,
+            captured.stdout.len(),
+            "separators are the only slack in the invariant"
+        );
+    }
+
+    /// `\r`-only progress output has no `\n` at all, so it takes the same
+    /// fallback path.
+    #[test]
+    fn carriage_return_only_output_is_separated_rather_than_spliced() {
+        let mut captured = CapturedOutput::default();
+        let chunk = "progress\r".repeat(456);
+        for _ in 0..((CAPTURE_MAX_RETAINED_BYTES / chunk.len()) * 4) {
+            captured.push_chunk(&chunk, chunk.len(), true);
+        }
+        assert!(captured.stdout_dropped_bytes > 0, "the test must elide");
+        assert!(
+            captured.stdout_separator_bytes > 0,
+            "\\r is not a line terminator for this cut: {captured:?}"
+        );
+        assert!(
+            captured.stdout.contains('\n'),
+            "the separator must be present"
+        );
+    }
+
+    /// A single line longer than the retained region must not defeat the
+    /// memory ceiling. This exercises the `tail_start <= head_end` guard's
+    /// neighbourhood, which is otherwise unreachable.
+    #[test]
+    fn one_enormous_line_still_respects_the_ceiling() {
+        let mut captured = CapturedOutput::default();
+        let chunk = "z".repeat(4096);
+        for _ in 0..((CAPTURE_MAX_RETAINED_BYTES / chunk.len()) * 16) {
+            captured.push_chunk(&chunk, chunk.len(), true);
+        }
+        // No newline was ever written, so every compaction took the fallback.
+        assert!(
+            captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes,
+            "a newline-free flood must not grow without bound: {} retained after {} written",
+            captured.stdout.len(),
+            captured.stdout_total_bytes
+        );
+        assert!(
+            captured.stdout_total_bytes > CAPTURE_MAX_RETAINED_BYTES * 8,
+            "the test must actually flood"
+        );
     }
 
     /// The total counts bytes the child wrote, not the length of the lossy
@@ -2927,11 +3026,22 @@ mod tests {
         }
         assert!(captured.stdout_dropped_bytes > 0, "the test must truncate");
         assert!(
-            captured.stdout.chars().all(|c| c == '\u{20ac}'),
-            "a boundary-splitting cut would leave replacement characters"
+            captured
+                .stdout
+                .chars()
+                .all(|c| c == '\u{20ac}' || c == '\n'),
+            "a boundary-splitting cut would leave replacement characters; the \
+             only newline permitted is the inserted elision separator"
         );
         assert_eq!(
-            captured.stdout_total_bytes - captured.stdout_dropped_bytes,
+            captured.stdout.matches('\n').count(),
+            captured.stdout_separator_bytes,
+            "this input has no newlines of its own, so every newline must be an \
+             accounted separator"
+        );
+        assert_eq!(
+            captured.stdout_total_bytes - captured.stdout_dropped_bytes
+                + captured.stdout_separator_bytes,
             captured.stdout.len()
         );
     }
@@ -2967,7 +3077,8 @@ mod tests {
             "truncation must be disclosed: {captured:?}"
         );
         assert_eq!(
-            captured.stdout_total_bytes - captured.stdout_dropped_bytes,
+            captured.stdout_total_bytes - captured.stdout_dropped_bytes
+                + captured.stdout_separator_bytes,
             captured.stdout.len(),
             "the invariant must hold across a real capture thread"
         );

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -3248,7 +3248,7 @@ mod tests {
             "a newline-free elision must insert a separator: {captured:?}"
         );
         assert!(
-            captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes,
+            captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES,
             "separators must not defeat the ceiling: {}",
             captured.stdout.len()
         );
@@ -3296,7 +3296,7 @@ mod tests {
         }
         // No newline was ever written, so every compaction took the fallback.
         assert!(
-            captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes,
+            captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES,
             "a newline-free flood must not grow without bound: {} retained after {} written",
             captured.stdout.len(),
             captured.stdout_total_bytes
@@ -3520,6 +3520,11 @@ mod tests {
         let target_bytes = CAPTURE_MAX_RETAINED_BYTES * 200;
         let rss_growth_ceiling = 32 * 1024 * 1024;
         let baseline_rss = process_rss_bytes();
+        #[cfg(unix)]
+        assert!(
+            baseline_rss.is_some(),
+            "Unix RSS baseline must be available"
+        );
 
         let sup = Supervisor::start(RestartPolicy::default(), move || {
             chatty_helper_command(target_bytes)
@@ -3534,13 +3539,15 @@ mod tests {
             let captured = sup.output();
             peak_retained = peak_retained.max(captured.stdout.len());
             assert!(
-                captured.stdout.len()
-                    <= CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes,
+                captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES,
                 "retained stdout exceeded the ceiling mid-soak at sample {samples}: {} > {}",
                 captured.stdout.len(),
-                CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes
+                CAPTURE_MAX_RETAINED_BYTES
             );
-            if let (Some(baseline), Some(now)) = (baseline_rss, process_rss_bytes()) {
+            let current_rss = process_rss_bytes();
+            #[cfg(unix)]
+            assert!(current_rss.is_some(), "Unix RSS sample must be available");
+            if let (Some(baseline), Some(now)) = (baseline_rss, current_rss) {
                 peak_rss_growth = peak_rss_growth.max(now.saturating_sub(baseline));
             }
             samples += 1;
@@ -3572,7 +3579,7 @@ mod tests {
             "the soak must sample while the child is live, not once at the end"
         );
         assert!(
-            peak_retained <= CAPTURE_MAX_RETAINED_BYTES + captured.stdout_separator_bytes,
+            peak_retained <= CAPTURE_MAX_RETAINED_BYTES,
             "peak retained stdout exceeded the ceiling: {peak_retained}"
         );
         assert!(
@@ -3580,6 +3587,10 @@ mod tests {
             "a soak past the ceiling must have elided output: {captured:?}"
         );
 
+        eprintln!(
+            "capture-soak samples={samples} bytes={} peak_retained={peak_retained} baseline_rss={baseline_rss:?} peak_rss_growth={peak_rss_growth}",
+            captured.stdout_total_bytes
+        );
         if baseline_rss.is_some() {
             assert!(
                 peak_rss_growth <= rss_growth_ceiling,

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -422,24 +422,6 @@ impl CapturedOutput {
         boundary
     }
 
-    /// Stream offset of the byte at `retained_index` in a transcript that has
-    /// elided `dropped` bytes.
-    ///
-    /// The head is pinned, so an index at or below [`CAPTURE_HEAD_BYTES`] is
-    /// already its own stream offset; everything after the elision is shifted
-    /// by the elided count. Indices in the few bytes between
-    /// [`CAPTURE_HEAD_BYTES`] and the actual head cut are treated as head
-    /// indices, which under-reports the offset rather than over-reports it —
-    /// the direction that surfaces a termination instead of excusing one.
-    #[must_use]
-    pub fn stream_offset(retained_index: usize, dropped: usize) -> usize {
-        if dropped == 0 || retained_index <= CAPTURE_HEAD_BYTES {
-            retained_index
-        } else {
-            retained_index.saturating_add(dropped)
-        }
-    }
-
     /// One line naming how much output was elided, for a consumer that renders
     /// the transcript to a human. `None` when nothing was dropped.
     #[must_use]
@@ -2896,23 +2878,6 @@ mod tests {
         assert_eq!(
             captured.stdout_total_bytes, 3,
             "the child wrote three bytes, whatever the decoding cost"
-        );
-    }
-
-    /// `stream_offset` lifts a retained index into the stream coordinate the
-    /// ledger publishes.
-    #[test]
-    fn stream_offset_pins_the_head_and_shifts_the_tail() {
-        assert_eq!(CapturedOutput::stream_offset(10, 0), 10, "no elision");
-        assert_eq!(
-            CapturedOutput::stream_offset(10, 4096),
-            10,
-            "an index inside the pinned head is already a stream offset"
-        );
-        assert_eq!(
-            CapturedOutput::stream_offset(CAPTURE_HEAD_BYTES + 1, 4096),
-            CAPTURE_HEAD_BYTES + 1 + 4096,
-            "an index past the head is shifted by the elided count"
         );
     }
 

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -253,13 +253,79 @@ impl Clone for RuntimeError {
     }
 }
 
+/// Bytes retained from the **start** of each stream, never evicted.
+///
+/// A child announces itself early — ready markers, link banners, the first
+/// error — and the host forwards what the supervisor retained. A pure sliding
+/// tail would let a later flood evict exactly the lines a supervisor exists to
+/// report, so the head is pinned and only the middle is elided (KEL-134).
+pub const CAPTURE_HEAD_BYTES: usize = 64 * 1024;
+
+/// Bytes retained from the **end** of each stream, sliding as output arrives.
+///
+/// The tail carries the most recent output, which is what the stderr tail
+/// carried by a crash diagnostic needs.
+pub const CAPTURE_TAIL_BYTES: usize = 192 * 1024;
+
+/// Bytes retained per stream once compaction has run: head plus tail.
+///
+/// A supervised child is untrusted and may print without bound. Retaining
+/// every byte let one faulty or hostile generation exhaust the host while
+/// crash isolation was supposed to keep the window alive (KEL-134).
+pub const CAPTURE_RETENTION_BYTES: usize = CAPTURE_HEAD_BYTES + CAPTURE_TAIL_BYTES;
+
+/// Slack allowed above [`CAPTURE_RETENTION_BYTES`] before compaction runs.
+///
+/// Compaction moves the retained tail, so compacting on every 4 KiB read would
+/// move the whole retained region per read. Draining only once the buffer
+/// exceeds retention *plus* this slack bounds that to one move per `SLACK`
+/// bytes written, while keeping the steady-state ceiling fixed and the hot
+/// path allocation-free.
+pub const CAPTURE_COMPACTION_SLACK_BYTES: usize = 64 * 1024;
+
+/// Hard ceiling on bytes retained per stream at any instant.
+pub const CAPTURE_MAX_RETAINED_BYTES: usize =
+    CAPTURE_RETENTION_BYTES + CAPTURE_COMPACTION_SLACK_BYTES;
+
 /// Stdout/stderr captured from the currently or most-recently supervised child.
+///
+/// `stdout` and `stderr` are **bounded transcripts**, not whole streams: at
+/// most [`CAPTURE_MAX_RETAINED_BYTES`] per stream is retained, as a pinned
+/// head of [`CAPTURE_HEAD_BYTES`] followed by a sliding tail. Only the middle
+/// is elided, so an early ready marker or first error survives an arbitrarily
+/// long later flood.
+///
+/// The `*_total_bytes` counters record everything the child wrote and never
+/// reset across restart generations, so an ordering fact taken from them stays
+/// comparable for the life of the supervisor. `*_dropped_bytes` states how
+/// much of the middle was elided, so a consumer can tell "nothing was printed"
+/// from "it was dropped" (KEL-134).
+///
+/// Once `*_dropped_bytes` is non-zero the retained bytes after the head are no
+/// longer at their stream offsets; use the counters, not string indices, for
+/// ordering.
 #[derive(Debug, Default, Clone)]
 pub struct CapturedOutput {
-    /// Combined stdout across every spawn attempt so far.
+    /// Retained stdout across every spawn attempt: pinned head, elided middle,
+    /// sliding tail. Bounded by [`CAPTURE_MAX_RETAINED_BYTES`]; see
+    /// [`Self::stdout_dropped_bytes`].
     pub stdout: String,
-    /// Combined stderr across every spawn attempt so far.
+    /// Retained stderr across every spawn attempt: pinned head, elided middle,
+    /// sliding tail. Bounded by [`CAPTURE_MAX_RETAINED_BYTES`]; see
+    /// [`Self::stderr_dropped_bytes`].
     pub stderr: String,
+    /// Total stdout bytes written by every generation, including bytes no
+    /// longer retained. Never reset by a restart; monotonic non-decreasing.
+    pub stdout_total_bytes: usize,
+    /// Total stderr bytes written by every generation, including bytes no
+    /// longer retained. Never reset by a restart; monotonic non-decreasing.
+    pub stderr_total_bytes: usize,
+    /// Stdout bytes elided from the middle to honour the retention bound.
+    /// Invariant: `stdout_total_bytes - stdout_dropped_bytes == stdout.len()`.
+    pub stdout_dropped_bytes: usize,
+    /// Stderr bytes elided from the middle to honour the retention bound.
+    /// Invariant: `stderr_total_bytes - stderr_dropped_bytes == stderr.len()`.
+    pub stderr_dropped_bytes: usize,
 }
 
 impl CapturedOutput {
@@ -271,6 +337,63 @@ impl CapturedOutput {
 
     pub(crate) fn stderr_tail(&self, max_chars: usize) -> String {
         Self::tail(&self.stderr, max_chars)
+    }
+
+    /// Appends `chunk`, counts every byte, and elides the middle back to
+    /// [`CAPTURE_RETENTION_BYTES`] once the buffer exceeds the slack ceiling.
+    ///
+    /// The pinned head is never evicted, so output a child printed before a
+    /// flood still reaches the host. Both cut points land on UTF-8 character
+    /// boundaries, so the retained transcript stays valid UTF-8 and the drop
+    /// count is exactly the bytes removed.
+    fn append(stream: &mut String, total: &mut usize, dropped: &mut usize, chunk: &str) {
+        *total = total.saturating_add(chunk.len());
+        stream.push_str(chunk);
+        if stream.len() <= CAPTURE_MAX_RETAINED_BYTES {
+            return;
+        }
+        // First boundary at or after the pinned head.
+        let head_end = Self::boundary_at_or_after(stream, CAPTURE_HEAD_BYTES);
+        // First boundary at or after the start of the sliding tail.
+        let tail_start =
+            Self::boundary_at_or_after(stream, stream.len().saturating_sub(CAPTURE_TAIL_BYTES));
+        if tail_start <= head_end {
+            return;
+        }
+        stream.drain(head_end..tail_start);
+        *dropped = dropped.saturating_add(tail_start - head_end);
+    }
+
+    /// Smallest UTF-8 character boundary at or after `index`, clamped to the
+    /// end of `stream`.
+    fn boundary_at_or_after(stream: &str, index: usize) -> usize {
+        if index >= stream.len() {
+            return stream.len();
+        }
+        let mut boundary = index;
+        while boundary < stream.len() && !stream.is_char_boundary(boundary) {
+            boundary += 1;
+        }
+        boundary
+    }
+
+    /// Records a captured chunk against the stream `is_stdout` selects.
+    fn push_chunk(&mut self, chunk: &str, is_stdout: bool) {
+        if is_stdout {
+            Self::append(
+                &mut self.stdout,
+                &mut self.stdout_total_bytes,
+                &mut self.stdout_dropped_bytes,
+                chunk,
+            );
+        } else {
+            Self::append(
+                &mut self.stderr,
+                &mut self.stderr_total_bytes,
+                &mut self.stderr_dropped_bytes,
+                chunk,
+            );
+        }
     }
 }
 
@@ -319,7 +442,10 @@ pub struct SelfTerminationRecord {
     pub pid: u32,
     /// Exit code when the OS reported one (`None` for signal termination).
     pub exit_code: Option<i32>,
-    /// Length of captured stdout when this termination was recorded.
+    /// Total stdout bytes written when this termination was recorded, taken
+    /// from [`CapturedOutput::stdout_total_bytes`]. This counts bytes the
+    /// child wrote, not bytes still retained, so it never moves backwards when
+    /// the bounded tail drops older output (KEL-134).
     pub stdout_len: usize,
 }
 
@@ -353,6 +479,10 @@ pub struct CrashLedger {
     /// cannot tell "crashed, then printed" from "printed, then crashed".
     /// Comparing a marker's offset against this length answers that question
     /// without any timing assumption (KEL-105).
+    ///
+    /// This is a *total written* offset from
+    /// [`CapturedOutput::stdout_total_bytes`], not an index into the retained
+    /// tail: retention is bounded, so an index would go stale (KEL-134).
     pub stdout_len_at_last_crash: usize,
     /// All unrequested self-terminations across every generation, including
     /// status zero. Never reset or evicted by restart policy.
@@ -1517,7 +1647,10 @@ fn record_self_termination(
     let (stdout_len, stderr_tail) = {
         let captured = output.lock().unwrap_or_else(PoisonError::into_inner);
         (
-            captured.stdout.len(),
+            // Total bytes written, not the retained tail: the retained tail is
+            // bounded (KEL-134) and would make this ordering point go backwards
+            // once older output is dropped.
+            captured.stdout_total_bytes,
             (exit_code != Some(0)).then(|| captured.stderr_tail(2000)),
         )
     };
@@ -1556,11 +1689,7 @@ fn spawn_capture_thread(
                     Ok(n) => {
                         let chunk = String::from_utf8_lossy(&buf[..n]);
                         let mut guard = output.lock().unwrap_or_else(PoisonError::into_inner);
-                        if is_stdout {
-                            guard.stdout.push_str(&chunk);
-                        } else {
-                            guard.stderr.push_str(&chunk);
-                        }
+                        guard.push_chunk(&chunk, is_stdout);
                     }
                 }
             }
@@ -1619,11 +1748,7 @@ fn spawn_capture_thread(
                     Ok(n) => {
                         let chunk = String::from_utf8_lossy(&buf[..n]);
                         let mut guard = output.lock().unwrap_or_else(PoisonError::into_inner);
-                        if is_stdout {
-                            guard.stdout.push_str(&chunk);
-                        } else {
-                            guard.stderr.push_str(&chunk);
-                        }
+                        guard.push_chunk(&chunk, is_stdout);
                         let _ =
                             budget.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
                                 (current != u64::MAX).then_some(current.saturating_sub(n as u64))
@@ -2576,9 +2701,16 @@ mod tests {
             "the crash must record how far stdout had got, or the host cannot \
              order it against the app's ready marker: {ledger:?}"
         );
+        let captured = sup.output();
         assert!(
-            ledger.stdout_len_at_last_crash <= sup.output().stdout.len(),
-            "the recorded position must be a real offset into captured stdout: {ledger:?}"
+            ledger.stdout_len_at_last_crash <= captured.stdout_total_bytes,
+            "the recorded position must be a real offset into the stdout the \
+             child actually wrote: {ledger:?}"
+        );
+        assert_eq!(
+            captured.stdout_total_bytes - captured.stdout_dropped_bytes,
+            captured.stdout.len(),
+            "retained tail, drop count and total must describe one stream: {captured:?}"
         );
         assert!(
             ledger.self_termination_count >= ledger.count,
@@ -2589,6 +2721,215 @@ mod tests {
             .expect("the all-termination view must retain the latest crash");
         assert_eq!(termination.exit_code, Some(3));
         assert_eq!(termination.stdout_len, ledger.stdout_len_at_last_crash);
+    }
+
+    /// KEL-134 storage bound, isolated from process spawning.
+    ///
+    /// This is the negative control for the retention cap: raising
+    /// `CAPTURE_RETENTION_BYTES`, or deleting the compaction branch in
+    /// `CapturedOutput::append`, makes the ceiling assertions below fail
+    /// deterministically on every OS row.
+    #[test]
+    fn bounded_capture_keeps_a_fixed_tail_and_counts_every_byte() {
+        let mut captured = CapturedOutput::default();
+        let chunk = "x".repeat(4096);
+        let chunks = (CAPTURE_MAX_RETAINED_BYTES / chunk.len()) * 4;
+        for _ in 0..chunks {
+            captured.push_chunk(&chunk, true);
+            captured.push_chunk(&chunk, false);
+        }
+        let written = chunk.len() * chunks;
+
+        assert!(
+            captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES,
+            "retained stdout must never exceed the documented ceiling: {} > {}",
+            captured.stdout.len(),
+            CAPTURE_MAX_RETAINED_BYTES
+        );
+        assert!(
+            captured.stderr.len() <= CAPTURE_MAX_RETAINED_BYTES,
+            "retained stderr must never exceed the documented ceiling: {} > {}",
+            captured.stderr.len(),
+            CAPTURE_MAX_RETAINED_BYTES
+        );
+        assert_eq!(
+            captured.stdout_total_bytes, written,
+            "every written byte must be counted even when it is not retained"
+        );
+        assert_eq!(captured.stderr_total_bytes, written);
+        assert!(
+            captured.stdout_dropped_bytes > 0,
+            "dropping output must be disclosed, not silent"
+        );
+        assert_eq!(
+            captured.stdout_total_bytes - captured.stdout_dropped_bytes,
+            captured.stdout.len(),
+            "total, dropped and retained must describe one stream"
+        );
+        assert_eq!(
+            captured.stderr_total_bytes - captured.stderr_dropped_bytes,
+            captured.stderr.len()
+        );
+        assert!(
+            captured.stdout.len() >= CAPTURE_RETENTION_BYTES,
+            "compaction must keep the retention target, not empty the tail"
+        );
+    }
+
+    /// A child announces itself before it floods. `keld-host` forwards the
+    /// retained transcript, so evicting the pinned head would lose the ready
+    /// marker that `no_flag_macos`/`no_flag_linux` assert is forwarded after
+    /// the fixture writes 1 MiB of noise.
+    #[test]
+    fn bounded_capture_pins_the_head_against_a_later_flood() {
+        let mut captured = CapturedOutput::default();
+        let marker = "KELD_EARLY_MARKER\n";
+        captured.push_chunk(marker, true);
+        let noise = "x".repeat(4096);
+        for _ in 0..((CAPTURE_MAX_RETAINED_BYTES / noise.len()) * 8) {
+            captured.push_chunk(&noise, true);
+        }
+        assert!(
+            captured.stdout_dropped_bytes > 0,
+            "the flood must have forced an elision, or this proves nothing"
+        );
+        assert!(
+            captured.stdout.starts_with(marker),
+            "the pinned head must survive an arbitrarily long later flood"
+        );
+        assert!(
+            captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES,
+            "pinning the head must not defeat the ceiling: {}",
+            captured.stdout.len()
+        );
+        assert!(
+            captured.stdout.ends_with('x'),
+            "the sliding tail must still carry the most recent output"
+        );
+    }
+
+    /// The retained transcript is a `String`, so a cut that split a multi-byte
+    /// character would be unrepresentable. Both cuts must land on boundaries,
+    /// and the drop count must equal the bytes removed.
+    #[test]
+    fn bounded_capture_cuts_on_a_utf8_character_boundary() {
+        let mut captured = CapturedOutput::default();
+        // Three-byte characters do not align with the byte overflow.
+        let chunk = "\u{20ac}".repeat(4096);
+        let chunks = (CAPTURE_MAX_RETAINED_BYTES / chunk.len()) * 4;
+        for _ in 0..chunks {
+            captured.push_chunk(&chunk, true);
+        }
+        assert!(captured.stdout_dropped_bytes > 0, "the test must truncate");
+        assert!(
+            captured.stdout.chars().all(|c| c == '\u{20ac}'),
+            "a boundary-splitting cut would leave replacement characters"
+        );
+        assert_eq!(
+            captured.stdout_total_bytes - captured.stdout_dropped_bytes,
+            captured.stdout.len()
+        );
+    }
+
+    /// A hostile or faulty child that prints without bound must not grow the
+    /// supervisor's retained memory. This is the KEL-134 defect end to end,
+    /// through a real process and the platform capture thread.
+    #[test]
+    fn chatty_child_does_not_grow_retained_capture() {
+        let target_bytes = CAPTURE_MAX_RETAINED_BYTES * 8;
+        let sup = Supervisor::start(RestartPolicy::default(), move || {
+            chatty_helper_command(target_bytes)
+        })
+        .expect("first spawn must succeed");
+        match sup.wait_for_outcome() {
+            SupervisorOutcome::Stopped => {}
+            other => panic!("chatty child should exit zero and stop, got {other:?}"),
+        }
+        let captured = sup.output();
+        assert!(
+            captured.stdout_total_bytes >= target_bytes,
+            "the child must actually have written past the ceiling: {} < {target_bytes}",
+            captured.stdout_total_bytes
+        );
+        assert!(
+            captured.stdout.len() <= CAPTURE_MAX_RETAINED_BYTES,
+            "retained stdout must stay bounded through the capture thread: {} > {}",
+            captured.stdout.len(),
+            CAPTURE_MAX_RETAINED_BYTES
+        );
+        assert!(
+            captured.stdout_dropped_bytes > 0,
+            "truncation must be disclosed: {captured:?}"
+        );
+        assert_eq!(
+            captured.stdout_total_bytes - captured.stdout_dropped_bytes,
+            captured.stdout.len(),
+            "the invariant must hold across a real capture thread"
+        );
+    }
+
+    /// Restart generations share one supervisor-owned counter. If a restart
+    /// reset or aliased it, an ordering fact recorded before the restart would
+    /// compare against a shorter stream afterwards.
+    #[test]
+    fn capture_totals_do_not_reset_across_restart_generations() {
+        let sup = Supervisor::start(RestartPolicy::default(), || {
+            shell_command("echo alive-before-dying && exit 3")
+        })
+        .expect("first spawn must succeed");
+        match sup.wait_for_outcome() {
+            SupervisorOutcome::CrashLoop(_) => {}
+            other => panic!("expected the breaker to trip, got {other:?}"),
+        }
+        let captured = sup.output();
+        let marker_len = "alive-before-dying\n".len();
+        let ledger = sup.crash_ledger();
+        assert!(
+            ledger.count >= 2,
+            "this test needs more than one generation: {ledger:?}"
+        );
+        assert!(
+            captured.stdout_total_bytes >= marker_len * 2,
+            "each generation's output must accumulate rather than reset: {captured:?}"
+        );
+        assert!(
+            ledger.stdout_len_at_last_crash >= marker_len * 2,
+            "the last crash must be ordered against the whole stream, not just \
+             the final generation: {ledger:?}"
+        );
+        assert!(
+            ledger.stdout_len_at_last_crash <= captured.stdout_total_bytes,
+            "an ordering point must never exceed the bytes written: {ledger:?}"
+        );
+    }
+
+    fn chatty_helper_command(target_bytes: usize) -> Command {
+        let mut command = Command::new(std::env::current_exe().expect("current test binary"));
+        command
+            .args(["--exact", "tests::chatty_helper_process", "--nocapture"])
+            .env("KELD_RUNTIME_CHATTY_BYTES", target_bytes.to_string());
+        command
+    }
+
+    #[test]
+    fn chatty_helper_process() {
+        let Some(target) = std::env::var_os("KELD_RUNTIME_CHATTY_BYTES") else {
+            return;
+        };
+        let target: usize = target
+            .to_string_lossy()
+            .parse()
+            .expect("chatty byte target must parse");
+        let line = "k".repeat(1023);
+        let mut written = 0_usize;
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+        while written < target {
+            std::io::Write::write_all(&mut stdout, line.as_bytes()).expect("helper stdout write");
+            std::io::Write::write_all(&mut stdout, b"\n").expect("helper stdout newline");
+            written += line.len() + 1;
+        }
+        std::io::Write::flush(&mut stdout).expect("helper stdout flush");
     }
 
     #[test]

--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -2126,22 +2126,16 @@ mod tests {
             &["prefixsuffix", "prefix"],
             move || {
                 let first = factory_calls.fetch_add(1, Ordering::SeqCst) == 0;
-                #[cfg(unix)]
-                let write = if first {
-                    "printf prefix"
-                } else {
-                    "printf suffix"
-                };
-                #[cfg(windows)]
-                let write = if first {
-                    "<nul set /p \"=prefix\""
-                } else {
-                    "<nul set /p \"=suffix\""
-                };
-                shell_command(&joined_steps(&[
-                    write,
-                    if first { "exit 1" } else { "exit 0" },
-                ]))
+                let mut command = Command::new("bun");
+                command.args([
+                    "-e",
+                    if first {
+                        "require('node:fs').writeSync(1,'prefix');process.exit(1)"
+                    } else {
+                        "require('node:fs').writeSync(1,'suffix');process.exit(0)"
+                    },
+                ]);
+                command
             },
         )
         .expect("spawn first generation");


### PR DESCRIPTION
## Summary

Bounds supervised stdout/stderr transcripts while preserving raw byte accounting and crash ordering. Capture retains a pinned head and recent tail, discloses elision, and enforces the retention ceiling even when a long line ends at a compaction boundary.

Known diagnostic readiness markers are registered before spawn and matched against raw stdout before decoding/truncation. Immutable first offsets survive restarts; partial matches cannot cross child generations, and repeated waits cannot reset the original readiness baseline. Existing start APIs remain compatible; unregistered needles can only search retained text. Shipping no-flag host readiness is unchanged.

## Spec refs

KEL-134; architecture 06 runtime/output ownership. No ownership boundary change. KEL-117's shipping readiness resolution remains intact.

## Review gates

- Public API: bounded CapturedOutput semantics/counters, additive registered-marker start/query APIs and diagnostic error semantics. Independent public-API/correctness review passed the marker integration; final whole-PR and incremental fixture reviews passed.
- unsafe: none.
- permission model: none.
- dependency addition: none.
- wire protocol: none.

## Tests

Exact rebased head b62af6b5805041c3d789413b3f00c3548cf56a2a: full local `just ci` passed601 workspace tests (2 configured skips),41 Bun tests, format, workspace clippy -D warnings, rustdoc, cargo-deny and repository gates. Existing idle Cargo target cache reused; source worktree was clean and frozen. All12 feature patches are unchanged by rebase onto31be376.

Failure-first coverage includes late-newline cap, distinct-tail preservation, registered marker after completed flood, production generation-reset removal, lossy unregistered marker offsets, and unavailable Unix RSS measurement. Independent whole-PR/public-API review passed, followed by incremental fixture/oracle review. Earlier Windows shell-fixture failure and its direct-Bun correction remain documented. Fresh hosted run34321960141 is pending.

## Platforms

Ubuntu local full workspace and native Linux test fixtures exercised. Prior macOS soak evidence is retained in discussion and is historical to its named head. Hosted macOS/Windows/Linux final-head results must pass before merge; no new physical macOS/Windows observation is claimed here.

## Perf impact

No comparative performance claim. Capture memory is bounded; marker registration is capped at32 unique nonempty strings/4096 aggregate bytes and allocates state before spawn. Matching adds no per-read allocation.

## Linear

KEL-134. PR stays unmerged pending final hosted checks and full-scope acceptance/review reconciliation.
