### PR TITLE
docs(agents): require current-documentation receipts

### DIFF
--- a/.agents/coordination.md
+++ b/.agents/coordination.md
@@ -31,6 +31,19 @@ gets this handoff:
 - Ticket status: In Progress | Blocked
 ```
 
+## Current-documentation receipt
+
+For each material external semantic selected by
+[`.agents/research.md` § Current-documentation receipt](research.md#current-documentation-receipt),
+record these exact fields under the required receipt heading in the relevant Linear
+decision, OS handoff, or branch handoff. A pure local refactor does not need one.
+
+- Applicability: applied:<external semantic> | not-applicable:<pure-local reason>
+- Context7: used:<library ID; query; retrieval date> | not-applicable:<reason> | unavailable:<exact tool failure>
+- Official primary: <URL or immutable source; applicable version/tag; retrieval date>
+- Supported claim: <exact decision-bearing claim>
+- Fallback/blocker: none | <unknown or blocked decision and next action>
+
 ## Branch handoff
 
 Every used branch gets one Linear block before its owner finishes:

--- a/.agents/dependencies.md
+++ b/.agents/dependencies.md
@@ -13,9 +13,10 @@ additions trigger the root gate and its independent evidence requirement.
    never what is current upstream.
 2. Read the selected version's upstream release notes or changelog and source tag.
    For a major bump, read the official migration guide before editing manifests.
-3. Retrieve current, version-specific API documentation with Context7 when available.
-   Context7 aids retrieval; it does not replace registry metadata, upstream releases,
-   source, or a migration guide.
+3. Apply [`.agents/research.md` § Current-documentation receipt](research.md#current-documentation-receipt)
+   to every current API or runtime semantic claim. It owns Context7 discovery, official
+   confirmation, fallback, and the reviewable receipt; the registry and upstream sources
+   above remain required dependency evidence.
 4. Check Keld's Rust toolchain/MSRV, Bun/runtime assumptions, supported targets,
    enabled features, license, maintenance state, and relevant advisories.
 5. Record the candidate version, release date, primary URLs, breaking changes,

--- a/.agents/docs.md
+++ b/.agents/docs.md
@@ -19,8 +19,9 @@ Load for agent-docs, generated docs, Mermaid, or public documentation changes.
 - Every block has `accTitle` and `accDescr`. Labels carry current/target and
   framework/showcase meaning without relying on color; surrounding prose names source of
   truth and any implementation gap.
-- Use stable repository/GitHub syntax. For unfamiliar syntax, Context7 MAY locate current
-  material, but official Mermaid docs remain the authority.
+- Use stable repository/GitHub syntax. For unfamiliar Mermaid syntax, apply
+  [`.agents/research.md` § Current-documentation receipt](research.md#current-documentation-receipt);
+  official Mermaid docs remain the authority.
 
 ## Shared semantic palette
 

--- a/.agents/index.md
+++ b/.agents/index.md
@@ -28,6 +28,7 @@ do not silently choose the less restrictive rule.
 | Tests, bug fixes, compatibility, process boundaries, fuzzing, or platform behavior | [`testing.md`](testing.md) |
 | Add/change Mermaid under private research or synthesize external evidence | [`docs.md`](docs.md), [`testing.md`](testing.md), and [`research.md`](research.md) |
 | Needs a paste prompt or external-research pack; or would otherwise invent a new prompt taxonomy | [`research.md`](research.md) and Prompt Tracker (`0monish/prompt-tracker` / local `keld-agent-prompts`) |
+| Material decision depends on current external OS/platform command, SDK/API, runtime, or external-tool semantics | [`research.md`](research.md) § Current-documentation receipt; [`testing.md`](testing.md) when behavior is exercised |
 | Material decision needs current external facts, sentiment, unpublished changes, or cross-source synthesis and local/primary evidence is insufficient | [`research.md`](research.md) |
 | Local docs, code, tests, and Prompt Tracker still cannot answer a material question | [`memory.md`](memory.md) for MemPalace and untrusted-lead rules |
 | Add, bump, remove, migrate, or make a current-version claim about a Cargo or Bun dependency | [`dependencies.md`](dependencies.md) |

--- a/.agents/instruction-budget.tsv
+++ b/.agents/instruction-budget.tsv
@@ -11,12 +11,12 @@ crates/keld-runtime/AGENTS.md	always	1536	runtime-invariants	path:crates/keld-ru
 crates/keld-wv/AGENTS.md	always	4096	webview-invariants	path:crates/keld-wv
 .agents/index.md	routed	4096	task-router	root:instruction-loading
 .agents/ci.md	routed	4096	ci-keldbot-policy	route:ci
-.agents/coordination.md	routed	3328	coordination-templates	route:coordination
+.agents/coordination.md	routed	4352	coordination-templates	route:coordination
 .agents/dependencies.md	routed	2560	dependency-policy	route:dependencies
 .agents/docs.md	routed	3072	documentation-policy	route:docs
 .agents/instructions.md	routed	3072	instruction-authoring-policy	route:instructions
 .agents/memory.md	routed	7168	external-memory-policy	route:memory
-.agents/research.md	routed	5120	research-publication-policy	route:research
+.agents/research.md	routed	6144	research-publication-policy	route:research
 .agents/review.md	routed	2304	git-pr-review-policy	route:review
 .agents/testing.md	routed	8192	testing-evidence-policy	route:testing
 .agents/skills/autofix/SKILL.md	routed	14336	coderabbit-autofix-skill	skill:autofix

--- a/.agents/research.md
+++ b/.agents/research.md
@@ -21,6 +21,29 @@ prompts live in Prompt Tracker (`0monish/prompt-tracker`) under the existing cat
 tree. Website Deep Research pastes follow that repo’s `docs/05-deep-research-host.md`
 and `prompts/SHARED/` chrome. This playbook still owns the escalation trigger below.
 
+## Current-documentation receipt
+
+Before deciding a material claim that depends on current external OS/platform-command,
+SDK/API, runtime, or external-tool semantics, use this playbook's receipt. It does not
+apply to a pure local refactor whose decision does not rely on external semantics.
+
+1. **Discover.** When Context7 is available, resolve the relevant library and make a
+   narrow query before deciding. Record the library ID, query, and retrieval date.
+   Context7 is discovery, never the authority.
+2. **Confirm.** Confirm every material claim with a current official primary source:
+   owning vendor/platform documentation, a release or migration guide, an immutable
+   upstream source tag, or a normative standard. Record the URL or immutable source
+   reference, applicable version/tag, retrieval date, and exact supported claim.
+3. **Handle gaps truthfully.** If Context7 is unavailable or its query fails, record the
+   exact failure and continue only when primary confirmation exists. If no relevant
+   Context7 library applies, record that reason as not-applicable; primary confirmation
+   is still required. If no current, unambiguous primary source is available, leave the
+   claim unknown or block the decision; local reproduction may demonstrate behavior but
+   cannot turn an unsupported external claim into documented fact.
+4. **Leave the record.** Use the `## Current-documentation receipt` template in
+   [`coordination.md`](coordination.md) on the relevant Linear decision, OS handoff,
+   or branch handoff. Do not place private source text or sensitive queries there.
+
 ## Escalation trigger
 
 Agents MUST ask the user to run one copy-ready external-research prompt only when all
