### PR TITLE
test(runtime): order supervised self-exit after registration

### DIFF
--- a/crates/keld-runtime/src/macos_guardian.rs
+++ b/crates/keld-runtime/src/macos_guardian.rs
@@ -3407,7 +3407,9 @@ mod tests {
     #[test]
     fn supervised_self_termination_returns_while_host_writer_is_still_live() {
         let (reader, writer) = liveness_pipe();
+        let (pid_tx, pid_rx) = mpsc::channel();
         let (done_tx, done_rx) = mpsc::channel();
+        let deadline = Instant::now() + Duration::from_secs(5);
         let worker = std::thread::spawn(move || {
             let result = run_supervised_with_registration(
                 reader,
@@ -3415,22 +3417,34 @@ mod tests {
                 io::sink(),
                 || {
                     let mut command = Command::new("/bin/sh");
-                    command.args(["-c", "exit 0"]);
+                    command.args(["-c", "kill -STOP $$; exit 0"]);
                     Ok(command)
                 },
-                |_| Ok(()),
+                move |pid| pid_tx.send(pid).map_err(io::Error::other),
                 || Ok(()),
             );
             done_tx.send(result).expect("report guardian result");
         });
-
-        let error = done_rx
-            .recv_timeout(Duration::from_secs(5))
+        // Enrollment must precede the exit under test. Confirm the shell has
+        // actually stopped so an early SIGCONT cannot race its SIGSTOP.
+        let pid = pid_rx
+            .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+            .expect("self-terminating child registered");
+        await_stopped_child(pid, deadline);
+        kill(
+            Pid::from_raw(i32::try_from(pid).expect("pid fits i32")),
+            Signal::SIGCONT,
+        )
+        .expect("let registered child exit zero");
+        let result = done_rx.recv_timeout(deadline.saturating_duration_since(Instant::now()));
+        // The result must arrive with the writer live; close it before asserting
+        // so a failed observation still lets the guardian clean up its child.
+        drop(writer);
+        worker.join().expect("guardian worker joins");
+        let error = result
             .expect("self-termination must wake the guardian while host is live")
             .expect_err("unrequested status-zero exit is fatal");
         assert!(error.to_string().contains("KELD-RUNTIME-012"), "{error}");
-        drop(writer);
-        worker.join().expect("guardian worker joins");
     }
 
     #[test]
@@ -3459,24 +3473,7 @@ mod tests {
             .expect("stopped child registered");
 
         let stopped_deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            let output = Command::new("/bin/ps")
-                .args(["-o", "state=", "-p", &pid.to_string()])
-                .output()
-                .expect("inspect accepted-Quit child state");
-            if String::from_utf8(output.stdout)
-                .expect("process state is UTF-8")
-                .trim()
-                .starts_with('T')
-            {
-                break;
-            }
-            assert!(
-                Instant::now() < stopped_deadline,
-                "accepted-Quit child never stopped"
-            );
-            std::thread::yield_now();
-        }
+        await_stopped_child(pid, stopped_deadline);
 
         writer.write_all(b"Q").expect("accept Quit before reply");
         assert_eq!(
@@ -3508,6 +3505,24 @@ mod tests {
             .expect("accepted Quit is a clean supervised shutdown");
         assert_eq!(report.1.self_termination_count, 0);
         worker.join().expect("guardian worker joins");
+    }
+
+    fn await_stopped_child(pid: u32, deadline: Instant) {
+        loop {
+            let output = Command::new("/bin/ps")
+                .args(["-o", "state=", "-p", &pid.to_string()])
+                .output()
+                .expect("inspect stopped child state");
+            if String::from_utf8(output.stdout)
+                .expect("process state is UTF-8")
+                .trim()
+                .starts_with('T')
+            {
+                break;
+            }
+            assert!(Instant::now() < deadline, "child never stopped");
+            std::thread::yield_now();
+        }
     }
 
     struct AckSender(mpsc::Sender<[u8; SUPERVISED_QUIT_ACK.len()]>);


### PR DESCRIPTION
## Summary

Make the live-writer self-termination fixture enroll its child before allowing that child to exit. The previous immediate `exit 0` could race group validation and return a registration error instead of exercising the intended post-registration self-termination path.

The test now observes the registered PID and stopped state before releasing the child. It keeps the host writer live through result receipt and preserves the existing RUNTIME012 assertion and five-second budget. The stopped-state helper is reused from the accepted-Quit fixture without changing its ordering. Production code and process-group configuration are unchanged.

## Spec refs

No boundary change. KEL-197; existing guardian registration, unrequested status-zero attribution, and liveness contracts. This is a test-fixture ordering correction, separate from KEL-196 window observation and the Bun pin.

## Review gates

Five root gates: none. CodeRabbit CLI reviewed exact tipfb7694f760055976ac31e314d1fa1a8ea13408a7 with zero issues. Independent isolated review verified the104276-byte production prefix is identical, the stopped-state loop preserves behavior, and the result is received before writer closure.

## Tests

- The prior full gate failed with RUNTIME003 before registration instead of required RUNTIME012.
- Temporary registration-boundary fault: reaped zero-exit child was rejected by the real lease validator with ESRCH, no callback/PID publication. This proves the boundary, not the exact historical schedule.
- Temporary no-exit mutation failed the original live-writer wake predicate at five seconds, then cleanup ran; restored before validation.
- Final guardian module31/31 and supervised subset5/5 passed.
- Full local `just ci` passed:634 workspace tests, two existing skips, documentation/Mermaid/TypeScript, format, warning-denied clippy, rustdoc and dependency gates.
- Required [CI34294521240](https://github.com/gyldlab/keld/actions/runs/34294521240) passed at the exact tip, including applicable Linux/macOS/Windows checks and CI required. No unresolved review threads.

## Platforms

Real macOS26.5.1 arm64. The changed code is entirely in the macOS test module; applicable hosted Linux/macOS/Windows checks remain required. The adjacent host-EOF fixture has distinct ordering and is untouched.

## Perf impact

No performance claim. No sleeps, retries, longer deadlines or production behavior changes. The original five-second budget covers registration, stopped-state observation, release and result; cleanup cannot convert a timeout into a pass.
