### PR TITLE
test(host): give fixture renderers a dark background

### DIFF
--- a/crates/keld-cli/tests/project_owner_linux.rs
+++ b/crates/keld-cli/tests/project_owner_linux.rs
@@ -12,6 +12,11 @@ use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+/// Dark background for fixture renderers, so a test run does not flash
+/// white windows across the operator's desktop. Cosmetic only: no test
+/// asserts on it, and the beacon/marker contracts are unchanged.
+const DARK_BG: &str = "<style>html,body{background:#111;color:#eee}</style>";
+
 const PROOF_ENV: &str = "KELD_REAL_LINUX_OWNER_PROOF";
 
 struct ForeignAccount {
@@ -167,8 +172,11 @@ fn real_linux_second_account_refuses_foreign_owned_project() {
         format!("await Bun.write({marker:?}, \"executed\\n\");\n"),
     )
     .expect("foreign entry");
-    fs::write(&renderer, "<!doctype html><title>foreign owner</title>\n")
-        .expect("foreign renderer");
+    fs::write(
+        &renderer,
+        format!("<!doctype html>{DARK_BG}<title>foreign owner</title>\n"),
+    )
+    .expect("foreign renderer");
 
     let invoking_principal = (
         rustix::process::geteuid().as_raw(),

--- a/crates/keld-host/tests/no_flag_linux.rs
+++ b/crates/keld-host/tests/no_flag_linux.rs
@@ -16,6 +16,10 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+/// Dark background for fixture renderers, so a test run does not flash
+/// white windows across the operator's desktop. Cosmetic only: no test
+/// asserts on it, and the beacon/marker contracts are unchanged.
+const DARK_BG: &str = "<style>html,body{background:#111;color:#eee}</style>";
 const PRODUCT_TITLE: &str = "KEL96 T4 Linux Fixture";
 const PRODUCT_DEADLINE: Duration = Duration::from_secs(20);
 
@@ -192,7 +196,7 @@ fn linux_no_flag_host_recovers_bun_in_the_same_renderer_window() {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
         ),
     )
     .expect("recovery renderer");
@@ -272,7 +276,7 @@ fn shipping_keld_dev_delegates_ownership_and_deletes_its_stage() {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
         ),
     )
     .expect("dev renderer");
@@ -357,7 +361,7 @@ fn shipping_keld_dev_cli_death_reaps_host_bun_and_stage() {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
         ),
     )
     .expect("death renderer");
@@ -427,7 +431,7 @@ fn linux_host_only_death_reaps_strict_tree_deletes_stage_and_relaunches() {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
         ),
     )
     .expect("host-death renderer");
@@ -504,7 +508,7 @@ impl StageFixture {
         fs::write(project.join("src/main.ts"), "console.log('linux');\n").expect("entry");
         fs::write(
             project.join("index.html"),
-            "<!doctype html><h1>Linux</h1>\n",
+            format!("<!doctype html>{DARK_BG}<h1>Linux</h1>\n"),
         )
         .expect("renderer");
         Self {
@@ -542,7 +546,11 @@ impl ProductFixture {
             ),
         )
         .expect("product entry");
-        fs::write(project.join("index.html"), "<!doctype html>\n").expect("renderer");
+        fs::write(
+            project.join("index.html"),
+            format!("<!doctype html>{DARK_BG}\n"),
+        )
+        .expect("renderer");
         Self { root, project }
     }
 }
@@ -599,7 +607,7 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><p id=exact>{label}</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><p id=exact>{label}</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
         ),
     )
     .expect("write renderer");

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -16,6 +16,10 @@ use std::sync::mpsc::{self, Receiver};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+/// Dark background for fixture renderers, so a test run does not flash
+/// white windows across the operator's desktop. Cosmetic only: no test
+/// asserts on it, and the beacon/marker contracts are unchanged.
+const DARK_BG: &str = "<style>html,body{background:#111;color:#eee}</style>";
 const TITLE: &str = "KEL96 T1b Fixture";
 const MARKER: &str = "KEL96_T1B_EXACT_RENDERER_7e2d9b";
 const FORWARDED_LOG: &str = "KEL96_T2_FORWARDED_LOG";