@@ -55,10 +78,9 @@ uncertainty.
   environment context, and model-generated diagrams are leads only. They MUST NOT be
   promoted into a diagram's factual edge or number until the source ledger or executable
   artifact is restored.
-- For unfamiliar Mermaid syntax, use Context7 when available to locate current material,
-  then confirm against [official Mermaid documentation](https://mermaid.js.org/) before authoring.
-  Record the official page used in the research source ledger; Context7 output is not
-  the cited authority.
+- For unfamiliar Mermaid syntax, apply [the current-documentation receipt](#current-documentation-receipt)
+  before authoring. Record the official [Mermaid documentation](https://mermaid.js.org/)
+  page in the research source ledger; Context7 output is not the cited authority.
 - The render report MUST name the exact stable renderer version and actual result. Keep
   generated SVG/PNG/PDF output temporary unless the rendered file is an intentionally
   reviewed research artifact; do not commit generated pictures merely to prove parsing.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -66,10 +66,9 @@ evidence only when a plausible defect can make it fail.
 - Run `just mermaid-test` and `just mermaid-check` for every diagram change. These prove
   the repository validator and structural policy; they do not replace the actual render
   required below.
-- Before using syntax the author has not already rendered in this repository, the author
-  SHOULD use Context7 when available to locate current material and MUST confirm the
-  syntax in the current official Mermaid docs. Context7 is discovery; official Mermaid
-  docs are the primary syntax authority and remain sufficient when the connector is absent.
+- Before using unfamiliar Mermaid syntax, apply
+  [`.agents/research.md` § Current-documentation receipt](research.md#current-documentation-receipt).
+  The official Mermaid docs are the primary syntax authority; Context7 remains discovery.
 - Every added or changed Mermaid block MUST pass `just mermaid-render-check`. It uses the
   official [`@mermaid-js/mermaid-cli`](https://github.com/mermaid-js/mermaid-cli)
   11.16.0 GHCR image pinned by immutable OCI digest, with the checkout read-only,

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -45,6 +45,11 @@ external contributors do not acquire that authority.
    Before implementation, compare the issue/paste pin with `origin/main`: inspect
    `git log <pin>..origin/main`, newly landed `docs/research` notes, and open PRs. Record
    that delta in this first Linear comment. A stale pin is a defect, not an excuse.
+   When a material decision depends on current external OS/platform-command, SDK/API,
+   runtime, or external-tool semantics, create the receipt owned by
+   [`.agents/research.md` § Current-documentation receipt](../../.agents/research.md#current-documentation-receipt)
+   using the [`.agents/coordination.md` template](../../.agents/coordination.md#current-documentation-receipt).
+   Pure local refactors do not need the receipt.
    For non-trivial work, that same first comment MUST record the decision-bearing atoms
    required by root `AGENTS.md` § Atomic problem-solving protocol. Record each atom's
    owner, boundary and inputs/outputs, failure mode, observable contract, independence
@@ -71,7 +76,8 @@ external contributors do not acquire that authority.
    blocker, supersession or another active owner, stop the overlap, record the conflict
    on the agent's own issue (or handoff), and notify the human/orchestrator; a worktree
    does not authorize competing architecture decisions. Apply the attempt, evidence,
-   status, and handoff rules owned by `.agents/coordination.md` to every OS criterion.
+   status, handoff, and current-documentation receipt rules owned by `.agents/coordination.md`
+   to every applicable OS or external-semantic criterion.
 5. **Verify**. `just ci` is the exact full local gate; format, warning-denied clippy, and
    the full workspace test suite are its mandatory core Rust subset. Also run the spec's
    test plan. Diagram changes additionally run

--- a/tools/atomic_protocol.rs
+++ b/tools/atomic_protocol.rs
@@ -711,16 +711,21 @@ fn require_current_documentation_consumer(
 
 fn check_current_documentation_receipts(root: &Path) -> Result<(), String> {
     let research = read(root, RESEARCH)?;
+    let research_rendered = visible_markdown(&research);
     let research_visible = binding_prose(&research);
-    let receipt = section(&research_visible, CURRENT_DOCUMENTATION_HEADING, RESEARCH)?;
+    let receipt = binding_prose(direct_section(
+        &research_rendered,
+        CURRENT_DOCUMENTATION_HEADING,
+        RESEARCH,
+    )?);
     for requirement in CURRENT_DOCUMENTATION_RESEARCH_REQUIREMENTS {
-        require_normalized(receipt, requirement, RESEARCH)?;
+        require_normalized(&receipt, requirement, RESEARCH)?;
         require_unique_normalized(&research_visible, requirement, RESEARCH)?;
     }
 
     let coordination = read(root, COORDINATION)?;
     let coordination_visible = visible_markdown(&coordination);
-    let receipt = section(
+    let receipt = direct_section(
         &coordination_visible,
         CURRENT_DOCUMENTATION_HEADING,
         COORDINATION,
@@ -1674,6 +1679,39 @@ mod tests {
             + "\n";
         temp.write(COORDINATION, &coordination);
         let error = check(&temp.path).expect_err("historical receipt field must not satisfy owner");
+        assert!(error.contains(field), "{error}");
+    }
+
+    #[test]
+    fn receipt_owner_requirements_cannot_move_to_a_nested_history_heading() {
+        let temp = fixture();
+        let requirement = CURRENT_DOCUMENTATION_RESEARCH_REQUIREMENTS[0];
+        let research = fs::read_to_string(temp.path.join(RESEARCH))
+            .expect("read research fixture")
+            .replacen(requirement, "historical requirement omitted", 1)
+            .replace(
+                "## Next",
+                &format!("### Historical receipt requirement\n\n{requirement}\n\n## Next"),
+            );
+        temp.write(RESEARCH, &research);
+        let error = check(&temp.path)
+            .expect_err("nested historical research requirement must not satisfy its owner");
+        assert!(error.contains(requirement), "{error}");
+
+        let temp = fixture();
+        let field = CURRENT_DOCUMENTATION_RECEIPT_FIELDS[2];
+        let coordination = fs::read_to_string(temp.path.join(COORDINATION))
+            .expect("read coordination fixture")
+            .replacen(field, "historical field omitted", 1)
+            .replace(
+                "## Standing autonomous merge delegation",
+                &format!(
+                    "### Historical receipt requirement\n\n{field}\n\n## Standing autonomous merge delegation"
+                ),
+            );
+        temp.write(COORDINATION, &coordination);
+        let error = check(&temp.path)
+            .expect_err("nested historical coordination field must not satisfy its owner");
         assert!(error.contains(field), "{error}");
     }
 

--- a/tools/atomic_protocol.rs
+++ b/tools/atomic_protocol.rs
@@ -14,6 +14,7 @@ use markdown_contract::{fence_marker, without_inline_code, without_struck_text};
 
 const ROOT: &str = "AGENTS.md";
 const WORKFLOW: &str = "docs/agents/workflow.md";
+const RESEARCH: &str = ".agents/research.md";
 const TESTING: &str = ".agents/testing.md";
 const COORDINATION: &str = ".agents/coordination.md";
 const REVIEW: &str = ".agents/review.md";
@@ -46,6 +47,9 @@ const CONFIG_CONTRIBUTING_LINE: &str =
     "    url: https://github.com/gyldlab/keld/blob/main/CONTRIBUTING.md";
 const CONFIG_CONTRIBUTING_BLOCK: &str = "contact_links:\n  - name: Contributing to Keld\n    url: https://github.com/gyldlab/keld/blob/main/CONTRIBUTING.md\n    about: Read the public scope, build, test, and pull-request process.";
 const INDEX_HEADING: &str = "## Task routing";
+const CURRENT_DOCUMENTATION_HEADING: &str = "## Current-documentation receipt";
+const CURRENT_DOCUMENTATION_ROUTE: &str =
+    "Material decision depends on current external OS/platform command, SDK/API, runtime, or external-tool semantics";
 const DEVELOPMENT_GUIDE_CI_ROW: &str = "| `just ci` | Full local gate; the `justfile` `ci` recipe is the sole source of its inventory and order. |";
 const ENFORCEMENT_LINE_PREFIX: &str =
     "Enforcement: `just atomic-protocol` validates the canonical stages";
@@ -109,6 +113,38 @@ const TESTING_REQUIREMENTS: &[&str] = &[
 const INDEX_REQUIREMENTS: &[&str] = &[
     "Any non-trivial design, diagnosis, review, or implementation",
     "Root `AGENTS.md` § Atomic problem-solving protocol",
+];
+
+const CURRENT_DOCUMENTATION_RESEARCH_REQUIREMENTS: &[&str] = &[
+    "Before deciding a material claim that depends on current external OS/platform-command, SDK/API, runtime, or external-tool semantics",
+    "It does not apply to a pure local refactor whose decision does not rely on external semantics.",
+    "When Context7 is available, resolve the relevant library and make a narrow query before deciding.",
+    "Context7 is discovery, never the authority.",
+    "Confirm every material claim with a current official primary source:",
+    "If Context7 is unavailable or its query fails, record the exact failure",
+    "If no relevant Context7 library applies, record that reason as not-applicable; primary confirmation is still required.",
+    "leave the claim unknown or block the decision;",
+    "Do not place private source text or sensitive queries there.",
+];
+
+const CURRENT_DOCUMENTATION_COORDINATION_REQUIREMENTS: &[&str] = &[
+    "For each material external semantic selected by",
+    "record these exact fields under the required receipt heading in the relevant Linear decision, OS handoff, or branch handoff.",
+    "A pure local refactor does not need one.",
+];
+
+const CURRENT_DOCUMENTATION_RECEIPT_FIELDS: &[&str] = &[
+    "- Applicability: applied:<external semantic> | not-applicable:<pure-local reason>",
+    "- Context7: used:<library ID; query; retrieval date> | not-applicable:<reason> | unavailable:<exact tool failure>",
+    "- Official primary: <URL or immutable source; applicable version/tag; retrieval date>",
+    "- Supported claim: <exact decision-bearing claim>",
+    "- Fallback/blocker: none | <unknown or blocked decision and next action>",
+];
+
+const CURRENT_DOCUMENTATION_WORKFLOW_REQUIREMENTS: &[&str] = &[
+    "When a material decision depends on current external OS/platform-command, SDK/API, runtime, or external-tool semantics, create the receipt owned by",
+    "Pure local refactors do not need the receipt.",
+    "status, handoff, and current-documentation receipt rules owned by `.agents/coordination.md`",
 ];
 
 const MERGE_OWNER_REQUIREMENTS: &[&str] = &[
@@ -596,6 +632,84 @@ fn check_references(root: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn check_current_documentation_receipts(root: &Path) -> Result<(), String> {
+    let research = read(root, RESEARCH)?;
+    let research_visible = binding_prose(&research);
+    let receipt = section(
+        &research_visible,
+        CURRENT_DOCUMENTATION_HEADING,
+        RESEARCH,
+    )?;
+    for requirement in CURRENT_DOCUMENTATION_RESEARCH_REQUIREMENTS {
+        require_normalized(receipt, requirement, RESEARCH)?;
+        require_unique_normalized(&research_visible, requirement, RESEARCH)?;
+    }
+
+    let coordination = read(root, COORDINATION)?;
+    let coordination_visible = visible_markdown(&coordination);
+    let receipt = section(
+        &coordination_visible,
+        CURRENT_DOCUMENTATION_HEADING,
+        COORDINATION,
+    )?;
+    for requirement in CURRENT_DOCUMENTATION_COORDINATION_REQUIREMENTS {
+        require_normalized(receipt, requirement, COORDINATION)?;
+        require_unique_normalized(&coordination_visible, requirement, COORDINATION)?;
+    }
+    for field in CURRENT_DOCUMENTATION_RECEIPT_FIELDS {
+        if !normalize(receipt).contains(&normalize(field)) {
+            return Err(format!(
+                "ATOMIC-PROTOCOL: coordination must retain receipt field {field} in its canonical section."
+            ));
+        }
+        if normalized_occurrences(&coordination, field) != 1 {
+            return Err(format!(
+                "ATOMIC-PROTOCOL: coordination must retain receipt field {field} exactly once."
+            ));
+        }
+    }
+
+    let index = read(root, INDEX)?;
+    let index_visible = visible_markdown(&index);
+    let routing = section(&index_visible, INDEX_HEADING, INDEX)?;
+    let route_is_in_table = routing.lines().any(|line| {
+        line.trim().starts_with('|')
+            && line.contains(CURRENT_DOCUMENTATION_ROUTE)
+            && line.contains("research.md")
+            && line.contains("Current-documentation receipt")
+            && line.contains("testing.md")
+    });
+    if !route_is_in_table || normalized_occurrences(&index_visible, CURRENT_DOCUMENTATION_ROUTE) != 1 {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: index must route {CURRENT_DOCUMENTATION_ROUTE} to the research receipt and testing inside its canonical table."
+        ));
+    }
+
+    let workflow = read(root, WORKFLOW)?;
+    let workflow_visible = binding_prose(&workflow);
+    let workflow_loop = section(&workflow_visible, WORKFLOW_HEADING, WORKFLOW)?;
+    let pickup = line_block(
+        workflow_loop,
+        "1. **Pick up and refresh.**",
+        Some("2. **Spec gate.**"),
+        WORKFLOW,
+    )?;
+    for requirement in &CURRENT_DOCUMENTATION_WORKFLOW_REQUIREMENTS[..2] {
+        require_normalized(pickup, requirement, WORKFLOW)?;
+        require_unique_normalized(&workflow_visible, requirement, WORKFLOW)?;
+    }
+    let implementation = line_block(
+        workflow_loop,
+        "4. **Implement and coordinate.**",
+        Some("5. **Verify**"),
+        WORKFLOW,
+    )?;
+    let requirement = CURRENT_DOCUMENTATION_WORKFLOW_REQUIREMENTS[2];
+    require_normalized(implementation, requirement, WORKFLOW)?;
+    require_unique_normalized(&workflow_visible, requirement, WORKFLOW)?;
+    Ok(())
+}
+
 fn check_autonomous_merge(root: &Path) -> Result<(), String> {
     let root_text = read(root, ROOT)?;
     let root_visible = binding_prose(&root_text);
@@ -845,6 +959,7 @@ fn check(root: &Path) -> Result<(), String> {
     let root_text = read(root, ROOT)?;
     check_root(&root_text)?;
     check_references(root)?;
+    check_current_documentation_receipts(root)?;
     check_autonomous_merge(root)?;
     check_public_intake(root)?;
     check_justfile_and_development_guide(root)
@@ -922,10 +1037,26 @@ mod tests {
         + "\n"
     }
 
+    fn fixture_research() -> String {
+        format!(
+            "# Research\n\n{CURRENT_DOCUMENTATION_HEADING}\n\n{}\n\n## Next\n",
+            CURRENT_DOCUMENTATION_RESEARCH_REQUIREMENTS.join("\n")
+        )
+    }
+
+    fn fixture_current_documentation_receipt() -> String {
+        format!(
+            "{CURRENT_DOCUMENTATION_HEADING}\n\n{}\n\n{}\n",
+            CURRENT_DOCUMENTATION_COORDINATION_REQUIREMENTS.join("\n"),
+            CURRENT_DOCUMENTATION_RECEIPT_FIELDS.join("\n"),
+        )
+    }
+
     fn fixture_coordination() -> String {
         format!(
-            "# Coordination\n\n{PROMPT_TRACKER_HANDOFF_REQUIREMENT}\n\n{}\n\n## Next\n",
-            canonical_merge_owner()
+            "# Coordination\n\n{PROMPT_TRACKER_HANDOFF_REQUIREMENT}\n\n{}\n{}\n\n## Next\n",
+            fixture_current_documentation_receipt(),
+            canonical_merge_owner(),
         )
     }
 
@@ -936,7 +1067,28 @@ mod tests {
             WORKFLOW,
             &format!("# Workflow\n\n{PUBLIC_INTAKE_HEADING}\n\n{}\n\n## The loop (one issue, one agent, one concern)\n\n1. **Pick up and refresh.** Fetch the Linear issue (team KELD, current milestone first),\nroot `AGENTS.md` § Atomic problem-solving protocol. The same first comment MUST record the decision-bearing atoms: owner, boundary and inputs/outputs, failure mode, observable contract, independence from the other atoms, and first falsifier.\n2. **Spec gate.** Larger than a bug fix and no spec? Write one from\n3. **Isolate.** Work separately.\n4. **Implement and coordinate.** Tests with the change (conformance entries *first* for\nA material-decision comment MUST also record every atom changed or added by the decision, its independence edges and first falsifier.\n5. **Verify** (the gate from root `AGENTS.md`): fmt + clippy `-D warnings` + full test\n7. **PR and handoff.** {} {}\n\n## Next\n", WORKFLOW_PUBLIC_INTAKE_REQUIREMENTS.join("\n"), WORKFLOW_MERGE_REQUIREMENTS[0], WORKFLOW_MERGE_REQUIREMENTS[1]),
         );
+        let workflow = fs::read_to_string(temp.path.join(WORKFLOW)).expect("read workflow fixture");
+        let workflow = workflow
+            .replacen(
+                "and first falsifier.\n2. **Spec gate.**",
+                &format!(
+                    "and first falsifier.\n{}\n{}\n2. **Spec gate.**",
+                    CURRENT_DOCUMENTATION_WORKFLOW_REQUIREMENTS[0],
+                    CURRENT_DOCUMENTATION_WORKFLOW_REQUIREMENTS[1],
+                ),
+                1,
+            )
+            .replacen(
+                "and first falsifier.\n5. **Verify**",
+                &format!(
+                    "and first falsifier.\n{}\n5. **Verify**",
+                    CURRENT_DOCUMENTATION_WORKFLOW_REQUIREMENTS[2],
+                ),
+                1,
+            );
+        temp.write(WORKFLOW, &workflow);
         temp.write(COORDINATION, &fixture_coordination());
+        temp.write(RESEARCH, &fixture_research());
         temp.write(
             CONTRIBUTING,
             &format!(
@@ -972,6 +1124,15 @@ mod tests {
         temp.write(
             INDEX,
             "# Index\n\n## Task routing\n\n| Task or path | Read |\n|---|---|\n| Any non-trivial design, diagnosis, review, or implementation | Root `AGENTS.md` § Atomic problem-solving protocol. |\n\n## Next\n",
+        );
+        temp.write(
+            INDEX,
+            &format!(
+                "# Index\n\n## Task routing\n\n| Task or path | Read |\n|---|---|\n| {} | {} |\n| {} | research.md Current-documentation receipt; testing.md when behavior is exercised |\n\n## Next\n",
+                INDEX_REQUIREMENTS[0],
+                INDEX_REQUIREMENTS[1],
+                CURRENT_DOCUMENTATION_ROUTE,
+            ),
         );
         temp.write(
             JUSTFILE,
@@ -1294,6 +1455,43 @@ mod tests {
                 assert!(error.contains(requirement), "{error}");
             }
         }
+    }
+
+    #[test]
+    fn current_documentation_receipt_bindings_fail_when_removed() {
+        for (path, requirements) in [
+            (RESEARCH, CURRENT_DOCUMENTATION_RESEARCH_REQUIREMENTS),
+            (COORDINATION, CURRENT_DOCUMENTATION_COORDINATION_REQUIREMENTS),
+            (WORKFLOW, CURRENT_DOCUMENTATION_WORKFLOW_REQUIREMENTS),
+            (COORDINATION, CURRENT_DOCUMENTATION_RECEIPT_FIELDS),
+        ] {
+            for requirement in requirements {
+                let temp = fixture();
+                replace_requirement(&temp, path, requirement);
+                let error = check(&temp.path).expect_err("removed receipt binding must fail");
+                assert!(error.contains(requirement), "{error}");
+            }
+        }
+
+        let temp = fixture();
+        replace_requirement(&temp, INDEX, CURRENT_DOCUMENTATION_ROUTE);
+        let error = check(&temp.path).expect_err("removed current-documentation route must fail");
+        assert!(error.contains("index"), "{error}");
+    }
+
+    #[test]
+    fn receipt_field_moved_to_history_does_not_satisfy_the_canonical_section() {
+        let temp = fixture();
+        let field = CURRENT_DOCUMENTATION_RECEIPT_FIELDS[2];
+        let coordination = fs::read_to_string(temp.path.join(COORDINATION))
+            .expect("read coordination fixture")
+            .replacen(field, "historical field omitted", 1)
+            + "\n## Historical receipt\n\n"
+            + field
+            + "\n";
+        temp.write(COORDINATION, &coordination);
+        let error = check(&temp.path).expect_err("historical receipt field must not satisfy owner");
+        assert!(error.contains(field), "{error}");
     }
 
     #[test]

--- a/tools/atomic_protocol.rs
+++ b/tools/atomic_protocol.rs
@@ -414,17 +414,23 @@ fn section<'a>(text: &'a str, heading: &str, path: &str) -> Result<&'a str, Stri
 fn direct_section<'a>(text: &'a str, heading: &str, path: &str) -> Result<&'a str, String> {
     let canonical_section = section(text, heading, path)?;
     let mut offset = 0_usize;
+    let mut previous_line_is_nonempty = false;
     for line in canonical_section.split_inclusive('\n') {
         let trimmed = line.trim_start();
         let marker_width = trimmed.bytes().take_while(|byte| *byte == b'#').count();
-        let is_nested_heading = marker_width >= 3
+        let is_new_heading = marker_width >= 1
             && trimmed
                 .as_bytes()
                 .get(marker_width)
                 .is_some_and(u8::is_ascii_whitespace);
-        if offset != 0 && is_nested_heading {
+        let setext = line.trim();
+        let is_setext_heading = previous_line_is_nonempty
+            && !setext.is_empty()
+            && setext.bytes().all(|byte| byte == b'=' || byte == b'-');
+        if offset != 0 && (is_new_heading || is_setext_heading) {
             return Ok(&canonical_section[..offset]);
         }
+        previous_line_is_nonempty = !setext.is_empty();
         offset += line.len();
     }
     Ok(canonical_section)
@@ -1625,27 +1631,34 @@ mod tests {
     }
 
     #[test]
-    fn current_documentation_consumer_directive_cannot_move_to_a_nested_history_heading() {
-        for (path, requirement) in [
-            (
-                DEPENDENCIES,
-                CURRENT_DOCUMENTATION_DEPENDENCIES_REQUIREMENTS[0],
-            ),
-            (DOCS, CURRENT_DOCUMENTATION_DOCS_REQUIREMENTS[1]),
-            (TESTING, CURRENT_DOCUMENTATION_TESTING_REQUIREMENTS[1]),
+    fn current_documentation_consumer_directive_cannot_move_to_a_historical_heading() {
+        for historical_heading in [
+            "### Historical receipt requirement",
+            "# Historical receipt requirement",
+            "Historical receipt requirement\n---",
         ] {
-            let temp = fixture();
-            let source = fs::read_to_string(temp.path.join(path)).expect("read consumer fixture");
-            let moved = source
-                .replacen(requirement, "historical directive omitted", 1)
-                .replace(
-                    "## Next",
-                    &format!("### Historical receipt requirement\n\n{requirement}\n\n## Next"),
-                );
-            temp.write(path, &moved);
-            let error = check(&temp.path)
-                .expect_err("nested historical directive must not satisfy the consumer binding");
-            assert!(error.contains(requirement), "{error}");
+            for (path, requirement) in [
+                (
+                    DEPENDENCIES,
+                    CURRENT_DOCUMENTATION_DEPENDENCIES_REQUIREMENTS[0],
+                ),
+                (DOCS, CURRENT_DOCUMENTATION_DOCS_REQUIREMENTS[1]),
+                (TESTING, CURRENT_DOCUMENTATION_TESTING_REQUIREMENTS[1]),
+            ] {
+                let temp = fixture();
+                let source =
+                    fs::read_to_string(temp.path.join(path)).expect("read consumer fixture");
+                let moved = source
+                    .replacen(requirement, "historical directive omitted", 1)
+                    .replace(
+                        "## Next",
+                        &format!("{historical_heading}\n\n{requirement}\n\n## Next"),
+                    );
+                temp.write(path, &moved);
+                let error = check(&temp.path)
+                    .expect_err("historical directive must not satisfy the consumer binding");
+                assert!(error.contains(requirement), "{error}");
+            }
         }
     }
 

--- a/tools/atomic_protocol.rs
+++ b/tools/atomic_protocol.rs
@@ -411,6 +411,25 @@ fn section<'a>(text: &'a str, heading: &str, path: &str) -> Result<&'a str, Stri
     Ok(&text[start..end])
 }
 
+fn direct_section<'a>(text: &'a str, heading: &str, path: &str) -> Result<&'a str, String> {
+    let canonical_section = section(text, heading, path)?;
+    let mut offset = 0_usize;
+    for line in canonical_section.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        let marker_width = trimmed.bytes().take_while(|byte| *byte == b'#').count();
+        let is_nested_heading = marker_width >= 3
+            && trimmed
+                .as_bytes()
+                .get(marker_width)
+                .is_some_and(u8::is_ascii_whitespace);
+        if offset != 0 && is_nested_heading {
+            return Ok(&canonical_section[..offset]);
+        }
+        offset += line.len();
+    }
+    Ok(canonical_section)
+}
+
 fn require_normalized(haystack: &str, needle: &str, path: &str) -> Result<(), String> {
     if normalize_binding(haystack).contains(&normalize_binding(needle)) {
         return Ok(());
@@ -674,10 +693,11 @@ fn require_current_documentation_consumer(
     requirements: &[&str],
 ) -> Result<(), String> {
     let text = read(root, path)?;
+    let rendered = visible_markdown(&text);
+    let canonical_section = binding_prose(direct_section(&rendered, heading, path)?);
     let visible = binding_prose(&text);
-    let canonical_section = section(&visible, heading, path)?;
     for requirement in requirements {
-        require_normalized(canonical_section, requirement, path)?;
+        require_normalized(&canonical_section, requirement, path)?;
         require_unique_normalized(&visible, requirement, path)?;
     }
     Ok(())
@@ -1602,6 +1622,31 @@ mod tests {
         temp.write(INDEX, &moved);
         let error = check(&temp.path).expect_err("out-of-table route row must fail");
         assert!(error.contains("index must route"), "{error}");
+    }
+
+    #[test]
+    fn current_documentation_consumer_directive_cannot_move_to_a_nested_history_heading() {
+        for (path, requirement) in [
+            (
+                DEPENDENCIES,
+                CURRENT_DOCUMENTATION_DEPENDENCIES_REQUIREMENTS[0],
+            ),
+            (DOCS, CURRENT_DOCUMENTATION_DOCS_REQUIREMENTS[1]),
+            (TESTING, CURRENT_DOCUMENTATION_TESTING_REQUIREMENTS[1]),
+        ] {
+            let temp = fixture();
+            let source = fs::read_to_string(temp.path.join(path)).expect("read consumer fixture");
+            let moved = source
+                .replacen(requirement, "historical directive omitted", 1)
+                .replace(
+                    "## Next",
+                    &format!("### Historical receipt requirement\n\n{requirement}\n\n## Next"),
+                );
+            temp.write(path, &moved);
+            let error = check(&temp.path)
+                .expect_err("nested historical directive must not satisfy the consumer binding");
+            assert!(error.contains(requirement), "{error}");
+        }
     }
 
     #[test]

--- a/tools/atomic_protocol.rs
+++ b/tools/atomic_protocol.rs
@@ -17,6 +17,8 @@ const WORKFLOW: &str = "docs/agents/workflow.md";
 const RESEARCH: &str = ".agents/research.md";
 const TESTING: &str = ".agents/testing.md";
 const COORDINATION: &str = ".agents/coordination.md";
+const DEPENDENCIES: &str = ".agents/dependencies.md";
+const DOCS: &str = ".agents/docs.md";
 const REVIEW: &str = ".agents/review.md";
 const CI: &str = ".agents/ci.md";
 const INDEX: &str = ".agents/index.md";
@@ -32,11 +34,13 @@ const RETIRED_HEADING: &str = "Failure decomposition protocol (MUST)";
 const WORKFLOW_HEADING: &str = "## The loop (one issue, one agent, one concern)";
 const PUBLIC_INTAKE_HEADING: &str = "## Public contributions";
 const TESTING_HEADING: &str = "## Failure-first proof";
+const DEPENDENCIES_AUTHORITATIVE_CHECKS_HEADING: &str = "## Authoritative checks";
+const DOCS_DIAGRAM_SELECTION_HEADING: &str = "## Diagram selection and meaning";
+const TESTING_MERMAID_GATE_HEADING: &str = "## Documentation and Mermaid render gate";
 const MERGE_HEADING: &str = "## Standing autonomous merge delegation";
 const MERGE_DEFAULT_PREFIX: &str = "Default eligible merge: ";
 const PROMPT_TRACKER_HANDOFF_REQUIREMENT: &str = "Handoffs MUST follow Prompt Tracker `docs/06-graph-engineering.md` for system/client/exact-model identity.";
-const CONTRIBUTING_LINK: &str =
-    "https://github.com/gyldlab/keld/blob/main/CONTRIBUTING.md";
+const CONTRIBUTING_LINK: &str = "https://github.com/gyldlab/keld/blob/main/CONTRIBUTING.md";
 const MAINTAINER_REVIEW_START: &str = "- **Review:**";
 const MAINTAINER_REVIEW_END: &str = "- **Direction:**";
 const FORM_CONTRIBUTING_REQUIREMENT: &str = "Follow the [contribution guide](https://github.com/gyldlab/keld/blob/main/CONTRIBUTING.md) for public scope and submission.";
@@ -48,8 +52,8 @@ const CONFIG_CONTRIBUTING_LINE: &str =
 const CONFIG_CONTRIBUTING_BLOCK: &str = "contact_links:\n  - name: Contributing to Keld\n    url: https://github.com/gyldlab/keld/blob/main/CONTRIBUTING.md\n    about: Read the public scope, build, test, and pull-request process.";
 const INDEX_HEADING: &str = "## Task routing";
 const CURRENT_DOCUMENTATION_HEADING: &str = "## Current-documentation receipt";
-const CURRENT_DOCUMENTATION_ROUTE: &str =
-    "Material decision depends on current external OS/platform command, SDK/API, runtime, or external-tool semantics";
+const CURRENT_DOCUMENTATION_ROUTE: &str = "Material decision depends on current external OS/platform command, SDK/API, runtime, or external-tool semantics";
+const CURRENT_DOCUMENTATION_LINK: &str = "[`.agents/research.md` § Current-documentation receipt](research.md#current-documentation-receipt)";
 const DEVELOPMENT_GUIDE_CI_ROW: &str = "| `just ci` | Full local gate; the `justfile` `ci` recipe is the sole source of its inventory and order. |";
 const ENFORCEMENT_LINE_PREFIX: &str =
     "Enforcement: `just atomic-protocol` validates the canonical stages";
@@ -145,6 +149,24 @@ const CURRENT_DOCUMENTATION_WORKFLOW_REQUIREMENTS: &[&str] = &[
     "When a material decision depends on current external OS/platform-command, SDK/API, runtime, or external-tool semantics, create the receipt owned by",
     "Pure local refactors do not need the receipt.",
     "status, handoff, and current-documentation receipt rules owned by `.agents/coordination.md`",
+];
+
+const CURRENT_DOCUMENTATION_DEPENDENCIES_REQUIREMENTS: &[&str] = &[
+    CURRENT_DOCUMENTATION_LINK,
+    "to every current API or runtime semantic claim.",
+    "It owns Context7 discovery, official confirmation, fallback, and the reviewable receipt; the registry and upstream sources above remain required dependency evidence.",
+];
+
+const CURRENT_DOCUMENTATION_DOCS_REQUIREMENTS: &[&str] = &[
+    "For unfamiliar Mermaid syntax, apply",
+    CURRENT_DOCUMENTATION_LINK,
+    "official Mermaid docs remain the authority.",
+];
+
+const CURRENT_DOCUMENTATION_TESTING_REQUIREMENTS: &[&str] = &[
+    "Before using unfamiliar Mermaid syntax, apply",
+    CURRENT_DOCUMENTATION_LINK,
+    "The official Mermaid docs are the primary syntax authority; Context7 remains discovery.",
 ];
 
 const MERGE_OWNER_REQUIREMENTS: &[&str] = &[
@@ -541,8 +563,7 @@ fn line_block<'a>(
     Ok(&text[start..end])
 }
 
-fn require_index_route(text: &str) -> Result<(), String> {
-    let visible = visible_markdown(text);
+fn canonical_task_routing_rows<'a>(visible: &'a str) -> Result<Vec<(&'a str, &'a str)>, String> {
     let routing = section(&visible, INDEX_HEADING, INDEX)?;
     let lines = routing
         .lines()
@@ -552,25 +573,39 @@ fn require_index_route(text: &str) -> Result<(), String> {
     let header = lines
         .iter()
         .position(|line| line.trim() == "| Task or path | Read |");
-    let route_is_in_table = header.is_some_and(|header| {
-        lines
-            .get(header + 1)
-            .is_some_and(|line| line.trim() == "|---|---|")
-            && lines[header + 2..]
-                .iter()
-                .take_while(|line| line.trim().starts_with('|'))
-                .any(|line| {
-                    line.trim()
-                        .strip_prefix('|')
-                        .and_then(|line| line.strip_suffix('|'))
-                        .map(|line| line.split('|').map(str::trim).collect::<Vec<_>>())
-                        .is_some_and(|cells| {
-                            cells.len() == 2
-                                && cells[0] == INDEX_REQUIREMENTS[0]
-                                && cells[1].contains(INDEX_REQUIREMENTS[1])
-                        })
-                })
-    });
+    let Some(header) = header else {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{INDEX}` must contain the canonical task-routing header in `{INDEX_HEADING}`."
+        ));
+    };
+    if !lines
+        .get(header + 1)
+        .is_some_and(|line| line.trim() == "|---|---|")
+    {
+        return Err(format!(
+            "ATOMIC-PROTOCOL: `{INDEX}` must contain the canonical two-cell task-routing separator in `{INDEX_HEADING}`."
+        ));
+    }
+
+    Ok(lines[header + 2..]
+        .iter()
+        .take_while(|line| line.trim().starts_with('|'))
+        .filter_map(|line| {
+            let row = line.trim().strip_prefix('|')?.strip_suffix('|')?;
+            let mut cells = row.split('|').map(str::trim);
+            let (Some(task), Some(read), None) = (cells.next(), cells.next(), cells.next()) else {
+                return None;
+            };
+            Some((task, read))
+        })
+        .collect())
+}
+
+fn require_index_route(text: &str) -> Result<(), String> {
+    let visible = visible_markdown(text);
+    let route_is_in_table = canonical_task_routing_rows(&visible)?
+        .iter()
+        .any(|(task, read)| *task == INDEX_REQUIREMENTS[0] && read.contains(INDEX_REQUIREMENTS[1]));
     if route_is_in_table && normalized_occurrences(&visible, INDEX_REQUIREMENTS[0]) == 1 {
         return Ok(());
     }
@@ -632,14 +667,26 @@ fn check_references(root: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn require_current_documentation_consumer(
+    root: &Path,
+    path: &str,
+    heading: &str,
+    requirements: &[&str],
+) -> Result<(), String> {
+    let text = read(root, path)?;
+    let visible = binding_prose(&text);
+    let canonical_section = section(&visible, heading, path)?;
+    for requirement in requirements {
+        require_normalized(canonical_section, requirement, path)?;
+        require_unique_normalized(&visible, requirement, path)?;
+    }
+    Ok(())
+}
+
 fn check_current_documentation_receipts(root: &Path) -> Result<(), String> {
     let research = read(root, RESEARCH)?;
     let research_visible = binding_prose(&research);
-    let receipt = section(
-        &research_visible,
-        CURRENT_DOCUMENTATION_HEADING,
-        RESEARCH,
-    )?;
+    let receipt = section(&research_visible, CURRENT_DOCUMENTATION_HEADING, RESEARCH)?;
     for requirement in CURRENT_DOCUMENTATION_RESEARCH_REQUIREMENTS {
         require_normalized(receipt, requirement, RESEARCH)?;
         require_unique_normalized(&research_visible, requirement, RESEARCH)?;
@@ -669,17 +716,40 @@ fn check_current_documentation_receipts(root: &Path) -> Result<(), String> {
         }
     }
 
+    for (path, heading, requirements) in [
+        (
+            DEPENDENCIES,
+            DEPENDENCIES_AUTHORITATIVE_CHECKS_HEADING,
+            CURRENT_DOCUMENTATION_DEPENDENCIES_REQUIREMENTS,
+        ),
+        (
+            DOCS,
+            DOCS_DIAGRAM_SELECTION_HEADING,
+            CURRENT_DOCUMENTATION_DOCS_REQUIREMENTS,
+        ),
+        (
+            TESTING,
+            TESTING_MERMAID_GATE_HEADING,
+            CURRENT_DOCUMENTATION_TESTING_REQUIREMENTS,
+        ),
+    ] {
+        require_current_documentation_consumer(root, path, heading, requirements)?;
+    }
+
     let index = read(root, INDEX)?;
     let index_visible = visible_markdown(&index);
-    let routing = section(&index_visible, INDEX_HEADING, INDEX)?;
-    let route_is_in_table = routing.lines().any(|line| {
-        line.trim().starts_with('|')
-            && line.contains(CURRENT_DOCUMENTATION_ROUTE)
-            && line.contains("research.md")
-            && line.contains("Current-documentation receipt")
-            && line.contains("testing.md")
-    });
-    if !route_is_in_table || normalized_occurrences(&index_visible, CURRENT_DOCUMENTATION_ROUTE) != 1 {
+    let route_is_in_table =
+        canonical_task_routing_rows(&index_visible)?
+            .iter()
+            .any(|(task, read)| {
+                *task == CURRENT_DOCUMENTATION_ROUTE
+                    && read.contains("research.md")
+                    && read.contains("Current-documentation receipt")
+                    && read.contains("testing.md")
+            });
+    if !route_is_in_table
+        || normalized_occurrences(&index_visible, CURRENT_DOCUMENTATION_ROUTE) != 1
+    {
         return Err(format!(
             "ATOMIC-PROTOCOL: index must route {CURRENT_DOCUMENTATION_ROUTE} to the research receipt and testing inside its canonical table."
         ));
@@ -870,10 +940,10 @@ fn check_public_intake(root: &Path) -> Result<(), String> {
             .then(|| yaml_top_level_value(&text, "body:"))
             .flatten()
             .ok_or_else(|| {
-            format!(
-                "ATOMIC-PROTOCOL: `{consumer}` must contain one top-level `body:` sequence."
-            )
-        })?;
+                format!(
+                    "ATOMIC-PROTOCOL: `{consumer}` must contain one top-level `body:` sequence."
+                )
+            })?;
         let visible = yaml_markdown_scalars(&body)
             .into_iter()
             .map(|scalar| visible_markdown(&scalar))
@@ -1032,9 +1102,8 @@ mod tests {
         format!(
             "# Rules\n\n{ROOT_HEADING}\n\nBefore selecting a design, answer or fix.\n\n{} Split the problem into decision-bearing atoms.\n{} Each atom MUST name its owner, boundary and inputs/outputs, failure mode, and observable contract.\n{} Changing or falsifying one atom MUST NOT silently alter another. Hidden coupling MUST be promoted into its own atom or an explicit edge between atoms.\n{} Each atom MUST have direct evidence or a falsifiable test or negative control. Prose, comments, mocks, or another atom's pass are not proof of that atom.\n{} Do not synthesize until every decision-bearing atom is passed, explicitly unknown, or named as a blocker. If the synthesis contradicts a passed atom, agents MUST stop and correct the model.\n\nPerformance decompositions MUST separate census, work, queue/copy, clock, statistic and artifact. Security decompositions MUST separate identity, authentication, authorization, OS containment, lifecycle/revocation and evidence provenance.\n\nEnforcement: `just atomic-protocol` validates the canonical stages.\n\n## Next\n",
             STAGES[0], STAGES[1], STAGES[2], STAGES[3], STAGES[4]
-        )
-        + ROOT_MERGE_REQUIREMENT
-        + "\n"
+        ) + ROOT_MERGE_REQUIREMENT
+            + "\n"
     }
 
     fn fixture_research() -> String {
@@ -1057,6 +1126,28 @@ mod tests {
             "# Coordination\n\n{PROMPT_TRACKER_HANDOFF_REQUIREMENT}\n\n{}\n{}\n\n## Next\n",
             fixture_current_documentation_receipt(),
             canonical_merge_owner(),
+        )
+    }
+
+    fn fixture_dependencies() -> String {
+        format!(
+            "# Dependencies\n\n{DEPENDENCIES_AUTHORITATIVE_CHECKS_HEADING}\n\n{}\n\n## Next\n",
+            CURRENT_DOCUMENTATION_DEPENDENCIES_REQUIREMENTS.join("\n"),
+        )
+    }
+
+    fn fixture_docs() -> String {
+        format!(
+            "# Docs\n\n{DOCS_DIAGRAM_SELECTION_HEADING}\n\n{}\n\n## Next\n",
+            CURRENT_DOCUMENTATION_DOCS_REQUIREMENTS.join("\n"),
+        )
+    }
+
+    fn fixture_testing() -> String {
+        format!(
+            "# Testing\n\n{TESTING_HEADING}\n\n{}\n\n{TESTING_MERMAID_GATE_HEADING}\n\n{}\n\n## Next\n",
+            TESTING_REQUIREMENTS.join("\n"),
+            CURRENT_DOCUMENTATION_TESTING_REQUIREMENTS.join("\n"),
         )
     }
 
@@ -1089,6 +1180,8 @@ mod tests {
         temp.write(WORKFLOW, &workflow);
         temp.write(COORDINATION, &fixture_coordination());
         temp.write(RESEARCH, &fixture_research());
+        temp.write(DEPENDENCIES, &fixture_dependencies());
+        temp.write(DOCS, &fixture_docs());
         temp.write(
             CONTRIBUTING,
             &format!(
@@ -1101,10 +1194,7 @@ mod tests {
         );
         temp.write(BUG_TEMPLATE, &form);
         temp.write(FEATURE_TEMPLATE, &form);
-        temp.write(
-            TEMPLATE_CONFIG,
-            &format!("{CONFIG_CONTRIBUTING_BLOCK}\n"),
-        );
+        temp.write(TEMPLATE_CONFIG, &format!("{CONFIG_CONTRIBUTING_BLOCK}\n"));
         temp.write(
             MAINTAINERS,
             &format!(
@@ -1112,15 +1202,9 @@ mod tests {
                 MAINTAINER_REVIEW_REQUIREMENTS.join(" ")
             ),
         );
-        temp.write(
-            REVIEW,
-            &format!("# Review\n\n{REVIEW_MERGE_REQUIREMENT}\n"),
-        );
+        temp.write(REVIEW, &format!("# Review\n\n{REVIEW_MERGE_REQUIREMENT}\n"));
         temp.write(CI, &format!("# CI\n\n{CI_MERGE_REQUIREMENT}.\n"));
-        temp.write(
-            TESTING,
-            "# Testing\n\n## Failure-first proof\n\nRoot `AGENTS.md` § Atomic problem-solving protocol owns the decomposition. The author MUST bind it to one named atom's observable contract and state why its oracle is independent of the implementation and the other atoms. Every negative control MUST name the one fault or mutation that falsifies that atom.\n\n## Next\n",
-        );
+        temp.write(TESTING, &fixture_testing());
         temp.write(
             INDEX,
             "# Index\n\n## Task routing\n\n| Task or path | Read |\n|---|---|\n| Any non-trivial design, diagnosis, review, or implementation | Root `AGENTS.md` § Atomic problem-solving protocol. |\n\n## Next\n",
@@ -1461,9 +1545,18 @@ mod tests {
     fn current_documentation_receipt_bindings_fail_when_removed() {
         for (path, requirements) in [
             (RESEARCH, CURRENT_DOCUMENTATION_RESEARCH_REQUIREMENTS),
-            (COORDINATION, CURRENT_DOCUMENTATION_COORDINATION_REQUIREMENTS),
+            (
+                COORDINATION,
+                CURRENT_DOCUMENTATION_COORDINATION_REQUIREMENTS,
+            ),
             (WORKFLOW, CURRENT_DOCUMENTATION_WORKFLOW_REQUIREMENTS),
             (COORDINATION, CURRENT_DOCUMENTATION_RECEIPT_FIELDS),
+            (
+                DEPENDENCIES,
+                CURRENT_DOCUMENTATION_DEPENDENCIES_REQUIREMENTS,
+            ),
+            (DOCS, CURRENT_DOCUMENTATION_DOCS_REQUIREMENTS),
+            (TESTING, CURRENT_DOCUMENTATION_TESTING_REQUIREMENTS),
         ] {
             for requirement in requirements {
                 let temp = fixture();
@@ -1477,6 +1570,38 @@ mod tests {
         replace_requirement(&temp, INDEX, CURRENT_DOCUMENTATION_ROUTE);
         let error = check(&temp.path).expect_err("removed current-documentation route must fail");
         assert!(error.contains("index"), "{error}");
+    }
+
+    #[test]
+    fn current_documentation_route_requires_a_canonical_two_cell_task_routing_row() {
+        let route_row = format!(
+            "| {CURRENT_DOCUMENTATION_ROUTE} | research.md Current-documentation receipt; testing.md when behavior is exercised |"
+        );
+
+        let temp = fixture();
+        let index = fs::read_to_string(temp.path.join(INDEX)).expect("read index fixture");
+        let malformed = index.replacen(
+            &route_row,
+            &format!(
+                "| {CURRENT_DOCUMENTATION_ROUTE} | research.md Current-documentation receipt; testing.md when behavior is exercised | decoy |"
+            ),
+            1,
+        );
+        temp.write(INDEX, &malformed);
+        let error = check(&temp.path).expect_err("three-cell route row must fail");
+        assert!(error.contains("index must route"), "{error}");
+
+        let temp = fixture();
+        let index = fs::read_to_string(temp.path.join(INDEX)).expect("read index fixture");
+        let moved = index
+            .replacen(&route_row, "| Other route | other.md |", 1)
+            .replace(
+                "## Next",
+                &format!("## Historical routing\n\n{route_row}\n\n## Next"),
+            );
+        temp.write(INDEX, &moved);
+        let error = check(&temp.path).expect_err("out-of-table route row must fail");
+        assert!(error.contains("index must route"), "{error}");
     }
 
     #[test]
@@ -1580,7 +1705,10 @@ mod tests {
             let temp = fixture();
             let maintainers = fs::read_to_string(temp.path.join(MAINTAINERS))
                 .expect("read maintainer fixture")
-                .replace(MAINTAINER_REVIEW_END, &format!("{insertion}\n{MAINTAINER_REVIEW_END}"));
+                .replace(
+                    MAINTAINER_REVIEW_END,
+                    &format!("{insertion}\n{MAINTAINER_REVIEW_END}"),
+                );
             temp.write(MAINTAINERS, &maintainers);
             let error = check(&temp.path).expect_err("duplicated merge policy must fail");
             assert!(error.contains(MAINTAINERS), "{error}");


### PR DESCRIPTION
## Summary
Routes material external semantics through an auditable Context7-discovery and official-primary receipt.

## Spec refs
KEL-200

## Review gates
none

## Tests
just ci (636 passed; 2 skipped)

## Platforms
CI-only

## Perf impact
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for verifying current external platform, API, runtime, and tool semantics.
  * Added a standardized documentation receipt covering source discovery, official confirmation, fallback handling, and recorded decisions.
  * Aligned Mermaid syntax research guidance with the new verification process.

* **Workflow**
  * Expanded task-routing and coordination requirements for decisions involving external behavior.

* **Quality**
  * Added automated checks to ensure required documentation receipts and workflow guidance remain present and correctly structured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->