### PR TITLE
test(macos): preserve recovery window identity across Spaces

### DIFF
--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -1156,7 +1156,19 @@ impl ShippingDevCycle {
         let old_bun = self.bun_pid;
         let old_descendant = self.descendant_pid;
         let old_link = self.session_dir.clone();
-        let window = native_windows(self.host_pid, TITLE);
+        let window = query_native_windows(
+            self.host_pid,
+            TITLE,
+            NativeWindowScope::All,
+            NativeWindowExpectation::Snapshot,
+            "shipping-recovery-before",
+        );
+        // Initial presentation was proved by launch(). During recovery, a
+        // Space change can remove a live window from the on-screen list.
+        assert!(
+            !window.is_empty(),
+            "recovery requires a live window identity"
+        );
         self.control_writer
             .write_all(b"CRASH\n")
             .expect("crash shipping generation");
@@ -1164,7 +1176,16 @@ impl ShippingDevCycle {
         successor.expect_ready_and_echoes();
         assert_eq!(successor.guardian_pid, old_guardian);
         assert_ne!(successor.bun_pid, old_bun);
-        assert_eq!(native_windows(self.host_pid, TITLE), window);
+        assert_eq!(
+            query_native_windows(
+                self.host_pid,
+                TITLE,
+                NativeWindowScope::All,
+                NativeWindowExpectation::Snapshot,
+                "shipping-recovery-after",
+            ),
+            window
+        );
         assert!(
             !old_link.exists(),
             "retired shipping link directory remains"


### PR DESCRIPTION
## Summary

Use the existing all-window census for the shipping recovery fixture's before/after identity snapshots. A live window can leave CoreGraphics' on-screen list when its active macOS Space changes; treating that as destruction caused `[]` versus `[6697]` after Bun recovery.

Initial launch still requires exactly one on-screen titled window. Recovery still requires exact native ID equality, and a new nonempty baseline guard prevents vacuous success. No product, activation, focus, process-group, retry, or deadline change.

## Spec refs

No boundary change. KEL-196; the existing `NativeWindowScope::All` / `OnScreen` distinction and retained-window recovery contract are reused. The user explicitly approved this correction after reviewing the paired evidence.

Real macOS capture at the unchanged pre-fix host test source: PID31337/window6697 remained AppKit-visible, unminimized and application-hidden=false. At monotonic31559.067576 its `onActiveSpace` was false; at31559.100493 the external census retained the titled ID in all windows but excluded it from on-screen. The test then failed its recovery equality. Actual teardown/order-off came afterward. The actor initiating Space changes is not claimed.

## Review gates

Five root gates: none. Isolated final review at `899643f27d4f382d09f62b79c750c1b6895cb68a` found no blocking issue and independently verified unchanged code outside the recovery method. CodeRabbit CLI 0.7.6 reviewed this exact tip with zero issues. The GitHub bot was rate-limited and is not counted as a review. There are no unresolved review threads.

## Tests

- Existing regression failed before the fix: shipping recovery expected `[6697]`, received `[]`, with independent all-window evidence proving the retained ID.
- Targeted shipping recovery test after the fix: passed, 1/1, uninstrumented, on macOS26.5.1 arm64.
- Full local `just ci` passed: 634 workspace tests with two existing skips, all static/docs/Mermaid/TypeScript gates, format, warning-denied clippy, rustdoc and cargo-deny. Required [CI34290097405](https://github.com/gyldlab/keld/actions/runs/34290097405) passed at this exact tip, including applicable Linux/macOS/Windows checks and CI required.
- Historical-source hosted [KEL-196 diagnostic](https://github.com/gyldlab/keld/actions/runs/34284439645): both control/trace jobs passed22/22. This is context, not a substitute for this PR's CI.

## Platforms

Real macOS test evidence; the edit is macOS-test-only. Hosted Linux/macOS/Windows verification applies through the existing router. No new production or cross-platform behavior claim.

## Perf impact

No performance claim. Recovery retains snapshot semantics and the existing query deadline argument; no extra poll or retry. Diagnostic code is not included in this PR. This fix does not retroactively prove the cause of every historical initial-presentation failure.
