### PR TITLE
test(macos): observe initial presentation before startup checks

### DIFF
--- a/crates/keld-host/tests/fixtures/native_window_census.swift
+++ b/crates/keld-host/tests/fixtures/native_window_census.swift
@@ -1,0 +1,186 @@
+import CoreGraphics
+import Darwin
+import Foundation
+
+// Query and prearmed observation share this exact PID/title/layer filter.
+func matchingWindows(_ rows: [[String: Any]], title: String) -> [Int: [UInt32]] {
+  var matches: [Int: [UInt32]] = [:]
+  for row in rows {
+    guard let owner = (row[kCGWindowOwnerPID as String] as? NSNumber)?.intValue,
+      row[kCGWindowName as String] as? String == title,
+      (row[kCGWindowLayer as String] as? NSNumber)?.intValue == 0
+    else { continue }
+    let number = (row[kCGWindowNumber as String] as! NSNumber).uint32Value
+    matches[owner, default: []].append(number)
+  }
+  return matches
+}
+
+func census(_ scope: String, title: String) -> [Int: [UInt32]] {
+  let options: CGWindowListOption
+  if scope == "on-screen" {
+    options = [.optionOnScreenOnly, .excludeDesktopElements]
+  } else if scope == "all" {
+    options = [.excludeDesktopElements]
+  } else {
+    fatalError("unknown native-window scope")
+  }
+  let rows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as! [[String: Any]]
+  return matchingWindows(rows, title: title)
+}
+
+enum HistoryResult: Equatable {
+  case pending
+  case live([UInt32])
+  case stale
+}
+
+struct PresentationHistory {
+  // One first valid snapshot per PID; never a union of windows from different
+  // samples, nor a replacement of a previously witnessed window identity.
+  var first: [Int: [UInt32]] = [:]
+  let count: Int
+
+  mutating func observe(_ onScreen: [Int: [UInt32]]) {
+    for (pid, ids) in onScreen where ids.count == count && first[pid] == nil {
+      precondition(first.count < 256, "native-window PID history exceeded its bound")
+      first[pid] = ids.sorted()
+    }
+  }
+
+  func result(pid: Int, allWindows: [Int: [UInt32]]) -> HistoryResult {
+    guard let observed = first[pid] else { return .pending }
+    return observed == (allWindows[pid] ?? []).sorted() ? .live(observed) : .stale
+  }
+}
+
+func query() {
+  let pid = Int(CommandLine.arguments[2])!
+  let title = CommandLine.arguments[3]
+  let expectation = CommandLine.arguments[4]
+  let deadline = Date().addingTimeInterval(Double(CommandLine.arguments[5])!)
+  let scope = CommandLine.arguments[6]
+  var seen = Set<UInt32>()
+  while true {
+    let found = census(scope, title: title)[pid] ?? []
+    seen.formUnion(found)
+    let matches: Bool
+    if expectation == "snapshot" {
+      matches = true
+    } else if expectation.hasPrefix("exact:") {
+      let ids = expectation.dropFirst("exact:".count).split(separator: ",").map { UInt32($0)! }.sorted()
+      matches = found.sorted() == ids
+    } else {
+      fatalError("unknown native-window expectation")
+    }
+    if matches {
+      for window in found { print(window) }
+      return
+    }
+    if Date() >= deadline {
+      fputs("native-window observed_ids=\(seen.sorted())\n", stderr)
+      exit(3)
+    }
+    sched_yield()
+  }
+}
+
+func observe() {
+  let title = CommandLine.arguments[2]
+  let count = Int(CommandLine.arguments[3])!
+  let timeout = Double(CommandLine.arguments[4])!
+  precondition(count == 1, "initial presentation requires exactly one window")
+  let flags = fcntl(STDIN_FILENO, F_GETFL)
+  precondition(flags >= 0 && fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK) == 0)
+  var history = PresentationHistory(count: count)
+  history.observe(census("on-screen", title: title))
+  print("READY")
+  fflush(stdout)
+  var command: [UInt8] = []
+  var input = [UInt8](repeating: 0, count: 32)
+  var target: Int?
+  var deadline: UInt64?
+  while true {
+    // stdin EOF is parent loss. It also bounds observer lifetime if the Rust
+    // owner exits without unwinding; no target process or UI is controlled.
+    let readCount = read(STDIN_FILENO, &input, input.count)
+    if readCount == 0 { exit(2) }
+    if readCount > 0 {
+      precondition(target == nil && command.count + readCount <= 32, "invalid observer command")
+      command.append(contentsOf: input.prefix(readCount))
+      if command.last == 10 {
+        guard let text = String(bytes: command.dropLast(), encoding: .utf8),
+          let pid = Int(text), pid > 0 else { fatalError("invalid observer PID") }
+        target = pid
+        // Collection before binding does not spend the assertion's deadline.
+        deadline = DispatchTime.now().uptimeNanoseconds + UInt64(timeout * 1_000_000_000)
+      }
+    } else if errno != EAGAIN && errno != EINTR {
+      fatalError("read observer command failed")
+    }
+    history.observe(census("on-screen", title: title))
+    if let pid = target {
+      switch history.result(pid: pid, allWindows: census("all", title: title)) {
+      case .live(let ids):
+        print("WINDOWS " + ids.map(String.init).joined(separator: ","))
+        return
+      case .stale:
+        fputs("native-window observed identity no longer matches live census\n", stderr)
+        exit(3)
+      case .pending:
+        break
+      }
+      if DispatchTime.now().uptimeNanoseconds >= deadline! {
+        fputs("native-window target was never observed on-screen\n", stderr)
+        exit(3)
+      }
+    }
+    sched_yield()
+  }
+}
+
+// Fixed snapshots prove history/identity logic only. Real product tests below
+// the Rust owner retain the independent CoreGraphics on-screen oracle.
+func historyRegressions() {
+  let pid = 42
+  let other = 43
+  let id: UInt32 = 7136
+  var history = PresentationHistory(count: 1)
+  precondition(history.result(pid: pid, allWindows: [pid: [id]]) == .pending,
+    "all-window existence must not fabricate presentation")
+  history.observe([other: [id]])
+  precondition(history.result(pid: pid, allWindows: [pid: [id]]) == .pending,
+    "another PID must not supply presentation")
+  history.observe([pid: [id, id + 1]])
+  precondition(history.result(pid: pid, allWindows: [pid: [id]]) == .pending,
+    "two-window snapshot must not satisfy count one")
+  history.observe([pid: [id]])
+  history.observe([:]) // A Space switch removes the on-screen row.
+  precondition(history.result(pid: pid, allWindows: [pid: [id]]) == .live([id]),
+    "late consumption must preserve an actually observed live identity")
+  precondition(history.result(pid: pid, allWindows: [:]) == .stale,
+    "destroyed window must fail")
+  precondition(history.result(pid: pid, allWindows: [pid: [id + 1]]) == .stale,
+    "replacement window must fail")
+  precondition(history.result(pid: pid, allWindows: [pid: [id, id + 1]]) == .stale,
+    "additional matching window must fail exact count")
+  history.observe([pid: [id + 1]])
+  precondition(history.result(pid: pid, allWindows: [pid: [id + 1]]) == .stale,
+    "later presentation must not overwrite stale first identity")
+  let row: [String: Any] = [kCGWindowOwnerPID as String: pid,
+    kCGWindowName as String: "fixture", kCGWindowLayer as String: 0,
+    kCGWindowNumber as String: id]
+  precondition(matchingWindows([row], title: "fixture") == [pid: [id]])
+  precondition(matchingWindows([row], title: "wrong").isEmpty)
+  var elevated = row
+  elevated[kCGWindowLayer as String] = 1
+  precondition(matchingWindows([elevated], title: "fixture").isEmpty)
+  print("PASS native-window history: unseen, PID, count, Space, destroyed, replaced, extra, first identity, title, layer")
+}
+
+switch CommandLine.arguments[1] {
+case "query": query()
+case "observe": observe()
+case "history-regressions": historyRegressions()
+default: fatalError("unknown census mode")
+}

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -12,6 +12,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::os::unix::process::{CommandExt as _, ExitStatusExt};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Output, Stdio};
+use std::sync::OnceLock;
 use std::sync::mpsc::{self, Receiver};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -532,6 +533,7 @@ impl RecoveryCycle {
         listener
             .set_nonblocking(true)
             .expect("nonblocking T3 fixture control");
+        let mut presentation = fixture.observe_initial_window();
         let child = Command::new(stage.host())
             .env("KELD_T1B_CONTROL", &control_path)
             .stdout(Stdio::piped())
@@ -556,7 +558,7 @@ impl RecoveryCycle {
             current: Some(current),
             process_groups: vec![first_group],
         };
-        let window = await_native_windows(host_pid, TITLE, 1);
+        let window = presentation.expect_initial(host_pid, "initial T3 native window");
         assert_eq!(window.len(), 1, "initial T3 native window: {window:?}");
         cycle.window = window;
         cycle
@@ -1062,6 +1064,7 @@ impl ShippingDevCycle {
         listener
             .set_nonblocking(true)
             .expect("nonblocking T2 fixture control");
+        let mut presentation = fixture.observe_initial_window();
         let cli = Command::new(helper)
             .args(["--exact", "keld_dev_helper_process", "--nocapture"])
             .process_group(0)
@@ -1126,10 +1129,7 @@ impl ShippingDevCycle {
         assert_eq!(read_control_line(&mut cycle.control_reader), "ECHO1");
         assert_eq!(read_control_line(&mut cycle.control_reader), "ECHO2");
         beacon.assert_exact();
-        assert_eq!(
-            await_native_windows_for(cycle.host_pid, TITLE, 1, name).len(),
-            1
-        );
+        assert_eq!(presentation.expect_initial(cycle.host_pid, name).len(), 1);
         assert!(native_windows(cli_pid, TITLE).is_empty());
         assert!(host_unix_sockets(cycle.host_pid) > 0);
         assert_eq!(host_unix_sockets(cli_pid), 0);
@@ -1327,6 +1327,7 @@ struct ProductFixture {
     project: PathBuf,
     link_source: String,
     harness: &'static str,
+    native_census: OnceLock<PathBuf>,
 }
 
 impl ProductFixture {
@@ -1345,7 +1346,15 @@ impl ProductFixture {
             project,
             link_source,
             harness: include_str!("fixtures/t1b_harness.ts"),
+            native_census: OnceLock::new(),
         }
+    }
+
+    fn observe_initial_window(&self) -> NativeWindowObserver {
+        let executable = self
+            .native_census
+            .get_or_init(|| compile_native_window_census(self.root.path()));
+        NativeWindowObserver::arm(executable)
     }
 
     fn stage(&self) -> keld_cli::boot::DevBootStage {
@@ -1421,6 +1430,7 @@ impl ProductFixture {
                 .env("KELD_T2_EXIT_ON_LINK_EOF", "1")
                 .stdin(Stdio::piped());
         }
+        let presentation = self.observe_initial_window();
         let mut child = command.spawn().expect("launch staged no-flag host");
         let lease_writer = child.stdin.take();
         let host_pid = child.id();
@@ -1439,6 +1449,7 @@ impl ProductFixture {
             control_reader,
             control_writer: control,
             beacon: Some(beacon),
+            presentation: Some(presentation),
             group_gone: false,
         };
         let hello = cycle.next_line();
@@ -2033,18 +2044,23 @@ struct LiveCycle {
     control_reader: BufReader<UnixStream>,
     control_writer: UnixStream,
     beacon: Option<Beacon>,
+    presentation: Option<NativeWindowObserver>,
     group_gone: bool,
 }
 
 impl LiveCycle {
-    fn assert_live_product(&self) {
+    fn assert_live_product(&mut self) {
         assert_ne!(self.host_pid, self.guardian_pid);
         assert_ne!(self.guardian_pid, self.bun_pid);
         assert_eq!(parent_process(self.guardian_pid), self.host_pid);
         assert_eq!(parent_process(self.bun_pid), self.guardian_pid);
         assert_eq!(process_group(self.bun_pid), self.bun_pid);
         assert_eq!(process_group(self.descendant_pid), self.bun_pid);
-        let windows = await_native_windows(self.host_pid, TITLE, 1);
+        let windows = self
+            .presentation
+            .take()
+            .expect("prearmed initial-presentation observer")
+            .expect_initial(self.host_pid, "initial-presentation");
         assert_eq!(
             windows.len(),
             1,
@@ -2518,6 +2534,173 @@ print("\(info.pipeinfo.pipe_handle) \(info.pipeinfo.pipe_peerhandle)")
     (handle, peer)
 }
 
+fn compile_native_window_census(root: &Path) -> PathBuf {
+    let source = root.join("native-window-census.swift");
+    let executable = root.join("native-window-census");
+    fs::write(&source, include_str!("fixtures/native_window_census.swift"))
+        .expect("write native-window census");
+    let output = Command::new("/usr/bin/xcrun")
+        .args(["swiftc", "-O"])
+        .arg(&source)
+        .arg("-o")
+        .arg(&executable)
+        .output()
+        .expect("compile native-window census");
+    assert!(output.status.success(), "compile native census: {output:?}");
+    executable
+}
+
+/// An external CoreGraphics observer is armed before spawn, when the target PID
+/// is not yet known. Only the authenticated PID supplied at the original check
+/// phase can consume its on-screen history, and those exact IDs must still live.
+struct NativeWindowObserver {
+    child: Option<Child>,
+    events: Receiver<Result<String, String>>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl NativeWindowObserver {
+    fn arm(executable: &Path) -> Self {
+        let mut child = Command::new(executable)
+            .args(["observe", TITLE, "1", &EVENT_DEADLINE.as_secs().to_string()])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("start prearmed native-window observer");
+        let stdout = child.stdout.take().expect("native-window observer stdout");
+        let (sender, events) = mpsc::sync_channel(2);
+        let reader = thread::spawn(move || {
+            let mut stdout = BufReader::new(stdout);
+            // Exactly two bounded records: readiness and one result. A broken
+            // helper cannot grow the parent's buffer or block Drop on send.
+            for _ in 0..2 {
+                let mut line = String::new();
+                let result = match stdout.by_ref().take(257).read_line(&mut line) {
+                    Ok(0) => Err(String::from("native-window observer EOF")),
+                    Ok(bytes) if bytes > 256 || !line.ends_with('\n') => {
+                        Err(String::from("invalid native-window observer record"))
+                    }
+                    Ok(_) => Ok(line.trim_end().to_owned()),
+                    Err(error) => Err(error.to_string()),
+                };
+                let failed = result.is_err();
+                if sender.send(result).is_err() || failed {
+                    break;
+                }
+            }
+        });
+        let observer = Self {
+            child: Some(child),
+            events,
+            reader: Some(reader),
+        };
+        assert_eq!(
+            observer.events.recv_timeout(EVENT_DEADLINE),
+            Ok(Ok(String::from("READY"))),
+            "native-window observer must be armed before host spawn"
+        );
+        observer
+    }
+
+    fn expect_initial(&mut self, pid: u32, observation: &str) -> Vec<u32> {
+        // Precollection has its own lifetime. The existing check-phase deadline
+        // starts here and includes command delivery, result reception and exit.
+        let deadline = Instant::now() + EVENT_DEADLINE;
+        writeln!(
+            self.child
+                .as_mut()
+                .expect("live native-window observer")
+                .stdin
+                .as_mut()
+                .expect("native-window observer command pipe"),
+            "{pid}"
+        )
+        .expect("bind native-window history to authenticated PID");
+        let event = self
+            .events
+            .recv_timeout(deadline.saturating_duration_since(Instant::now()));
+        assert!(
+            event.is_ok() && Instant::now() < deadline,
+            "CoreGraphics presentation ({observation}): {event:?}; target-PID rows: {}",
+            native_window_rows(pid)
+        );
+        let output = wait_child_output(
+            self.child
+                .take()
+                .expect("native-window observer exit owner"),
+            deadline.saturating_duration_since(Instant::now()),
+        );
+        assert!(
+            output.status.success() && Instant::now() < deadline,
+            "CoreGraphics presentation ({observation}): {event:?}; {output:?}; target-PID rows: {}",
+            native_window_rows(pid)
+        );
+        let line = event
+            .expect("received native-window event")
+            .expect("native-window result");
+        let windows: Vec<u32> = line
+            .strip_prefix("WINDOWS ")
+            .expect("native-window identity record")
+            .split(',')
+            .map(|id| id.parse().expect("numeric native-window identity"))
+            .collect();
+        assert_eq!(windows.len(), 1, "initial native-window count");
+        windows
+    }
+}
+
+impl Drop for NativeWindowObserver {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+#[test]
+fn native_window_observer_history_retains_only_presented_live_identity() {
+    let root = tempfile::tempdir().expect("native-window history fixture");
+    let executable = compile_native_window_census(root.path());
+    let output = Command::new(executable)
+        .arg("history-regressions")
+        .output()
+        .expect("run fixed native-window history snapshots");
+    assert!(output.status.success(), "history regressions: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).starts_with("PASS native-window history:"));
+}
+
+#[test]
+fn native_window_observer_reaps_on_assertion_unwind_and_parent_eof() {
+    let root = tempfile::tempdir().expect("native-window cleanup fixture");
+    let executable = compile_native_window_census(root.path());
+    let observer = NativeWindowObserver::arm(&executable);
+    let pid = observer.child.as_ref().expect("observer child").id();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let _observer = observer;
+        panic!("injected post-arm assertion failure");
+    }));
+    assert!(result.is_err(), "negative control must unwind");
+    await_process_gone(pid);
+
+    let mut observer = NativeWindowObserver::arm(&executable);
+    let child = observer.child.as_mut().expect("observer child");
+    let pid = child.id();
+    drop(child.stdin.take());
+    let output = wait_child_output(observer.child.take().expect("EOF observer"), EVENT_DEADLINE);
+    assert_eq!(output.status.code(), Some(2), "parent EOF: {output:?}");
+    assert_eq!(
+        observer.events.recv_timeout(EVENT_DEADLINE),
+        Ok(Err(String::from("native-window observer EOF")))
+    );
+    drop(observer);
+    await_process_gone(pid);
+}
+
 fn native_windows(pid: u32, title: &str) -> Vec<u32> {
     query_native_windows(
         pid,
@@ -2572,20 +2755,6 @@ print(String(data: data, encoding: .utf8)!)
     }
 }
 
-fn await_native_windows(pid: u32, title: &str, expected: usize) -> Vec<u32> {
-    await_native_windows_for(pid, title, expected, "initial-presentation")
-}
-
-fn await_native_windows_for(pid: u32, title: &str, expected: usize, observation: &str) -> Vec<u32> {
-    query_native_windows(
-        pid,
-        title,
-        NativeWindowScope::OnScreen,
-        NativeWindowExpectation::Count(expected),
-        observation,
-    )
-}
-
 /// Recovery preserves the already-observed native window identity. Visibility is
 /// a separate launch contract, so this check deliberately uses the all-window
 /// census while keeping the existing bounded observation deadline.
@@ -2612,7 +2781,6 @@ enum NativeWindowScope {
 #[derive(Clone, Copy)]
 enum NativeWindowExpectation<'a> {
     Snapshot,
-    Count(usize),
     Exact(&'a [u32]),
 }
 
@@ -2623,61 +2791,9 @@ fn query_native_windows(
     expectation: NativeWindowExpectation<'_>,
     observation: &str,
 ) -> Vec<u32> {
-    const SCRIPT: &str = r#"
-import CoreGraphics
-import Darwin
-import Foundation
-let wantedPID = Int(CommandLine.arguments[1])!
-let wantedTitle = CommandLine.arguments[2]
-let expectation = CommandLine.arguments[3]
-let deadline = Date().addingTimeInterval(Double(CommandLine.arguments[4])!)
-let scope = CommandLine.arguments[5]
-var seen = Set<UInt32>()
-while true {
-  let options: CGWindowListOption
-  if scope == "on-screen" {
-    options = [.optionOnScreenOnly, .excludeDesktopElements]
-  } else if scope == "all" {
-    options = [.excludeDesktopElements]
-  } else {
-    fatalError("unknown native-window scope")
-  }
-  let rows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as! [[String: Any]]
-  var found: [UInt32] = []
-  for row in rows {
-    let owner = (row[kCGWindowOwnerPID as String] as? NSNumber)?.intValue
-    let name = row[kCGWindowName as String] as? String
-    let layer = (row[kCGWindowLayer as String] as? NSNumber)?.intValue
-    if owner == wantedPID && name == wantedTitle && layer == 0 {
-      found.append((row[kCGWindowNumber as String] as! NSNumber).uint32Value)
-    }
-  }
-  seen.formUnion(found)
-  let matches: Bool
-  if expectation == "snapshot" {
-    matches = true
-  } else if expectation.hasPrefix("count:") {
-    matches = found.count == Int(expectation.dropFirst("count:".count))!
-  } else if expectation.hasPrefix("exact:") {
-    let ids = expectation.dropFirst("exact:".count).split(separator: ",").map { UInt32($0)! }.sorted()
-    matches = found.sorted() == ids
-  } else {
-    fatalError("unknown native-window expectation")
-  }
-  if matches {
-    for window in found { print(window) }
-    exit(0)
-  }
-  if Date() >= deadline {
-    fputs("native-window observed_ids=\(seen.sorted())\n", stderr)
-    exit(3)
-  }
-  sched_yield()
-}
-"#;
+    const SCRIPT: &str = include_str!("fixtures/native_window_census.swift");
     let expectation_arg = match expectation {
         NativeWindowExpectation::Snapshot => String::from("snapshot"),
-        NativeWindowExpectation::Count(value) => format!("count:{value}"),
         NativeWindowExpectation::Exact(windows) => format!(
             "exact:{}",
             windows
@@ -2697,6 +2813,7 @@ while true {
             "swift",
             "-e",
             SCRIPT,
+            "query",
             &pid.to_string(),
             title,
             &expectation_arg,


### PR DESCRIPTION
## Summary

Arm the macOS initial-presentation census before launching the unchanged host or CLI. The old tests started their on-screen query only after readiness, echoes, renderer beacon and some process checks; a Space change could remove an already-presented window before that late query began.

The external observer records actual CoreGraphics on-screen PID/title/layer/ID snapshots, binds only the subsequently authenticated host PID, and verifies that the same IDs still exist at readiness. A never-presented, destroyed, replaced, wrong-PID or extra-window state cannot pass. Product launch, activation, focus, process groups, readiness assertions, retry policy and the existing15-second check-phase deadline remain unchanged.

## Spec refs

No boundary change. KEL-196 initial presentation and KEL-96 shipping host/window/lifecycle evidence. The native query and observer share one extracted Swift PID/title/layer filter; recovery still uses the landed all-window identity contract. The user approved the test-oracle correction after inspecting paired AppKit/CG evidence.

## Review gates

Five root gates: none. Isolated exact-tip review at3767d9d1613714bad52caf16b314d0aca747c06b found no actionable issue in identity, deadlines or child/reader cleanup. It independently compiled the Swift regressions and exercised EOF, unseen-target timeout and fragmented command cases. The two-file patch is byte-identical to the CodeRabbit-reviewed1cd23fac patch (zero issues). Isolated exact-current-tip review passed after rebasing onto the landed KEL-197 fixture fix and latest onboarding/documentation changes, with no observer interaction. No unresolved review threads.

## Tests

- Fixed-snapshot regressions cover prior actual presentation, PID/title/layer/count binding, later Space absence, destroyed/replaced/extra IDs, and preserving first identity.
- Three temporary negative controls failed the intended assertions: discarded history, skipped current identity check, and existence substituted for presentation.
- Replay through the exact new history implementation using captured PID31337/window6697 CG rows:12 pre-close inactive-Space frames now retain actual prior presentation and current identity;2 never-presented frames remain pending. This is replay logic evidence, not a new live OS claim.
- Real macOS focused lifecycle suite:15 passed,0 failed, six unchanged negative-boot/navigation cases excluded from this focused run. Includes all three launch paths, recovery, lease/CLI death, cleanup and observer unwind/parent EOF.
- Focused warning-denied clippy, formatting and whitespace checks passed.
- Final full local `just ci` passed at3767d9d using a worktree-private target:636 workspace tests, two existing skips, all static/docs/Mermaid/TypeScript/format/clippy/rustdoc/dependency gates. Required [CI34296239194](https://github.com/gyldlab/keld/actions/runs/34296239194) passed all applicable Linux/macOS/Windows lanes and CI required. The earlier guardian failure was fixed separately in PR199; an intermediate stale shared-cache artifact was diagnosed and replaced by the clean private build, with failed evidence retained.

## Platforms

macOS test-only change, verified on physical macOS26.5.1 arm64 with Screen Capture permission. Other-platform code is unchanged; required routed hosted checks remain mandatory. No new production behavior claim.

## Perf impact

No performance claim. The observer is compiled once per fixture and runs outside the host. History and protocol buffers are bounded; it is reaped on panic and parent EOF. Precollection does not spend or extend the original assertion-phase15-second budget, which covers command delivery, result receipt and helper exit. No sleep synchronization, product suspension, scheduling override or retry was added.