@@ -221,7 +225,7 @@ fn stalled_initial_navigation_rolls_back_window_link_and_process_group() {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{TITLE}</title><img src=\"http://127.0.0.1:{}/never\">\n",
+            "<!doctype html>{DARK_BG}<title>{TITLE}</title><img src=\"http://127.0.0.1:{}/never\">\n",
             blocker.port
         ),
     )
@@ -517,7 +521,7 @@ impl RecoveryCycle {
         fs::write(
             fixture.project.join("index.html"),
             format!(
-                "<!doctype html><title>{TITLE}</title><p id=marker>{MARKER}</p><img src=\"http://127.0.0.1:{}/{MARKER}\">\n",
+                "<!doctype html>{DARK_BG}<title>{TITLE}</title><p id=marker>{MARKER}</p><img src=\"http://127.0.0.1:{}/{MARKER}\">\n",
                 beacon.port()
             ),
         )
@@ -1048,7 +1052,7 @@ impl ShippingDevCycle {
         fs::write(
             fixture.project.join("index.html"),
             format!(
-                "<!doctype html><title>{TITLE}</title><p id=marker>{MARKER}</p><img src=\"http://127.0.0.1:{}/{MARKER}\">\n",
+                "<!doctype html>{DARK_BG}<title>{TITLE}</title><p id=marker>{MARKER}</p><img src=\"http://127.0.0.1:{}/{MARKER}\">\n",
                 beacon.port()
             ),
         )
@@ -1330,7 +1334,9 @@ impl ProductFixture {
         if !self.project.join("index.html").exists() {
             fs::write(
                 self.project.join("index.html"),
-                format!("<!doctype html><title>{TITLE}</title><p id=marker>{MARKER}</p>\n"),
+                format!(
+                    "<!doctype html>{DARK_BG}<title>{TITLE}</title><p id=marker>{MARKER}</p>\n"
+                ),
             )
             .expect("fallback renderer");
         }
@@ -1363,7 +1369,7 @@ impl ProductFixture {
         fs::write(
             self.project.join("index.html"),
             format!(
-                "<!doctype html><title>{TITLE}</title><p id=marker>{MARKER}</p><img src=\"http://127.0.0.1:{}/{MARKER}\">\n",
+                "<!doctype html>{DARK_BG}<title>{TITLE}</title><p id=marker>{MARKER}</p><img src=\"http://127.0.0.1:{}/{MARKER}\">\n",
                 beacon.port()
             ),
         )

--- a/crates/keld-host/tests/no_flag_windows.rs
+++ b/crates/keld-host/tests/no_flag_windows.rs
@@ -27,6 +27,10 @@ use windows_sys::Win32::System::Threading::{
     WaitForSingleObject,
 };
 
+/// Dark background for fixture renderers, so a test run does not flash
+/// white windows across the operator's desktop. Cosmetic only: no test
+/// asserts on it, and the beacon/marker contracts are unchanged.
+const DARK_BG: &str = "<style>html,body{background:#111;color:#eee}</style>";
 const PRODUCT_TITLE: &str = "KEL96 T4 Windows Fixture";
 const PRODUCT_DEADLINE: Duration = Duration::from_secs(20);
 const RENDERER_ACCEPT_POLL: Duration = Duration::from_millis(10);
@@ -458,7 +462,7 @@ fn run_same_window_recovery(failure_command: &str) {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><p id=exact>{failure_command}</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><p id=exact>{failure_command}</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
         ),
     )
     .expect("write recovery renderer");
@@ -581,7 +585,7 @@ fn shipping_windows_keld_dev_delegates_and_cleans_the_orderly_stage() {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><p id=exact>shipping</p><script>\
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><p id=exact>shipping</p><script>\
              const leaked=(typeof process!=='undefined'&&process.env?.KELD_APP_LINK)||globalThis.KELD_APP_LINK;\
              const image=document.createElement('img');\
              image.src='http://127.0.0.1:{beacon_port}/'+(leaked?'leaked':'ready')+'.png';\
@@ -652,7 +656,7 @@ fn shipping_windows_cli_death_reaps_the_delegated_host_and_bun() {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><p id=exact>lease</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><p id=exact>lease</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
         ),
     )
     .expect("write lease renderer");
@@ -755,7 +759,7 @@ fn run_console_ctrl_c_case() {
     let beacon_port = beacon_listener.local_addr().expect("beacon address").port();
     let beacon = spawn_renderer_beacon(beacon_listener);
     fs::write(fixture.project.join("index.html"), format!(
-        "<!doctype html><title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+        "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
     )).expect("console renderer");
     let helper = prepare_keld_dev_helper(&fixture);
     let mut cli = Command::new(helper)
@@ -896,7 +900,7 @@ fn shipping_windows_host_death_reaps_bun_descendant_deletes_stage_and_relaunches
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><p id=exact>host-death</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><p id=exact>host-death</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
         ),
     )
     .expect("write host-death renderer");
@@ -1333,7 +1337,7 @@ fn run_product_cycle(fixture: &ProductFixture, label: &str) -> ProductEvidence {
     fs::write(
         fixture.project.join("index.html"),
         format!(
-            "<!doctype html><title>{PRODUCT_TITLE}</title><p id=exact>{label}</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
+            "<!doctype html>{DARK_BG}<title>{PRODUCT_TITLE}</title><p id=exact>{label}</p><img src=\"http://127.0.0.1:{beacon_port}/ready.png\">\n"
         ),
     )
     .expect("write renderer");
@@ -2334,7 +2338,11 @@ impl ProductFixture {
             ),
         )
         .expect("product entry");
-        fs::write(project.join("index.html"), "<!doctype html>\n").expect("product renderer");
+        fs::write(
+            project.join("index.html"),
+            format!("<!doctype html>{DARK_BG}\n"),
+        )
+        .expect("product renderer");
         Self { root, project }
     }
 }


