### PR TITLE
docs(specs): record KEL-102/T2 as landed

### DIFF
--- a/docs/specs/kel102-host-guard-enforcement.md
+++ b/docs/specs/kel102-host-guard-enforcement.md
@@ -679,9 +679,9 @@ owners into T2 would create unused scaffolding or implement later tasks early.
       task-specific predecessor table below is necessary but not sufficient for
       T3 dispatch: execution frontier `237-execution-frontier-refuted`
       (research `8c1d9466d5fc8860f91d3fba9c000b483b17974f`) lists three further
-      predicates, none of them met at that pin — `KEL-130/T1` landed, which
-      KEL-130 has not started; a `keld-native` -> `keld-core` dependency
-      review; and that frontier naming `KEL-102/T3` ready.
+      predicates, none of them met at that pin: `KEL-130/T1` must land, and
+      KEL-130 has not started; a `keld-native` -> `keld-core` dependency review
+      must pass; and that frontier must name `KEL-102/T3` ready.
 - [ ] `KEL-102/T3`: Wire the v0 authenticated app link through `keld-core` to
       the live `keld-native::fs` broker with a host-derived `AppProcess`
       context. Core routes and passes the verified snapshot/principal/request;

--- a/docs/specs/kel102-host-guard-enforcement.md
+++ b/docs/specs/kel102-host-guard-enforcement.md
@@ -649,7 +649,7 @@ owners into T2 would create unused scaffolding or implement later tasks early.
       fixture root, fixed opened `keld.permissions.jsonc` handle, and decoded
       digest consumed by `KEL-102/T2`; T1b proves the durable no-flag host
       consumer. Later KEL-96 T2/T3 are landed but are not KEL-102 predecessors.
-- [ ] `KEL-102/T2`: Add the exact guard-owned loader and `run_guarded` API,
+- [x] `KEL-102/T2`: Add the exact guard-owned loader and `run_guarded` API,
       host-owned manifest resolution, private immutable `GuardSnapshot`, and
       typed fail-closed startup errors. Reuse KEL-131's landed bounded,
       duplicate-rejecting parser and 64 KiB retained-handle read; a verified
@@ -669,7 +669,17 @@ owners into T2 would create unused scaffolding or implement later tasks early.
       the injected retained-handle read failure, 27 exact KEL-96 boot classes,
       five post-selection policy byte classes, the full 16-test real-macOS
       no-flag suite, Windows cross-check, and 576/576 workspace tests. Landing
-      and the final execution artifact remain required before T3 becomes ready.
+      and the final execution artifact were both required before T3 could
+      become ready; both are satisfied. Landed evidence: PR #115 merged at
+      `b9ea8f843390b2229235bd694d7b3d581ea863dc`, whose shipping no-flag
+      `keld-host` calls `run_guarded`; passed `keld.execution-artifact/v1` with
+      `task_id=KEL-102/T2` in Linear comment
+      `800fc0fb-8ae2-4bac-8982-8d6dc157ae2f`; claim released in
+      `826f4c33-f358-4ae3-a90e-435623312ccf`. Satisfying T3's row in the
+      task-specific predecessor table below is necessary but not sufficient for
+      T3 dispatch: `docs/specs/kel133-kipc-receiver-semantics.md` adds that a
+      partial merge "cannot unlock KEL-130, KEL-102/T3, or KEL-97", and the
+      current execution frontier owns the remaining readiness call.
 - [ ] `KEL-102/T3`: Wire the v0 authenticated app link through `keld-core` to
       the live `keld-native::fs` broker with a host-derived `AppProcess`
       context. Core routes and passes the verified snapshot/principal/request;

--- a/docs/specs/kel102-host-guard-enforcement.md
+++ b/docs/specs/kel102-host-guard-enforcement.md
@@ -677,9 +677,11 @@ owners into T2 would create unused scaffolding or implement later tasks early.
       `800fc0fb-8ae2-4bac-8982-8d6dc157ae2f`; claim released in
       `826f4c33-f358-4ae3-a90e-435623312ccf`. Satisfying T3's row in the
       task-specific predecessor table below is necessary but not sufficient for
-      T3 dispatch: the current execution frontier additionally enumerates a
-      landed `KEL-130/T1`, an unrun `keld-native -> keld-core` dependency
-      review, and its own naming of `KEL-102/T3` as outstanding predicates.
+      T3 dispatch: execution frontier `237-execution-frontier-refuted`
+      (research `8c1d9466d5fc8860f91d3fba9c000b483b17974f`) lists three further
+      predicates, none of them met at that pin — `KEL-130/T1` landed, which
+      KEL-130 has not started; a `keld-native` -> `keld-core` dependency
+      review; and that frontier naming `KEL-102/T3` ready.
 - [ ] `KEL-102/T3`: Wire the v0 authenticated app link through `keld-core` to
       the live `keld-native::fs` broker with a host-derived `AppProcess`
       context. Core routes and passes the verified snapshot/principal/request;

