### PR TITLE
ci(docs): reject unsubstituted placeholders and inert fixture rows

### DIFF
--- a/crates/keld-guard/src/lib.rs
+++ b/crates/keld-guard/src/lib.rs
@@ -1190,6 +1190,54 @@ mod tests {
         );
     }
 
+    /// The conformance fixture's escape-sensitive scopes must decode to the bytes their
+    /// comments claim.
+    ///
+    /// KEL-208 shipped `"https:\\\\t//**"`, which JSONC decodes to a backslash and the
+    /// letter `t` rather than a tab. The row still denied — against a tab-bearing resource
+    /// it simply failed to match — so neither the decision matrix nor the load-bearing
+    /// check could see it. Only the decoded bytes can, which is why they are asserted here
+    /// rather than inferred from an outcome.
+    #[test]
+    fn fixture_scopes_decode_to_their_intended_bytes() {
+        let manifest = parse_manifest(include_str!("../tests/fixtures/scopes.jsonc"))
+            .expect("the checked fixture must parse");
+        let expected: &[(&str, &[&str])] = &[
+            ("net_tab.connect", &["https:\t//**"]),
+            ("net_backslash.connect", &["https:\\/**"]),
+            ("net_single_slash.connect", &["https:/**"]),
+            ("net_triple_slash.connect", &["https:///**"]),
+            ("net.connect", &["https://**"]),
+            ("fs2.read", &["/srv/backup:/**", "\\\\?\\C:/**"]),
+        ];
+        for (capability, want) in expected {
+            let node = grant_node(&manifest, capability)
+                .unwrap_or_else(|| panic!("fixture is missing `{capability}`"));
+            let got: Vec<&str> = node
+                .as_array()
+                .unwrap_or_else(|| panic!("`{capability}` must be an array"))
+                .iter()
+                .filter_map(Value::as_str)
+                .collect();
+            assert_eq!(
+                got.len(),
+                want.len(),
+                "`{capability}` scope count changed: {got:?}"
+            );
+            for (got_scope, want_scope) in got.iter().zip(want.iter()) {
+                assert_eq!(
+                    got_scope.as_bytes(),
+                    want_scope.as_bytes(),
+                    "`{capability}` decoded to {:?} ({:02x?}), expected {:?} ({:02x?}). A JSONC string is escaped once; doubling a backslash changes the grant.",
+                    got_scope,
+                    got_scope.as_bytes(),
+                    want_scope,
+                    want_scope.as_bytes()
+                );
+            }
+        }
+    }
+
     #[test]
     fn json_pointer_for_dotted_capability() {
         assert_eq!(json_pointer_for("fs.read"), "/app/fs/read");

--- a/crates/keld-guard/tests/acl.rs
+++ b/crates/keld-guard/tests/acl.rs
@@ -369,43 +369,84 @@ fn decision_snapshot(manifest: &PermissionsManifest) -> Vec<String> {
 ///
 /// Rows are dropped by line, so this test needs no knowledge of how a scope is escaped;
 /// that is exactly the knowledge the original defect got wrong.
+/// Whether a fixture line is a bare string element of a scope array.
+fn is_grant_row(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('"') && (trimmed.ends_with('"') || trimmed.ends_with("\","))
+}
+
+/// The fixture text without `index`, kept parseable.
+///
+/// Dropping the last element of an array strands the previous element's comma before
+/// the `]`. Repairing it matters: skipping those rows instead would leave the last
+/// entry of every array unchecked, which is the silent-coverage failure this contract
+/// exists to catch.
+fn without_row(lines: &[&str], index: usize) -> String {
+    let mut kept: Vec<String> = lines
+        .iter()
+        .enumerate()
+        .filter(|(other, _)| *other != index)
+        .map(|(_, line)| (*line).to_owned())
+        .collect();
+    let closes_array = kept
+        .get(index)
+        .is_some_and(|line| line.trim_start().starts_with(']'));
+    if closes_array && index > 0 {
+        for previous in (0..index).rev() {
+            let visible = kept[previous].trim_end().len();
+            if kept[previous][..visible].ends_with(',') {
+                // `,` is ASCII, so `visible - 1` is a char boundary.
+                kept[previous].truncate(visible - 1);
+                break;
+            }
+            if visible != 0 {
+                break;
+            }
+        }
+    }
+    kept.join("\n")
+}
+
 #[test]
 fn every_fixture_grant_row_is_load_bearing() {
     let text = include_str!("fixtures/scopes.jsonc");
     let baseline = decision_snapshot(&load_fixture("scopes.jsonc"));
 
     let lines: Vec<&str> = text.split('\n').collect();
+    let rows: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| is_grant_row(line))
+        .map(|(index, _)| index)
+        .collect();
+
     let mut checked = 0usize;
-    for (index, line) in lines.iter().enumerate() {
-        let trimmed = line.trim();
-        // A grant row is a bare string element of a scope array.
-        if !trimmed.starts_with('"') || !(trimmed.ends_with('"') || trimmed.ends_with("\",")) {
-            continue;
-        }
-        let reduced_text = lines
-            .iter()
-            .enumerate()
-            .filter(|(other, _)| *other != index)
-            .map(|(_, value)| *value)
-            .collect::<Vec<&str>>()
-            .join("\n");
-        // Dropping the last element of an array leaves a trailing comma; skip a row whose
-        // removal cannot produce valid JSONC rather than pretending it was checked.
-        let Ok(reduced) = parse_manifest(&reduced_text) else {
-            continue;
-        };
+    for &index in &rows {
+        let reduced = parse_manifest(&without_row(&lines, index)).unwrap_or_else(|error| {
+            panic!(
+                "dropping line {} must still yield valid JSONC: {error}",
+                index + 1
+            )
+        });
         checked += 1;
         assert_ne!(
             decision_snapshot(&reduced),
             baseline,
-            "removing line {} of scopes.jsonc ({}) changes no decision, so the row pins              nothing. Give it its own capability, or delete it.",
+            "removing line {} of scopes.jsonc ({}) changes no decision, so the row pins nothing. Give it its own capability, or delete it.",
             index + 1,
-            trimmed
+            lines[index].trim()
         );
     }
+    // A row skipped for any reason is a row this contract did not cover.
+    assert_eq!(
+        checked,
+        rows.len(),
+        "every detected grant row must be checked, not skipped"
+    );
     assert!(
-        checked >= 10,
-        "expected the fixture to contribute many droppable rows, checked only {checked}"
+        rows.len() >= 10,
+        "expected the fixture to contribute many grant rows, found {}",
+        rows.len()
     );
 }
 

--- a/crates/keld-guard/tests/acl.rs
+++ b/crates/keld-guard/tests/acl.rs
@@ -267,6 +267,17 @@ fn load_fixture(name: &str) -> PermissionsManifest {
     load_manifest(&path).expect("checked ACL fixture must load")
 }
 
+/// The one rendering of a decision as snapshot text.
+///
+/// `assert_case` and `decision_snapshot` both emit it — the asserting path for the
+/// checked-in matrix, the comparing path for a reduced fixture — so it has one owner.
+fn decision_text(decision: &Decision) -> String {
+    match decision {
+        Decision::Allow => "allow".to_owned(),
+        Decision::Deny(reason) => format!("deny {} {}", reason.code(), reason.kind()),
+    }
+}
+
 fn assert_case(manifest: &PermissionsManifest, case: Case) -> String {
     let actual = evaluate(manifest, Principal::AppProcess, case.operation, case.path);
     match (case.expected, actual) {
@@ -291,7 +302,7 @@ fn assert_case(manifest: &PermissionsManifest, case: Case) -> String {
                 "{} returned the wrong denial variant: {reason:?}",
                 case.name
             );
-            format!("deny {} {}", reason.code(), reason.kind())
+            decision_text(&Decision::Deny(reason))
         }
         (ExpectedDecision::Allow, actual) => {
             assert_eq!(
@@ -338,12 +349,14 @@ fn fixture_decision_matrix_matches_authority_contract() {
 fn decision_snapshot(manifest: &PermissionsManifest) -> Vec<String> {
     CASES
         .iter()
-        .map(
-            |case| match evaluate(manifest, Principal::AppProcess, case.operation, case.path) {
-                Decision::Allow => "allow".to_owned(),
-                Decision::Deny(reason) => format!("deny {} {}", reason.code(), reason.kind()),
-            },
-        )
+        .map(|case| {
+            decision_text(&evaluate(
+                manifest,
+                Principal::AppProcess,
+                case.operation,
+                case.path,
+            ))
+        })
         .collect()
 }
 

--- a/crates/keld-guard/tests/acl.rs
+++ b/crates/keld-guard/tests/acl.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 
 use keld_guard::{
     Decision, DenyReason, ManifestError, PermissionsManifest, Principal, evaluate, load_manifest,
+    parse_manifest,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -152,31 +153,31 @@ const CASES: &[Case] = &[
     },
     Case {
         name: "url authority swallowed by wss scheme glob",
-        operation: "net.connect",
+        operation: "net_wss.connect",
         path: "wss://attacker.example/ws",
         expected: OUT_OF_SCOPE,
     },
     Case {
         name: "url origin prefix grant",
-        operation: "net.connect",
+        operation: "net_origin.connect",
         path: "https://api.example.com/v1",
         expected: ALLOW,
     },
     Case {
         name: "url origin root itself",
-        operation: "net.connect",
+        operation: "net_origin.connect",
         path: "https://api.example.com",
         expected: ALLOW,
     },
     Case {
         name: "url sibling authority beyond origin prefix",
-        operation: "net.connect",
+        operation: "net_origin.connect",
         path: "https://api.example.com.evil.test/v1",
         expected: OUT_OF_SCOPE,
     },
     Case {
         name: "url authority swallowed by single-slash scheme glob",
-        operation: "net.connect",
+        operation: "net_single_slash.connect",
         path: "https:/evil.example.com",
         expected: OUT_OF_SCOPE,
     },
@@ -212,19 +213,19 @@ const CASES: &[Case] = &[
     },
     Case {
         name: "one letter scheme glob with separators",
-        operation: "net.connect",
+        operation: "net_one_letter.connect",
         path: "a://evil.example.com",
         expected: OUT_OF_SCOPE,
     },
     Case {
         name: "backslash scheme glob",
-        operation: "net.connect",
+        operation: "net_backslash.connect",
         path: "https:\\/evil.example.com",
         expected: OUT_OF_SCOPE,
     },
     Case {
         name: "tab separated scheme glob",
-        operation: "net.connect",
+        operation: "net_tab.connect",
         path: "https:\t//evil.example.com",
         expected: OUT_OF_SCOPE,
     },
@@ -327,6 +328,71 @@ fn fixture_decision_matrix_matches_authority_contract() {
         observed,
         include_str!("fixtures/scopes.expected"),
         "the checked decision snapshot must change only with an intentional authority-contract change"
+    );
+}
+
+/// Decides every case in the matrix against `manifest`, as one comparable snapshot.
+///
+/// Unlike `assert_case` this never panics: it is used to compare a reduced fixture
+/// against the real one, where decisions are *expected* to move.
+fn decision_snapshot(manifest: &PermissionsManifest) -> Vec<String> {
+    CASES
+        .iter()
+        .map(
+            |case| match evaluate(manifest, Principal::AppProcess, case.operation, case.path) {
+                Decision::Allow => "allow".to_owned(),
+                Decision::Deny(reason) => format!("deny {} {}", reason.code(), reason.kind()),
+            },
+        )
+        .collect()
+}
+
+/// Every grant row in the fixture must change at least one decision when removed.
+///
+/// KEL-208 shipped two rows that did not: one whose JSONC escaping made it a different
+/// grant than its comment claimed, and one fully shadowed by a broader entry in the same
+/// list. Both looked like coverage and pinned nothing, which is worse than no row at all
+/// — `crates/keld-guard/AGENTS.md` requires this fixture to be a permanent bypass record.
+///
+/// Rows are dropped by line, so this test needs no knowledge of how a scope is escaped;
+/// that is exactly the knowledge the original defect got wrong.
+#[test]
+fn every_fixture_grant_row_is_load_bearing() {
+    let text = include_str!("fixtures/scopes.jsonc");
+    let baseline = decision_snapshot(&load_fixture("scopes.jsonc"));
+
+    let lines: Vec<&str> = text.split('\n').collect();
+    let mut checked = 0usize;
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        // A grant row is a bare string element of a scope array.
+        if !trimmed.starts_with('"') || !(trimmed.ends_with('"') || trimmed.ends_with("\",")) {
+            continue;
+        }
+        let reduced_text = lines
+            .iter()
+            .enumerate()
+            .filter(|(other, _)| *other != index)
+            .map(|(_, value)| *value)
+            .collect::<Vec<&str>>()
+            .join("\n");
+        // Dropping the last element of an array leaves a trailing comma; skip a row whose
+        // removal cannot produce valid JSONC rather than pretending it was checked.
+        let Ok(reduced) = parse_manifest(&reduced_text) else {
+            continue;
+        };
+        checked += 1;
+        assert_ne!(
+            decision_snapshot(&reduced),
+            baseline,
+            "removing line {} of scopes.jsonc ({}) changes no decision, so the row pins              nothing. Give it its own capability, or delete it.",
+            index + 1,
+            trimmed
+        );
+    }
+    assert!(
+        checked >= 10,
+        "expected the fixture to contribute many droppable rows, checked only {checked}"
     );
 }
 

--- a/crates/keld-guard/tests/fixtures/scopes.jsonc
+++ b/crates/keld-guard/tests/fixtures/scopes.jsonc
@@ -11,30 +11,57 @@
       ],
       "write": []
     },
-    // Permanent wildcard-swallow bypass fixture (KEL-208). Every entry but the
-    // last strips to a prefix that is a scheme followed only by separators or
-    // ASCII whitespace, so it names no destination. This list is a spelling
-    // inventory: a URL parser reads one host from all of them, while an
-    // authority rule keyed on `://` sees only some. No row here is *required*
-    // for the suite to catch a regression: the
-    // `url_scope_glob_must_not_delegate_the_authority` table in lib.rs gives
-    // every spelling its own manifest. Within this list the subsumption is
-    // only partial — `https:/**` also matches the `//` spellings once the
-    // rule is off, because they share the `/` anchor byte, but not the `\\`
-    // or tab rows, whose anchor byte differs; those two are the only rows
-    // here that pin their own byte in the post-colon set. The last entry is
-    // the legitimate
-    // origin-rooted grant they must not be confused with. A URL-valued
-    // capability is not wired in v0 — `evaluate` is capability agnostic, so
-    // this pins the matcher contract the moment one is.
+    // Permanent wildcard-swallow bypass fixture (KEL-208), one hostile spelling per
+    // capability. They are deliberately not pooled into one grant list: pooled, a row
+    // records a denial a broader neighbour caused, so it looks like coverage and pins
+    // nothing. `every_fixture_grant_row_is_load_bearing` enforces that, and it caught
+    // exactly this on `"https://**"`. A URL parser reads one host from all of these
+    // spellings while an authority rule keyed on `://` sees only some, which is why the
+    // matcher refuses the grant rather than inspecting the resource. No URL-valued
+    // capability is wired in v0 — `evaluate` is capability agnostic, so this pins the
+    // contract the moment one is.
     "net": {
       "connect": [
-        "https://**",
-        "https:/**",
-        "wss://**",
-        "a://**",
-        "https:\\/**",
-        "https:\t//**",
+        "https://**"
+      ]
+    },
+    "net_single_slash": {
+      "connect": [
+        "https:/**"
+      ]
+    },
+    "net_triple_slash": {
+      "connect": [
+        "https:///**"
+      ]
+    },
+    "net_wss": {
+      "connect": [
+        "wss://**"
+      ]
+    },
+    // A one-letter scheme is indistinguishable from a Windows drive, so `a:/**` stays a
+    // path glob; `a://**` carries separators and is refused like any other scheme glob.
+    "net_one_letter": {
+      "connect": [
+        "a://**"
+      ]
+    },
+    // `\\` and tab are separators to a URL parser too: it folds `\\` for a special
+    // scheme and strips tab/LF/CR before parsing.
+    "net_backslash": {
+      "connect": [
+        "https:\\/**"
+      ]
+    },
+    "net_tab": {
+      "connect": [
+        "https:\t//**"
+      ]
+    },
+    // The legitimate origin-rooted grant the hostile spellings must not be confused with.
+    "net_origin": {
+      "connect": [
         "https://api.example.com/**"
       ]
     },
@@ -42,25 +69,25 @@
     // ordinary path grants and must keep working (RFC 3986 3.1 anchors a
     // scheme at the start of the reference).
     "fs2": {
-      "read": ["/srv/backup:/**", "\\\\?\\C:/**"]
-    },
-    // `https:///**` shares a decision with the two shorter spellings whenever
-    // they sit in one grant list, so it gets its own capability: in `net` it
-    // would record a deny it did not cause, and deleting it would change
-    // nothing. Here it is the only grant, so the row is load-bearing.
-    "net_triple_slash": {
-      "connect": ["https:///**"]
+      "read": [
+        "/srv/backup:/**",
+        "\\\\?\\C:/**"
+      ]
     },
     // `C:` is a valid RFC 3986 scheme and the usual Windows drive; a drive
     // glob must keep plain path semantics rather than acquire an authority.
     "shell": {
-      "open": ["C:/**"]
+      "open": [
+        "C:/**"
+      ]
     },
     // The anchor byte is `/` and only `/`: a backslash at the grant boundary
     // is out of scope. Nothing else pins that, and accepting `\\` there would
     // be a silent widening.
     "anchor": {
-      "read": ["/foo/bar/**"]
+      "read": [
+        "/foo/bar/**"
+      ]
     }
   }
 }

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ hello:
 
 # Run every CI gate locally (deny requires `cargo install cargo-deny --locked`).
 # gitleaks stays GitHub-only (pinned OSS CLI in .github/workflows/ci.yml).
-ci: agents-md atomic-protocol agent-context ci-router-test hooks-test mermaid-test mermaid-check mermaid-render-check product-status-test product-status-check llms-test llms-check hygiene typescript fmt-check clippy test doc deny
+ci: agents-md atomic-protocol agent-context ci-router-test hooks-test doc-placeholders-test doc-placeholders-check mermaid-test mermaid-check mermaid-render-check product-status-test product-status-check llms-test llms-check hygiene typescript fmt-check clippy test doc deny
 
 # Verify the package compiler and runtime contracts from one frozen dependency graph.
 typescript:
@@ -129,6 +129,18 @@ llms-test:
     mkdir -p target/llms-docs
     rustc --edition=2024 -D warnings --test tools/llms_docs.rs -o target/llms-docs/llms-docs-test
     target/llms-docs/llms-docs-test
+
+# CI gate: no unsubstituted template placeholder may reach checked-in prose (KEL-213).
+doc-placeholders-check:
+    mkdir -p target/doc-placeholders
+    rustc --edition=2024 -D warnings tools/doc_placeholders.rs -o target/doc-placeholders/doc-placeholders
+    target/doc-placeholders/doc-placeholders check .
+
+# Contract tests for the placeholder inventory, fences, adjacency, and stale entries.
+doc-placeholders-test:
+    mkdir -p target/doc-placeholders
+    rustc --edition=2024 -D warnings --test tools/doc_placeholders.rs -o target/doc-placeholders/doc-placeholders-test
+    target/doc-placeholders/doc-placeholders-test
 
 # Validate Mermaid fences, accessibility metadata, stable types, and semantic palette.
 mermaid-check:

--- a/tools/doc_placeholders.rs
+++ b/tools/doc_placeholders.rs
@@ -1,0 +1,358 @@
+//! Rejects unsubstituted template placeholders in checked-in prose.
+//!
+//! KEL-208 shipped a literal `{BS}{BS}?{BS}C:/**` into `docs/architecture/03-security.md`
+//! and its generated mirror: a Python plain string where the edit needed an f-string.
+//! Every existing gate passed, because each one checks *consistency* — the generated
+//! corpus faithfully reproduced a source sentence that meant nothing.
+//!
+//! Prose does contain legitimate template slots (`notes.{channel}`), so a blanket scan
+//! would be noise. This checker uses the repository's inventory idiom instead: every
+//! placeholder a document may use is listed here, and an unlisted one fails. A leaked
+//! generator variable is unlisted by construction, and adding a real template slot stays
+//! a deliberate one-line act.
+
+#[path = "markdown_contract.rs"]
+#[allow(
+    dead_code,
+    reason = "shared contract module; this checker deliberately does not strip \n              inline code, because that is where the KEL-208 placeholder shipped"
+)]
+mod markdown_contract;
+
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use markdown_contract::{fence_marker, without_struck_text};
+
+/// Directories scanned in full, recursively.
+const SCANNED_DIRS: &[&str] = &["docs", ".agents"];
+/// Individual files scanned at the repository root.
+const SCANNED_FILES: &[&str] = &["llms.txt", "llms-full.txt", "AGENTS.md", "README.md"];
+/// Skipped: a nested private checkout with its own contracts.
+const SKIPPED_PREFIX: &str = "docs/research";
+
+/// Template slots documents are allowed to write.
+///
+/// Sorted, deduplicated, and every entry must still appear somewhere in the scanned
+/// prose — a stale entry is as much a defect as an unlisted one, because it lets the
+/// next leaked variable name hide behind a name nobody uses any more.
+const KNOWN_PLACEHOLDERS: &[&str] = &[
+    "channel", "digest", "id", "kind", "N", "name", "owner", "panel", "passed", "path", "repo",
+];
+
+#[derive(Debug, PartialEq, Eq)]
+struct Finding {
+    file: String,
+    line: usize,
+    detail: String,
+}
+
+fn is_ident_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+/// Placeholder tokens on one line, as `(token, byte offset)`.
+///
+/// A token is `{` + an identifier + `}`. Anything else — an empty `{}`, a brace holding
+/// punctuation, a Rust format spec — is not a template slot and is not this gate's
+/// business.
+fn placeholders(line: &str) -> Vec<(String, usize)> {
+    let bytes = line.as_bytes();
+    let mut found = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'{' {
+            index += 1;
+            continue;
+        }
+        let start = index + 1;
+        let mut end = start;
+        while end < bytes.len() && is_ident_byte(bytes[end]) {
+            end += 1;
+        }
+        if end > start && end < bytes.len() && bytes[end] == b'}' {
+            found.push((line[start..end].to_owned(), index));
+            index = end + 1;
+        } else {
+            index += 1;
+        }
+    }
+    found
+}
+
+/// Scans one document, returning findings and the placeholders it legitimately used.
+fn scan(relative: &str, text: &str, known: &BTreeSet<&str>) -> (Vec<Finding>, BTreeSet<String>) {
+    let mut findings = Vec::new();
+    let mut used = BTreeSet::new();
+    let mut fence: Option<(u8, usize)> = None;
+
+    for (offset, line) in text.split('\n').enumerate() {
+        let number = offset + 1;
+        // A fenced block is verbatim sample text: `println!("{name}")` is code, not prose.
+        if let Some((marker, width, closing_tail)) = fence_marker(line) {
+            match fence {
+                Some((open_marker, open_width))
+                    if marker == open_marker && width >= open_width && closing_tail =>
+                {
+                    fence = None;
+                }
+                None => fence = Some((marker, width)),
+                _ => {}
+            }
+            continue;
+        }
+        if fence.is_some() {
+            continue;
+        }
+
+        // Inline code is deliberately NOT stripped: the KEL-208 placeholder shipped
+        // inside backticks, which is exactly where a formatting bug lands. Struck-through
+        // text is stripped, because retracted prose makes no live claim.
+        let visible = without_struck_text(line);
+        let line = visible.as_str();
+        for (token, at) in placeholders(line) {
+            if known.contains(token.as_str()) {
+                used.insert(token.clone());
+            } else {
+                findings.push(Finding {
+                    file: relative.to_owned(),
+                    line: number,
+                    detail: format!(
+                        "unknown template placeholder `{{{token}}}`. If the writing tool \
+                         should have substituted it, fix the substitution; if it is a real \
+                         template slot, add `\"{token}\"` to KNOWN_PLACEHOLDERS in \
+                         tools/doc_placeholders.rs"
+                    ),
+                });
+            }
+            // Concatenated slots are a formatting bug even when each name is known:
+            // no document writes `{a}{b}` as a template.
+            if at >= 1 && line.as_bytes()[at - 1] == b'}' {
+                findings.push(Finding {
+                    file: relative.to_owned(),
+                    line: number,
+                    detail: format!(
+                        "placeholder `{{{token}}}` is concatenated with the one before it. \
+                         Adjacent slots are a substitution bug, not a template"
+                    ),
+                });
+            }
+        }
+    }
+    (findings, used)
+}
+
+fn relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn collect_markdown(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(()),
+    };
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("DOC-PLACEHOLDERS: cannot read `{dir:?}`: {error}"))?;
+        let path = entry.path();
+        if relative_path(root, &path).starts_with(SKIPPED_PREFIX) {
+            continue;
+        }
+        if path.is_dir() {
+            collect_markdown(root, &path, out)?;
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn documents(root: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut files = Vec::new();
+    for dir in SCANNED_DIRS {
+        collect_markdown(root, &root.join(dir), &mut files)?;
+    }
+    for file in SCANNED_FILES {
+        let path = root.join(file);
+        if path.is_file() {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn check(root: &Path) -> Result<String, String> {
+    let known: BTreeSet<&str> = KNOWN_PLACEHOLDERS.iter().copied().collect();
+    if known.len() != KNOWN_PLACEHOLDERS.len() {
+        return Err("DOC-PLACEHOLDERS: KNOWN_PLACEHOLDERS contains a duplicate entry.".to_owned());
+    }
+
+    let files = documents(root)?;
+    if files.is_empty() {
+        return Err(format!(
+            "DOC-PLACEHOLDERS: no documents found under {root:?}. \
+             Run this from the repository root."
+        ));
+    }
+
+    let mut findings = Vec::new();
+    let mut used = BTreeSet::new();
+    for path in &files {
+        let text = fs::read_to_string(path)
+            .map_err(|error| format!("DOC-PLACEHOLDERS: cannot read `{path:?}`: {error}"))?;
+        let (mut file_findings, file_used) = scan(&relative_path(root, path), &text, &known);
+        findings.append(&mut file_findings);
+        used.extend(file_used);
+    }
+
+    if !findings.is_empty() {
+        let mut report = String::new();
+        for finding in &findings {
+            report.push_str(&format!(
+                "DOC-PLACEHOLDERS: {}:{}: {}\n",
+                finding.file, finding.line, finding.detail
+            ));
+        }
+        report.push_str(&format!("{} placeholder defect(s).", findings.len()));
+        return Err(report);
+    }
+
+    let stale: Vec<&str> = KNOWN_PLACEHOLDERS
+        .iter()
+        .copied()
+        .filter(|token| !used.contains(*token))
+        .collect();
+    if !stale.is_empty() {
+        return Err(format!(
+            "DOC-PLACEHOLDERS: KNOWN_PLACEHOLDERS lists {stale:?}, which no scanned document \
+             uses. Remove the stale entry so an unlisted placeholder cannot hide behind it."
+        ));
+    }
+
+    Ok(format!(
+        "doc-placeholders ok: {} document(s), {} known placeholder(s) all in use",
+        files.len(),
+        KNOWN_PLACEHOLDERS.len()
+    ))
+}
+
+fn run_cli() -> Result<(), String> {
+    let mut args = env::args().skip(1);
+    match args.next().as_deref() {
+        Some("check") => {
+            let root = args.next().unwrap_or_else(|| ".".to_owned());
+            let report = check(Path::new(&root))?;
+            println!("{report}");
+            Ok(())
+        }
+        other => Err(format!(
+            "DOC-PLACEHOLDERS: expected `check <root>`, got {other:?}."
+        )),
+    }
+}
+
+fn main() {
+    if let Err(error) = run_cli() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn known() -> BTreeSet<&'static str> {
+        KNOWN_PLACEHOLDERS.iter().copied().collect()
+    }
+
+    /// The exact line KEL-208 shipped into the normative security spec.
+    #[test]
+    fn the_kel208_placeholder_line_is_rejected() {
+        let line = "  `$APPDATA/cache/https:/**` and the `{BS}{BS}?{BS}C:/**` shape";
+        let (findings, _) = scan("docs/architecture/03-security.md", line, &known());
+        assert!(
+            findings.iter().any(|f| f.detail.contains("`{BS}`")),
+            "the leaked variable must be named: {findings:?}"
+        );
+        assert!(
+            findings.iter().any(|f| f.detail.contains("concatenated")),
+            "adjacent slots must be reported too: {findings:?}"
+        );
+    }
+
+    /// A single stray placeholder is the same bug without the adjacency tell.
+    #[test]
+    fn a_lone_unknown_placeholder_is_rejected() {
+        let (findings, _) = scan("docs/x.md", "the `{BS}C:/**` shape", &known());
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert!(findings[0].detail.contains("unknown template placeholder"));
+    }
+
+    /// Documented template slots must not be flagged, or the gate gets switched off.
+    #[test]
+    fn documented_template_slots_are_accepted() {
+        let (findings, used) = scan(
+            "docs/architecture/02-ipc.md",
+            "Channel `notes.{channel}` maps to `{name}` for run `{id}`.",
+            &known(),
+        );
+        assert!(findings.is_empty(), "{findings:?}");
+        assert_eq!(used.len(), 3);
+    }
+
+    /// Concatenation is a substitution bug even when both names are legitimate.
+    #[test]
+    fn adjacent_known_placeholders_are_still_rejected() {
+        let (findings, _) = scan("docs/x.md", "path `{name}{id}` here", &known());
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert!(findings[0].detail.contains("concatenated"));
+    }
+
+    /// Fenced blocks are verbatim samples; Rust format strings live there.
+    #[test]
+    fn fenced_code_is_sample_text_not_prose() {
+        let text = "before\n```rust\nprintln!(\"{unknown_variable}\");\n```\nafter";
+        let (findings, _) = scan("docs/x.md", text, &known());
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    /// Inline code is where the KEL-208 defect landed, so it is scanned, not stripped.
+    #[test]
+    fn inline_code_is_scanned_because_that_is_where_the_defect_landed() {
+        let (findings, _) = scan("docs/x.md", "see `{BS}` there", &known());
+        assert_eq!(findings.len(), 1, "inline code must not be exempt: {findings:?}");
+    }
+
+    /// `{}` and format specs are not template slots and are none of this gate's business.
+    #[test]
+    fn non_identifier_braces_are_ignored() {
+        let (findings, _) = scan("docs/x.md", "use {} and {:?} and { spaced } freely", &known());
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn placeholders_reports_token_and_offset() {
+        assert_eq!(
+            placeholders("a {one} b {two}"),
+            vec![("one".to_owned(), 2), ("two".to_owned(), 10)]
+        );
+        assert_eq!(placeholders("{} {:?} {a-b}"), Vec::new());
+    }
+
+    #[test]
+    fn known_placeholders_is_sorted_and_unique() {
+        let mut sorted = KNOWN_PLACEHOLDERS.to_vec();
+        sorted.sort_by_key(|token| token.to_ascii_lowercase());
+        sorted.dedup();
+        let mut actual = KNOWN_PLACEHOLDERS.to_vec();
+        actual.dedup();
+        assert_eq!(actual.len(), KNOWN_PLACEHOLDERS.len(), "duplicate entry");
+        assert_eq!(sorted, KNOWN_PLACEHOLDERS.to_vec(), "keep the list sorted");
+    }
+}

--- a/tools/doc_placeholders.rs
+++ b/tools/doc_placeholders.rs
@@ -174,10 +174,14 @@ fn relative_path(root: &Path, path: &Path) -> String {
 }
 
 fn collect_markdown(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
-    let entries = match fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(_) => return Ok(()),
-    };
+    // A scan root that cannot be opened must fail the gate, not silently shrink it:
+    // swallowing the error lets `check` report success having scanned one root.
+    let entries = fs::read_dir(dir).map_err(|error| {
+        format!(
+            "DOC-PLACEHOLDERS: cannot read scan directory `{}`: {error}. Every entry in SCANNED_DIRS must exist and be readable.",
+            relative_path(root, dir)
+        )
+    })?;
     for entry in entries {
         let entry =
             entry.map_err(|error| format!("DOC-PLACEHOLDERS: cannot read `{dir:?}`: {error}"))?;

--- a/tools/doc_placeholders.rs
+++ b/tools/doc_placeholders.rs
@@ -29,8 +29,31 @@ use markdown_contract::{fence_marker, without_struck_text};
 const SCANNED_DIRS: &[&str] = &["docs", ".agents"];
 /// Individual files scanned at the repository root.
 const SCANNED_FILES: &[&str] = &["llms.txt", "llms-full.txt", "AGENTS.md", "README.md"];
-/// Skipped: a nested private checkout with its own contracts.
-const SKIPPED_PREFIX: &str = "docs/research";
+/// Directory names never scanned.
+///
+/// Mirrors `should_skip_dir` in `tools/agent_context.rs` and adds the research
+/// worktrees, which land as `docs/keld-research-<n>-<slug>` siblings of the nested
+/// `docs/research` checkout. They are untracked private material: scanning them
+/// produced 385 findings against another agent's notes, and a gate that fires on
+/// content the repository does not own is a gate somebody switches off. Extracting
+/// this set into `tools/repo_path_contract.rs` alongside its two current users is
+/// the DRY end state; it is parked because that file is the instruction-budget
+/// checker's dependency and widening this PR into instruction governance is a
+/// separate concern.
+const SKIPPED_DIRS: &[&str] = &[
+    ".bun",
+    ".git",
+    "competitors",
+    "node_modules",
+    "research",
+    "target",
+];
+/// Prefix of a research worktree directory name.
+const SKIPPED_DIR_PREFIX: &str = "keld-research-";
+
+fn should_skip_dir(name: &str) -> bool {
+    SKIPPED_DIRS.contains(&name) || name.starts_with(SKIPPED_DIR_PREFIX)
+}
 
 /// Template slots documents are allowed to write.
 ///
@@ -159,10 +182,11 @@ fn collect_markdown(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<(
         let entry =
             entry.map_err(|error| format!("DOC-PLACEHOLDERS: cannot read `{dir:?}`: {error}"))?;
         let path = entry.path();
-        if relative_path(root, &path).starts_with(SKIPPED_PREFIX) {
-            continue;
-        }
         if path.is_dir() {
+            let name = path.file_name().and_then(|name| name.to_str()).unwrap_or("");
+            if should_skip_dir(name) {
+                continue;
+            }
             collect_markdown(root, &path, out)?;
         } else if path.extension().is_some_and(|ext| ext == "md") {
             out.push(path);
@@ -334,6 +358,26 @@ mod tests {
     fn non_identifier_braces_are_ignored() {
         let (findings, _) = scan("docs/x.md", "use {} and {:?} and { spaced } freely", &known());
         assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    /// Untracked research worktrees sit under `docs/` and are not this repository's
+    /// prose. Scanning them produced 385 findings against another agent's notes.
+    #[test]
+    fn research_worktrees_and_build_output_are_not_scanned() {
+        for name in [
+            "research",
+            "keld-research-232-competitor-field-refresh",
+            "target",
+            "node_modules",
+            ".git",
+            ".bun",
+            "competitors",
+        ] {
+            assert!(should_skip_dir(name), "`{name}` must not be scanned");
+        }
+        for name in ["architecture", "agents", "engineering", "onboarding", "specs"] {
+            assert!(!should_skip_dir(name), "`{name}` must be scanned");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- KEL-208 took five independent review rounds. The matcher was correct and byte-identical from its third commit onward; every round instead found defects in the **prose and fixtures** around it, and **every existing gate passed on all of them**. This adds the checkers instead of a sixth hand-editing pass.
- `tools/doc_placeholders.rs` rejects an unsubstituted template placeholder in checked-in prose. A literal `{BS}{BS}?{BS}C:/**` reached the normative security spec and its generated mirror; `just llms-check` passed because the corpus faithfully reproduced a source sentence that meant nothing. Every gate checks *consistency*; none checked meaning.
- Two contracts land in `keld-guard`, where the real parser is reachable: one asserts the **decoded bytes** of each escape-sensitive fixture scope, the other requires **every grant row to change a decision when removed**.

The load-bearing test immediately caught a live defect: `"https://**"` was inert in the pooled `net.connect` list, subsumed by `https:/**` — the same thing the fourth KEL-208 review round found by hand. Pooling is the cause, so each hostile spelling now has its own capability and no row can borrow a neighbour's denial.

**Why an inventory rather than a blanket scan.** 11 legitimate template slots exist across 65 documents; a gate that cries wolf gets switched off. Every placeholder a document may write is listed, an unlisted one fails, and a listed one no document uses is stale and also fails — so a leaked name cannot hide behind it. Fenced blocks are skipped as verbatim samples; **inline code is deliberately not skipped**, because that is exactly where the KEL-208 placeholder shipped.

## Spec refs

- `crates/keld-guard/AGENTS.md` — "Bypass fixtures (traversal, symlink swap, case folding, wildcard-swallow) permanent."
- `.agents/testing.md` — "A test MUST fail when the behavior under test is deleted or replaced with a no-op or constant result. Strengthen or remove a test that survives that change."
- `.agents/ci.md` — checker/justfile conventions. Root `AGENTS.md` § Reuse: Markdown parsing comes from `tools/markdown_contract.rs`; the fixture contracts use the crate's own parser rather than a second JSONC stripper.

## Review gates

- unsafe: none. public API: none — no `pub` item added or changed. permission model: none — `path_in_scope`/`names_no_destination` are untouched; the fixture is reorganised into more capabilities, and the decision matrix snapshot is unchanged for every pre-existing case. dependency addition: none. wire protocol: none.

## Tests

Verified against **real history**, not synthetic input:

```
# placeholder scan, docs/architecture/03-security.md as it stood at 7959881
DOC-PLACEHOLDERS: docs/architecture/03-security.md:105: unknown template placeholder `{BS}` …
DOC-PLACEHOLDERS: docs/architecture/03-security.md:105: placeholder `{BS}` is concatenated with the one before it …
4 placeholder defect(s).   exit=1

# same checker on the current tree
doc-placeholders ok: 65 document(s), 11 known placeholder(s) all in use   exit=0
```

Negative controls, each restored afterwards:

| mutation | result |
|---|---|
| re-pool a hostile spelling into `net.connect` | `every_fixture_grant_row_is_load_bearing` fails, naming `removing line 25 … ("https://**")` |
| flip the tab escape to `\t` | `fixture_scopes_decode_to_their_intended_bytes` fails with the byte diff — got `5c 74`, expected `09` |
| restore the `{BS}` spec line | placeholder scan exits 1 at line 105 |

`cargo test -p keld-guard` 44 + 6 + 5 + 1 + 4 passed, 0 failed. `just doc-placeholders-test` 12 passed.

**`just ci` is not green on this branch, and not because of this change.** `keld-runtime tests::natural_exit_does_not_wait_for_descendant_capture_eof_before_restart` fails under full-workspace concurrency and **reproduces identically on unmodified `main` @ `fa1bfd7`** (`602/617 tests run: 601 passed, 1 failed`), while passing isolated three times in a row. Its oracle is a 2-second deadline loop rather than an awaited condition. Reported with evidence on KEL-118, whose subject it is; not absorbed, not worked around, and no budget raised.

## Platforms

- **Windows 11 (Ramani), real dev box:** checker, both fixture contracts and the guard suite exercised; the pre-existing `keld-runtime` failure above is the only gate blocker and is unrelated.
- macOS / Linux: not run locally. Nothing here is OS-specific — a text scan and two pure-parser tests — so no real-OS acceptance is owed. This PR's CI lanes cover the other OSes.

## Perf impact

none. The checker is a single-pass text scan over 65 documents in a standalone `rustc` build; the two tests reuse the existing fixture load.

## Linear

KEL-213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of network URL patterns, including escaped, malformed, and alternate slash spellings.
  * Preserved distinct handling for legitimate origin-based network permissions and path-based grants.

* **Tests**
  * Added coverage confirming permission fixture values decode correctly.
  * Added checks ensuring each fixture grant meaningfully affects permission decisions.

* **Chores**
  * Added automated checks to detect unresolved placeholders in documentation and validate placeholder usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->