### PR DESCRIPTION
## Summary

- Windowed fixtures wrote a minimal document with no background, so the webview painted default white and a test run flashed white windows across the operator's desktop.
- Each test binary now carries one `DARK_BG` constant interpolated after the doctype, rather than nineteen copies of the same style block.
- Test-only and cosmetic. The shipped `keld create` scaffold is deliberately untouched.

## Linear

None. Requested directly by the repository owner in session as test hygiene. Mint an issue or accept it as owner-directed.

## Spec refs

No boundary change.

## Review gates

`none` — no unsafe, no public API, no permission model, no dependency addition, no wire protocol. Only fixture HTML strings inside test binaries.

## Tests

```
cargo fmt --all --check                                        exit 0
cargo clippy --workspace --all-targets -- -D warnings          exit 0
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps      exit 0
cargo nextest run --workspace --profile ci -j 2 --no-fail-fast  634 passed, 2 skipped
coderabbit review --committed --base main (CLI 0.7.6)          No findings, 4 files
```

The hosted CodeRabbit check reports "Review rate limited", which `.agents/review.md` does not accept as review; the CLI run above at the exact tip `0c69528` is the recorded substitute.

No assertion reads the style. The marker (`<p id=marker>`) and renderer-beacon (`<img src=…>`) contracts are unchanged.

## Platforms

- **macOS** — real device (this Mac mini): the 22 `keld-host::no_flag_macos` window tests were run; 21 passed and `dev_lease_bytes_are_non_authority_and_only_eof_stops_the_host` failed once under load and passes standalone. That is the pre-existing load-sensitive GUI flake owned by `agent/kel-195-macos-gui-serial`, not this change.
- **Linux** — CI automation only (`clippy + test (ubuntu-latest)`, `Linux GUI smoke test (Xvfb)`). The `no_flag_linux` fixtures changed here are exercised on the hosted runner; no real Linux desktop observation was made by me.
- **Windows** — CI automation only (`clippy + test (windows-latest)`). The `no_flag_windows` fixtures changed here are not verified on a real Windows desktop by me.
- Remaining OS handoff: none required — the change alters only document background styling, which no acceptance criterion on any OS asserts.

## Perf impact

none.