--- a/docs/specs/kel102-host-guard-enforcement.md
+++ b/docs/specs/kel102-host-guard-enforcement.md
@@ -677,9 +677,9 @@ owners into T2 would create unused scaffolding or implement later tasks early.
       `800fc0fb-8ae2-4bac-8982-8d6dc157ae2f`; claim released in
       `826f4c33-f358-4ae3-a90e-435623312ccf`. Satisfying T3's row in the
       task-specific predecessor table below is necessary but not sufficient for
-      T3 dispatch: `docs/specs/kel133-kipc-receiver-semantics.md` adds that a
-      partial merge "cannot unlock KEL-130, KEL-102/T3, or KEL-97", and the
-      current execution frontier owns the remaining readiness call.
+      T3 dispatch: the current execution frontier additionally enumerates a
+      landed `KEL-130/T1`, an unrun `keld-native -> keld-core` dependency
+      review, and its own naming of `KEL-102/T3` as outstanding predicates.
 - [ ] `KEL-102/T3`: Wire the v0 authenticated app link through `keld-core` to
       the live `keld-native::fs` broker with a host-derived `AppProcess`
       context. Core routes and passes the verified snapshot/principal/request;


### PR DESCRIPTION
## Summary

`docs/specs/kel102-host-guard-enforcement.md` §6 still carried `- [ ] KEL-102/T2` although T2 landed on 2026-08-30. This flips the checkbox and replaces the now-false closing sentence with landed evidence, following the `T0g`/`T1` precedent already in that section.

Verified against `origin/main` `99e2998` before editing:

- `crates/keld-host/src/main.rs:95` — `.and_then(keld_core::app_session::run_guarded)`, which is exactly what T2's text requires ("Replace the shipping no-flag `keld-host` call to `run_unprivileged` with `run_guarded`").
- T2 merged at `b9ea8f843390b2229235bd694d7b3d581ea863dc` (PR #115).
- Passed `keld.execution-artifact/v1`, `task_id=KEL-102/T2`, in Linear comment `800fc0fb-8ae2-4bac-8982-8d6dc157ae2f`; claim released in `826f4c33-f358-4ae3-a90e-435623312ccf`.

Both predicates the old sentence named ("landing and the final execution artifact") are therefore satisfied, so the unchecked box was drift, not an accurate open state.

**This PR does not imply KEL-102/T3 is ready.** T3's row in the task-specific predecessor table is now satisfied, but that is necessary and not sufficient — the new text says so explicitly and cites `docs/specs/kel133-kipc-receiver-semantics.md` ("A partial merge cannot unlock KEL-130, KEL-102/T3, or KEL-97") plus the execution frontier as the remaining gates. Full dispatch analysis: KEL-102 comment `caed991f`.

## Spec refs

`docs/specs/kel102-host-guard-enforcement.md` §6 only. No contract text weakened or reworded, no decision-digest field touched, no T3/T4/T5/T6 entry changed.

## Review gates

- `unsafe`: none
- public API: none
- permission model: none — documentation of an already-approved, already-landed task; no policy, grant, principal or evaluation path is altered
- dependency addition: none
- wire protocol: none

## Tests

Docs-only; no behavior to test. Full local gate inventory run anyway on the exact branch tip:

- `just ci` — **exit 0** (whole chain: agents-md, atomic-protocol, agent-context, ci-router-test, hooks-test, mermaid-{test,check,render-check}, product-status-{test,check}, llms-{test,check}, hygiene, typescript, fmt-check, clippy, test, doc, deny)
- `just fmt-check` — exit 0
- `just clippy` (`--workspace --all-targets -- -D warnings`) — exit 0
- `just test` — `583 tests run: 583 passed (2 leaky), 3 skipped`
- `cargo deny` — `advisories ok, bans ok, licenses ok, sources ok`
- `git diff --check` — clean

Confirmed this spec feeds no generator before editing: 0 occurrences in `llms-full.txt`, no `docs/engineering/product-status.tsv` row, and no digest validator references the header's `Decision digest`.

## Platforms

Not applicable — documentation only, no OS-specific behavior. No real-OS acceptance claimed.

## Perf impact

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the KEL-102/T2 status to indicate completion.
  * Recorded the associated pull request, passed execution artifact, and released claim.
  * Clarified that T3 remains pending additional prerequisites.
  * Documented the outstanding requirements, including KEL-130/T1, dependency review, and a ready frontier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->