### PR TITLE
fix(host): charge Unix descriptors to the process that opened them

### DIFF
--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -13,8 +13,8 @@ use std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 use std::os::unix::process::{CommandExt as _, ExitStatusExt};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Output, Stdio};
-use std::sync::OnceLock;
 use std::sync::mpsc::{self, Receiver};
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -83,6 +83,7 @@ fn unix_descriptor_census_fixture_process() {
 /// read back out of the census under validation.
 #[test]
 fn unix_descriptor_census_charges_only_self_opened_sockets() {
+    let _isolation = census_isolation();
     let fixture = tempfile::tempdir().expect("census fixture root");
     let leaked_path = fixture.path().join("leaked.sock");
     let owned_path = fixture.path().join("owned.sock");
@@ -160,6 +161,7 @@ fn unix_descriptor_census_charges_only_self_opened_sockets() {
 /// socket's far end, which would fail the child on `EPIPE`.
 #[test]
 fn unix_descriptor_census_charges_a_copy_the_harness_does_not_hold() {
+    let _isolation = census_isolation();
     let fixture = tempfile::tempdir().expect("census fixture root");
     let leaked_path = fixture.path().join("leaked.sock");
     let owned_path = fixture.path().join("owned.sock");
@@ -261,6 +263,7 @@ fn unix_descriptor_census_charges_a_copy_the_harness_does_not_hold() {
 /// with whatever the census believes.
 #[test]
 fn unix_descriptor_census_charges_anonymous_sockets_it_cannot_attribute() {
+    let _isolation = census_isolation();
     let harness_anonymous = UnixDatagram::unbound().expect("harness unbound Unix socket");
     assert!(
         unix_socket_identities(std::process::id())
@@ -323,6 +326,7 @@ fn unix_descriptor_census_charges_anonymous_sockets_it_cannot_attribute() {
 /// the one that survives even if `->(none)` is special-cased.
 #[test]
 fn unix_descriptor_census_charges_a_listener_rebound_on_a_released_path() {
+    let _isolation = census_isolation();
     let fixture = tempfile::tempdir().expect("census fixture root");
     let shared_path = fixture.path().join("released.sock");
     let shared_identity = shared_path.to_str().expect("UTF-8 fixture path").to_owned();
@@ -389,6 +393,7 @@ fn unix_descriptor_census_charges_a_listener_rebound_on_a_released_path() {
 /// [`empty_unix_census_rejects_a_reaped_pid`] is the load-bearing path.
 #[test]
 fn unix_descriptor_census_requires_a_live_descriptor_table() {
+    let _isolation = census_isolation();
     assert!(
         process_has_open_descriptors(std::process::id()),
         "this harness is running, so it has a descriptor table"
@@ -464,6 +469,7 @@ fn empty_unix_census_rejects_a_reaped_pid() {
 /// collision tests, each of which fails against a census that gets it wrong.
 #[test]
 fn unix_descriptor_census_of_a_process_without_unix_descriptors_is_empty() {
+    let _isolation = census_isolation();
     let mut closes = String::new();
     for record in unix_descriptors(std::process::id()) {
         // 0, 1 and 2 are replaced by the spawn's own stdio redirection.
@@ -3024,6 +3030,29 @@ fn unix_socket_identities(pid: u32) -> Vec<String> {
         .collect()
 }
 
+/// Serialises the census fixtures against each other.
+///
+/// macOS `std` has no atomic `SOCK_CLOEXEC`: it creates a socket and then sets
+/// `FD_CLOEXEC` in a second call, so a `posix_spawn` on another thread inside that
+/// window captures the descriptor by number. A socket that leaks into another test's
+/// child that way is charged to that child as soon as its real owner closes it,
+/// because the census can no longer attribute it to the harness. Measured on these
+/// tests sharing one process, that is one failure in 300 runs, and the panic names a
+/// socket from a different fixture's temporary directory.
+///
+/// The mandated gate runs every test in its own process, where the interleaving
+/// cannot happen at all; this lock buys a shared-process run the same isolation. It
+/// is uncontended under the gate. Poisoning is ignored deliberately: a panicking
+/// census test has already failed the run, and refusing the lock afterwards would
+/// replace that failure with a less informative one.
+static CENSUS_ISOLATION: Mutex<()> = Mutex::new(());
+
+fn census_isolation() -> MutexGuard<'static, ()> {
+    CENSUS_ISOLATION
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
 /// Every Unix-domain socket open on this harness, by kernel address.
 fn harness_unix_sockets() -> Vec<String> {
     unix_descriptors(std::process::id())
@@ -3062,14 +3091,21 @@ fn harness_unix_sockets() -> Vec<String> {
 /// over-charge in the `dup` reading, which is investigable.
 ///
 /// The harness table is read on both sides of the target census, and only what
-/// both readings agree on can excuse anything. macOS reissues freed socket
-/// addresses heavily — 74 of 90 stream-pair addresses returned across three
-/// consecutive runs, and 16 to 27 of 45 for unbound datagrams — so one reading
-/// would excuse a socket `pid` opened at an address whose previous tenant the
-/// harness had just closed. Agreement costs a wider window in which a harness
-/// close over-charges a genuinely inherited descriptor, which is again the loud
-/// direction. Neither behaviour can be pinned without a test whose timing decides
-/// the result, so both are argued from measurement rather than asserted by a test.
+/// both readings agree on can excuse anything. macOS reuses freed socket addresses,
+/// at a rate that varies far too much between sessions to quote as a figure —
+/// repeated measurements of the same 90 stream-pair ends have returned anywhere
+/// from 15 to 74 of them — so reuse has to be assumed rather than treated as rare.
+/// One reading would then excuse a socket `pid` opened at an address whose previous
+/// tenant the harness had just closed.
+///
+/// The cost is that a harness close between the two readings over-charges a
+/// genuinely inherited descriptor. That is not hypothetical, and an earlier version
+/// of this comment was wrong to say no thread here closes a Unix socket: when these
+/// tests share one process they close each other's, and it cost one failure in 300
+/// runs until [`CENSUS_ISOLATION`] serialised them. It is still the loud direction,
+/// which is why the reading stays doubled: the alternative excuses a socket the
+/// target may have opened and says nothing. Neither behaviour can be pinned without
+/// a test whose timing decides the result, so both are argued from measurement.
 ///
 /// What survives is what `pid` did not inherit *from this harness*, which is why
 /// the name says that and not "opened itself". The two coincide only for a direct

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -7,6 +7,7 @@
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::os::fd::OwnedFd;
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::os::unix::process::{CommandExt as _, ExitStatusExt};
@@ -38,6 +39,95 @@ fn keld_dev_helper_process() {
         return;
     };
     keld_cli::dev::run_dev(Path::new(&project)).expect("shipping keld dev helper");
+}
+
+/// Fixture child for [`unix_descriptor_census_charges_only_self_opened_sockets`].
+///
+/// Opens exactly one Unix listener of its own, then holds the Unix descriptor
+/// the harness passed down as stdin until the harness closes the far end. That
+/// read is the release signal, so the census always observes a live process
+/// instead of racing its exit. Returns immediately when the harness did not
+/// select it, like [`keld_dev_helper_process`].
+#[test]
+fn unix_descriptor_census_fixture_process() {
+    let Some(owned) = std::env::var_os("KELD_T2_CENSUS_OWNED_SOCKET") else {
+        return;
+    };
+    let _owned = UnixListener::bind(Path::new(&owned)).expect("census fixture Unix listener");
+    let mut released = Vec::new();
+    std::io::stdin()
+        .read_to_end(&mut released)
+        .expect("hold the inherited Unix descriptor until the harness releases it");
+}
+
+/// KEL-222: the Unix-descriptor census charges a descriptor to the process that
+/// opened it, never to a process that merely inherited one.
+///
+/// A shell that leaves a Unix socket without `FD_CLOEXEC` leaks it through every
+/// `exec` into the process under test, so counting `lsof -U` rows answers "does
+/// this pid hold any Unix descriptor from any source" instead of "did this pid
+/// open one". This test reproduces that leak deliberately: the harness keeps its
+/// own copy of an accepted Unix stream and hands a duplicate down as the child's
+/// stdin, while the child opens one listener of its own. Both expected
+/// identities are paths this test chose before the census ran, so neither is
+/// read back out of the census under validation.
+#[test]
+fn unix_descriptor_census_charges_only_self_opened_sockets() {
+    let fixture = tempfile::tempdir().expect("census fixture root");
+    let leaked_path = fixture.path().join("leaked.sock");
+    let owned_path = fixture.path().join("owned.sock");
+    let leaked_identity = leaked_path.to_str().expect("UTF-8 fixture path").to_owned();
+    let owned_identity = owned_path.to_str().expect("UTF-8 fixture path").to_owned();
+
+    // `lsof` names an accepted peer by the listener's bound `sun_path`, so the
+    // leaked descriptor's identity is a path this test already knows.
+    let leaked_listener = UnixListener::bind(&leaked_path).expect("bind harness leak socket");
+    let far_end = UnixStream::connect(&leaked_path).expect("connect harness leak socket");
+    let (harness_copy, _) = leaked_listener
+        .accept()
+        .expect("accept harness leak socket");
+    let inherited = harness_copy
+        .try_clone()
+        .expect("duplicate the leaked descriptor for the child");
+
+    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+        .args(["--exact", "unix_descriptor_census_fixture_process"])
+        .env("KELD_T2_CENSUS_OWNED_SOCKET", &owned_path)
+        .stdin(Stdio::from(OwnedFd::from(inherited)))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("launch Unix-descriptor census fixture");
+    let child_pid = child.id();
+    let deadline = Instant::now() + PROCESS_DEADLINE;
+    while !owned_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "census fixture never bound its own Unix listener"
+        );
+        thread::yield_now();
+    }
+
+    // The fixture is only meaningful while the leak is real: prove the child
+    // holds the inherited descriptor before asserting that it is not charged.
+    let observed = unix_socket_identities(child_pid);
+    assert!(
+        observed.contains(&leaked_identity),
+        "fixture leaked no harness Unix descriptor into the child: {observed:?}"
+    );
+    assert_eq!(
+        self_opened_unix_sockets(child_pid),
+        vec![owned_identity],
+        "census must charge the child only the listener it bound itself: {observed:?}"
+    );
+
+    // Closing the far end is the child's release signal; the harness keeps its
+    // own copy and the listener until scope end, so the leaked identity stays in
+    // the harness table for the whole census above.
+    drop(far_end);
+    let status = child.wait().expect("reap census fixture");
+    assert!(status.success(), "census fixture failed: {status:?}");
+    await_process_gone(child_pid);
 }
 
 #[test]
@@ -1131,8 +1221,15 @@ impl ShippingDevCycle {
         beacon.assert_exact();
         assert_eq!(presentation.expect_initial(cycle.host_pid, name).len(), 1);
         assert!(native_windows(cli_pid, TITLE).is_empty());
-        assert!(host_unix_sockets(cycle.host_pid) > 0);
-        assert_eq!(host_unix_sockets(cli_pid), 0);
+        assert!(
+            !self_opened_unix_sockets(cycle.host_pid).is_empty(),
+            "host owns no Unix app-link descriptor it opened itself"
+        );
+        let cli_sockets = self_opened_unix_sockets(cli_pid);
+        assert!(
+            cli_sockets.is_empty(),
+            "CLI {cli_pid} owns Unix descriptors it opened itself: {cli_sockets:?}"
+        );
         if name == "t2-cli" {
             assert_lease_descriptor_ownership(
                 cli_pid,
@@ -2067,11 +2164,11 @@ impl LiveCycle {
             "exact host-owned native window: {windows:?}"
         );
         assert!(
-            host_unix_sockets(self.host_pid) > 0,
+            !self_opened_unix_sockets(self.host_pid).is_empty(),
             "host owns no authenticated Unix app-link descriptor"
         );
         assert!(
-            host_unix_sockets(self.bun_pid) > 0,
+            !self_opened_unix_sockets(self.bun_pid).is_empty(),
             "Bun owns no authenticated Unix app-link descriptor"
         );
         assert!(
@@ -2395,7 +2492,14 @@ fn await_process_gone(pid: u32) {
     }
 }
 
-fn host_unix_sockets(pid: u32) -> usize {
+/// One identity per Unix-domain descriptor open on `pid`.
+///
+/// The identity is the `lsof -Fn` name field: the bound `sun_path` for a
+/// listener and for each peer it accepted, or `->0x<kernel address>` for a
+/// connected or paired endpoint. `exec` preserves it byte for byte, so one
+/// kernel socket reports the same identity in a parent and in every child that
+/// inherited the descriptor. Identities repeat, so callers keep the multiset.
+fn unix_socket_identities(pid: u32) -> Vec<String> {
     let output = Command::new("/usr/sbin/lsof")
         .args(["-n", "-P", "-a", "-p", &pid.to_string(), "-U", "-Fn"])
         .output()
@@ -2407,8 +2511,42 @@ fn host_unix_sockets(pid: u32) -> usize {
     String::from_utf8(output.stdout)
         .expect("lsof output UTF-8")
         .lines()
-        .filter(|line| line.starts_with('n'))
-        .count()
+        .filter_map(|line| line.strip_prefix('n'))
+        .map(str::to_owned)
+        .collect()
+}
+
+/// The Unix-domain descriptors `pid` opened itself, as identities.
+///
+/// A raw `lsof -U` count is not an oracle for app-link ownership. Every product
+/// process censused here descends from this harness, and a Unix socket the
+/// launching shell left without `FD_CLOEXEC` reaches all of them through `exec`,
+/// so the raw count charges the CLI for descriptors it never opened (KEL-222).
+/// The harness is their only ancestor, so its own live descriptor table bounds
+/// everything they can have inherited: whatever survives subtracting it was
+/// opened by `pid`. Two live sockets never share an identity — a `sun_path` is
+/// exclusive while bound and a kernel address is unique while open — so the
+/// subtraction can only ever discount the very descriptor that was inherited.
+///
+/// Removing one harness identity per match keeps this a multiset operation,
+/// because a listener and each peer it accepted report the same `sun_path`, and
+/// a duplicate beyond the inherited one must still be charged to `pid`. The
+/// harness is censused first: a descriptor it opens afterwards cannot have been
+/// inherited by an already-spawned child, so measuring it later could only
+/// excuse a real leak. `cargo nextest` gives each test its own process, so the
+/// table read here is this test's own.
+fn self_opened_unix_sockets(pid: u32) -> Vec<String> {
+    let mut inherited = unix_socket_identities(std::process::id());
+    let mut opened = Vec::new();
+    for identity in unix_socket_identities(pid) {
+        match inherited.iter().position(|held| *held == identity) {
+            Some(index) => {
+                inherited.swap_remove(index);
+            }
+            None => opened.push(identity),
+        }
+    }
+    opened
 }
 
 fn lsof_stdin(pid: u32) -> String {

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -25,13 +25,6 @@ const DARK_BG: &str = "<style>html,body{background:#111;color:#eee}</style>";
 const TITLE: &str = "KEL96 T1b Fixture";
 const MARKER: &str = "KEL96_T1B_EXACT_RENDERER_7e2d9b";
 const FORWARDED_LOG: &str = "KEL96_T2_FORWARDED_LOG";
-/// What `lsof` reports for a Unix socket that is neither bound nor connected.
-///
-/// This is a placeholder, not an identity: every unbound socket on the machine
-/// reports it, so unlike a `sun_path` or a peer address it can never establish
-/// that two descriptors are the same kernel object (measured on macOS `lsof`
-/// 4.91).
-const ANONYMOUS_UNIX_SOCKET: &str = "->(none)";
 const EVENT_DEADLINE: Duration = Duration::from_secs(15);
 const PROCESS_DEADLINE: Duration = Duration::from_secs(5);
 
@@ -153,8 +146,8 @@ fn unix_descriptor_census_charges_only_self_opened_sockets() {
 /// that opened its own anonymous socket look clean whenever the harness happened
 /// to hold one too — a silent loss of detection power in exactly the direction
 /// this issue exists to close. The expected placeholder is written literally
-/// here, so this test pins the observed `lsof` output rather than agreeing with
-/// whatever constant the census uses.
+/// here, so this test pins what `lsof` was measured to print rather than agreeing
+/// with whatever the census believes.
 #[test]
 fn unix_descriptor_census_charges_anonymous_sockets_it_cannot_attribute() {
     let harness_anonymous = UnixDatagram::unbound().expect("harness unbound Unix socket");
@@ -208,6 +201,68 @@ fn unix_descriptor_census_charges_anonymous_sockets_it_cannot_attribute() {
     drop(harness_anonymous);
 }
 
+/// KEL-222: a `sun_path` is not an identity either, because a socket keeps
+/// reporting it after that path is unlinked.
+///
+/// The harness holds an accepted socket still named by a path that no longer
+/// exists on disk, and the child then binds a brand-new listener at that same
+/// path. `lsof` prints one name for both, so a name-keyed census excuses the
+/// child's own listener; keyed on the socket address the two never collide. This
+/// is the second of the two collisions that made name-keying unsound, and it is
+/// the one that survives even if `->(none)` is special-cased.
+#[test]
+fn unix_descriptor_census_charges_a_listener_rebound_on_a_released_path() {
+    let fixture = tempfile::tempdir().expect("census fixture root");
+    let shared_path = fixture.path().join("released.sock");
+    let shared_identity = shared_path.to_str().expect("UTF-8 fixture path").to_owned();
+
+    // Keep an accepted end, then release the name: the descriptor still reports it.
+    let listener = UnixListener::bind(&shared_path).expect("bind harness release socket");
+    let far_end = UnixStream::connect(&shared_path).expect("connect harness release socket");
+    let (harness_stale, _) = listener.accept().expect("accept harness release socket");
+    drop(listener);
+    fs::remove_file(&shared_path).expect("release the fixture path");
+    assert!(
+        unix_socket_identities(std::process::id()).contains(&shared_identity),
+        "harness lost the stale name, so this test collides with nothing"
+    );
+
+    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+        .args(["--exact", "unix_descriptor_census_fixture_process"])
+        .env("KELD_T2_CENSUS_OWNED_SOCKET", &shared_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("launch Unix-descriptor census fixture");
+    let child_pid = child.id();
+    let deadline = Instant::now() + PROCESS_DEADLINE;
+    while !shared_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "census fixture never rebound the released path"
+        );
+        thread::yield_now();
+    }
+
+    let observed = unix_socket_identities(child_pid);
+    assert!(
+        observed.contains(&shared_identity),
+        "fixture did not rebind the released path: {observed:?}"
+    );
+    assert_eq!(
+        self_opened_unix_sockets(child_pid),
+        vec![shared_identity],
+        "census must charge the listener the child bound itself: {observed:?}"
+    );
+
+    drop(child.stdin.take().expect("census fixture release lease"));
+    let status = child.wait().expect("reap census fixture");
+    assert!(status.success(), "census fixture failed: {status:?}");
+    await_process_gone(child_pid);
+    drop((harness_stale, far_end));
+}
+
 /// KEL-222: owning no Unix descriptor is an empty census, not a census failure.
 ///
 /// Zero is the *passing* value for the CLI, so the census must distinguish "this
@@ -215,14 +270,21 @@ fn unix_descriptor_census_charges_anonymous_sockets_it_cannot_attribute() {
 /// closes every Unix descriptor this harness could leak into it, discovered from
 /// the harness's own census rather than hard-coded, so it provably owns none, and
 /// reports readiness on its own pipe so the census never races the `exec`.
+///
+/// What it pins is the `lsof` exit contract, not attribution. The second
+/// assertion below cannot fail once the first passes, because the charged set is
+/// always a subset of the observed one — it is kept as a statement of the
+/// relationship, not as independent detection. Attribution is proved by
+/// [`unix_descriptor_census_charges_only_self_opened_sockets`] and the two
+/// collision tests, each of which fails against a census that gets it wrong.
 #[test]
 fn unix_descriptor_census_of_a_process_without_unix_descriptors_is_empty() {
     let mut closes = String::new();
-    for (descriptor, _) in unix_descriptors(std::process::id()) {
+    for record in unix_descriptors(std::process::id()) {
         // 0, 1 and 2 are replaced by the spawn's own stdio redirection.
-        if !matches!(descriptor.as_str(), "0" | "1" | "2") {
+        if !matches!(record.descriptor.as_str(), "0" | "1" | "2") {
             closes.push_str("exec ");
-            closes.push_str(&descriptor);
+            closes.push_str(&record.descriptor);
             closes.push_str(">&-; ");
         }
     }
@@ -2620,22 +2682,34 @@ fn await_process_gone(pid: u32) {
     }
 }
 
-/// Every Unix-domain descriptor open on `pid`, as `(descriptor, identity)`.
+/// One Unix-domain descriptor: its number, the kernel socket behind it, and the
+/// name `lsof` prints for it.
+struct UnixDescriptor {
+    descriptor: String,
+    /// `lsof`'s `d` field: the address of the socket object itself. Two live
+    /// sockets never share one, and `exec` preserves it, so this is what
+    /// identifies a descriptor across processes.
+    socket: String,
+    /// `lsof`'s `n` field: the bound `sun_path` for a listener and for each peer
+    /// it accepted, `->0x<address>` naming the *peer* socket for a connected or
+    /// paired endpoint, or `->(none)` when there is neither. Human-readable, and
+    /// deliberately not used to decide identity.
+    identity: String,
+}
+
+/// Every Unix-domain descriptor open on `pid`.
 ///
-/// The identity is the `lsof` name field: the bound `sun_path` for a listener
-/// and for each peer it accepted, or `->0x<kernel address>` for a connected or
-/// paired endpoint. `exec` preserves it byte for byte, so one kernel socket
-/// reports the same identity in a parent and in every child that inherited the
-/// descriptor. Identities repeat, so callers keep the multiset.
-///
-/// `lsof` exits 1 only when it cannot locate the pid at all. A live process that
-/// owns no Unix descriptor exits 0 with no rows, so an empty census is a result
-/// and not an error (measured on macOS `lsof` 4.91). Censusing a pid that has
-/// already exited does fail here, which is the intent: treating that as an empty
-/// census would let an ownership assertion pass vacuously against a dead process.
-fn unix_descriptors(pid: u32) -> Vec<(String, String)> {
+/// `lsof` exits 1 when it cannot report on the pid at all — because it cannot be
+/// located, or cannot be inspected. Being unable to report is distinct from
+/// having nothing to report: a live process that owns no Unix descriptor exits 0
+/// with no rows, so an empty census is a result and not an error (measured on
+/// macOS `lsof` 4.91; its `DIAGNOSTICS` text does not promise this, so the
+/// behaviour is measured rather than specified). Censusing a pid that has already
+/// exited does fail here, which is the intent: treating that as an empty census
+/// would let an ownership assertion pass vacuously against a dead process.
+fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
     let output = Command::new("/usr/sbin/lsof")
-        .args(["-n", "-P", "-a", "-p", &pid.to_string(), "-U", "-Ffn"])
+        .args(["-n", "-P", "-a", "-p", &pid.to_string(), "-U", "-Fdfn"])
         .output()
         .expect("enumerate Unix descriptors");
     assert!(
@@ -2644,75 +2718,76 @@ fn unix_descriptors(pid: u32) -> Vec<(String, String)> {
     );
     let rendered = String::from_utf8(output.stdout).expect("lsof output UTF-8");
     let mut descriptor = None;
+    let mut socket = None;
     let mut descriptors = Vec::new();
     for line in rendered.lines() {
         if let Some(fd) = line.strip_prefix('f') {
             descriptor = Some(fd.to_owned());
+            socket = None;
+        } else if let Some(address) = line.strip_prefix('d') {
+            socket = Some(address.to_owned());
         } else if let Some(name) = line.strip_prefix('n') {
-            descriptors.push((
-                descriptor
+            descriptors.push(UnixDescriptor {
+                descriptor: descriptor
                     .take()
-                    .expect("lsof names a descriptor it listed"),
-                name.to_owned(),
-            ));
+                    .expect("lsof numbers a descriptor it names"),
+                socket: socket.take().expect("lsof addresses a descriptor it names"),
+                identity: name.to_owned(),
+            });
         }
     }
     descriptors
 }
 
-/// One identity per Unix-domain descriptor open on `pid`.
+/// One printable name per Unix-domain descriptor open on `pid`.
 fn unix_socket_identities(pid: u32) -> Vec<String> {
     unix_descriptors(pid)
         .into_iter()
-        .map(|(_, identity)| identity)
+        .map(|descriptor| descriptor.identity)
         .collect()
 }
 
-/// The Unix-domain descriptors `pid` opened itself, as identities.
+/// The Unix-domain descriptors `pid` opened itself, named for a human.
 ///
 /// A raw `lsof -U` count is not an oracle for app-link ownership. Every product
 /// process censused here descends from this harness, and a Unix socket the
 /// launching shell left without `FD_CLOEXEC` reaches all of them through `exec`,
 /// so the raw count charges the CLI for descriptors it never opened (KEL-222).
-/// The harness is their only ancestor, so its own live descriptor table bounds
-/// everything they can have inherited: whatever survives subtracting it was
-/// opened by `pid`.
+/// The harness is their only ancestor, so its descriptor table bounds what they
+/// can have inherited: whatever survives subtracting it was opened by `pid`.
 ///
-/// Subtracting is only safe for a *named* identity: a `sun_path` names the socket
-/// bound to it and every peer accepted on it, and a peer address is unique while
-/// both ends are open, so removing one discounts the inherited descriptor rather
-/// than a coincidental twin. An unbound socket has no identity at all — `lsof`
-/// reports every one of them as [`ANONYMOUS_UNIX_SOCKET`] — so it is never
-/// subtracted and is always charged to `pid`. That keeps an anonymous socket the
-/// process opened itself visible; the cost is charging one it merely inherited,
-/// which fails loudly instead of passing silently.
+/// The subtraction is keyed on the socket object's own address, never on the
+/// printable name, because names are not identities. Measured on macOS `lsof`
+/// 4.91: every socket that is neither bound nor connected is named `->(none)`,
+/// and a socket keeps reporting its `sun_path` after that path is unlinked, so a
+/// replacement bound to the same path reports the same name. Either would let a
+/// name-keyed subtraction excuse a descriptor `pid` opened itself — the silent
+/// false pass this oracle exists to prevent. An address is unique among live
+/// sockets and `exec` preserves it, so a match means the same kernel object.
 ///
-/// One residual is inherent to naming a socket by its path: a descriptor stays
-/// bound to its `sun_path` after that path is unlinked, so a harness holding a
-/// stale-bound descriptor could absorb a censused process that rebinds the same
-/// path. This harness binds only fixture paths under its own temporary directory
-/// and never a product session path, so it cannot construct that collision.
+/// Removing one address per match keeps this a multiset operation, because `dup`
+/// and inheritance give one socket several descriptors, and a copy beyond the one
+/// the harness holds must still be charged to `pid`.
 ///
-/// Removing one harness identity per match keeps this a multiset operation,
-/// because a listener and each peer it accepted report the same `sun_path`, and
-/// a duplicate beyond the inherited one must still be charged to `pid`. The
-/// harness is censused first: a descriptor it opens afterwards cannot have been
-/// inherited by an already-spawned child, so measuring it later could only
-/// excuse a real leak. `cargo nextest` gives each test its own process, so the
-/// table read here is this test's own.
+/// Two limits are inherent to comparing two live tables and are left loud rather
+/// than papered over. A descriptor the harness closes after spawning `pid` is no
+/// longer subtractable, so `pid` is charged for something it only inherited: that
+/// fails, and a failure is investigable. And an address freed between the two
+/// censuses could in principle be reissued to a socket `pid` then opens; this is
+/// single-threaded and the two calls are adjacent, so the harness closes nothing
+/// in that window.
 fn self_opened_unix_sockets(pid: u32) -> Vec<String> {
-    let mut inherited = unix_socket_identities(std::process::id());
+    let mut inherited: Vec<String> = unix_descriptors(std::process::id())
+        .into_iter()
+        .map(|descriptor| descriptor.socket)
+        .collect();
     let mut opened = Vec::new();
-    for identity in unix_socket_identities(pid) {
-        if identity == ANONYMOUS_UNIX_SOCKET {
-            opened.push(identity);
-            continue;
-        }
-        match inherited.iter().position(|held| *held == identity) {
+    for descriptor in unix_descriptors(pid) {
+        match inherited.iter().position(|held| *held == descriptor.socket) {
             Some(index) => {
                 inherited.swap_remove(index);
             }
-            None => opened.push(identity),
+            None => opened.push(descriptor.identity),
         }
     }
     opened

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -100,7 +100,7 @@ fn unix_descriptor_census_charges_only_self_opened_sockets() {
         .try_clone()
         .expect("duplicate the leaked descriptor for the child");
 
-    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+    let child = Command::new(std::env::current_exe().expect("current test executable"))
         .args(["--exact", "unix_descriptor_census_fixture_process"])
         .env("KELD_T2_CENSUS_OWNED_SOCKET", &owned_path)
         .stdin(Stdio::from(OwnedFd::from(inherited)))
@@ -126,7 +126,7 @@ fn unix_descriptor_census_charges_only_self_opened_sockets() {
         "fixture leaked no harness Unix descriptor into the child: {observed:?}"
     );
     assert_eq!(
-        self_opened_unix_sockets(child_pid),
+        unix_sockets_not_inherited_from_harness(child_pid),
         vec![owned_identity],
         "census must charge the child only the listener it bound itself: {observed:?}"
     );
@@ -135,26 +135,31 @@ fn unix_descriptor_census_charges_only_self_opened_sockets() {
     // own copy and the listener until scope end, so the leaked identity stays in
     // the harness table for the whole census above.
     drop(far_end);
-    let status = child.wait().expect("reap census fixture");
-    assert!(status.success(), "census fixture failed: {status:?}");
+    let output = wait_child_output(child, PROCESS_DEADLINE);
+    assert!(output.status.success(), "census fixture failed: {output:?}");
     await_process_gone(child_pid);
 }
 
-/// KEL-222: a second descriptor on an inherited socket is still inherited.
+/// KEL-222: a copy of a socket the harness does not hold is charged.
 ///
-/// `dup`, `exec` and fd-passing all give one kernel socket several descriptors.
-/// Every one of them is the socket the harness holds, so none of them is something
-/// the censused process opened, however many there are. This pins that: the child
-/// receives the same accepted socket twice, on stdin and on stdout, while the
-/// harness holds exactly one descriptor for it, and must still be charged only the
-/// listener it bound itself. A census that removed one harness address per match
-/// would charge the second copy and fail here.
+/// A target holding two descriptors on a socket the harness holds once looks the
+/// same to `lsof` whether it `dup`ed an inherited descriptor or opened the socket
+/// itself and passed a copy up over `SCM_RIGHTS`. The census charges the extra
+/// copy, because the dangerous reading of an ambiguous picture is the one where a
+/// process opened an app link. This pins that choice using the half of the
+/// ambiguity that needs no `SCM_RIGHTS` support to build. A census that excused
+/// every copy of a harness-held address charges nothing here and passes.
+///
+/// Fixture integrity is checked by socket address, and the harness's own copy is
+/// counted rather than assumed: by name alone this fixture would look correct
+/// while handing down two *different* sockets that share one `sun_path`, and it
+/// would then be testing nothing.
 ///
 /// The second copy lands on stderr rather than stdout because the child's test
 /// harness writes its result line to stdout after the harness has closed the
 /// socket's far end, which would fail the child on `EPIPE`.
 #[test]
-fn unix_descriptor_census_charges_no_extra_copy_of_an_inherited_socket() {
+fn unix_descriptor_census_charges_a_copy_the_harness_does_not_hold() {
     let fixture = tempfile::tempdir().expect("census fixture root");
     let leaked_path = fixture.path().join("leaked.sock");
     let owned_path = fixture.path().join("owned.sock");
@@ -166,6 +171,10 @@ fn unix_descriptor_census_charges_no_extra_copy_of_an_inherited_socket() {
     let (harness_copy, _) = leaked_listener
         .accept()
         .expect("accept harness leak socket");
+    // The listener reports the same `sun_path` as the peer it accepted, so leaving
+    // it open makes this fixture's own integrity check ambiguous — the very
+    // ambiguity the census refuses to resolve by name.
+    drop(leaked_listener);
     let first = harness_copy
         .try_clone()
         .expect("duplicate the leaked descriptor for the child");
@@ -173,7 +182,7 @@ fn unix_descriptor_census_charges_no_extra_copy_of_an_inherited_socket() {
         .try_clone()
         .expect("duplicate the leaked descriptor a second time");
 
-    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+    let child = Command::new(std::env::current_exe().expect("current test executable"))
         .args(["--exact", "unix_descriptor_census_fixture_process"])
         .env("KELD_T2_CENSUS_OWNED_SOCKET", &owned_path)
         // stdin and stderr, not stdout: the test harness writes its result line to
@@ -193,31 +202,49 @@ fn unix_descriptor_census_charges_no_extra_copy_of_an_inherited_socket() {
         thread::yield_now();
     }
 
-    // The fixture is only meaningful while the child really holds two descriptors
-    // on the one socket the harness holds once.
-    let observed = unix_socket_identities(child_pid);
-    let copies = observed
+    // The fixture only means anything while the child holds two descriptors on one
+    // socket and the harness holds exactly one.
+    let harness_copies: Vec<String> = unix_descriptors(std::process::id())
+        .into_iter()
+        .filter(|descriptor| descriptor.identity == leaked_identity)
+        .map(|descriptor| descriptor.socket)
+        .collect();
+    assert_eq!(
+        harness_copies.len(),
+        1,
+        "harness must hold exactly one descriptor on the leaked socket: {harness_copies:?}"
+    );
+    let leaked_socket = harness_copies
+        .into_iter()
+        .next()
+        .expect("the harness copy just counted");
+    let child_table = unix_descriptors(child_pid);
+    let copies = child_table
         .iter()
-        .filter(|identity| **identity == leaked_identity)
+        .filter(|descriptor| descriptor.socket == leaked_socket)
         .count();
+    let rendered: Vec<String> = child_table
+        .iter()
+        .map(|descriptor| {
+            format!(
+                "f{} d{} n{}",
+                descriptor.descriptor, descriptor.socket, descriptor.identity
+            )
+        })
+        .collect();
     assert_eq!(
         copies, 2,
-        "fixture did not receive the inherited socket twice: {observed:?}"
+        "fixture did not receive one socket twice: {rendered:?}"
     );
     assert_eq!(
-        harness_unix_sockets().len(),
-        unix_descriptors(std::process::id()).len(),
-        "harness census disagrees with itself"
-    );
-    assert_eq!(
-        self_opened_unix_sockets(child_pid),
-        vec![owned_identity],
-        "census must charge only the listener the child bound itself: {observed:?}"
+        unix_sockets_not_inherited_from_harness(child_pid),
+        vec![leaked_identity, owned_identity],
+        "census must charge the copy the harness does not hold: {rendered:?}"
     );
 
     drop(far_end);
-    let status = child.wait().expect("reap census fixture");
-    assert!(status.success(), "census fixture failed: {status:?}");
+    let output = wait_child_output(child, PROCESS_DEADLINE);
+    assert!(output.status.success(), "census fixture failed: {output:?}");
     await_process_gone(child_pid);
 }
 
@@ -269,7 +296,7 @@ fn unix_descriptor_census_charges_anonymous_sockets_it_cannot_attribute() {
         observed.iter().any(|identity| identity == "->(none)"),
         "fixture opened no anonymous Unix socket, so there is nothing to attribute: {observed:?}"
     );
-    let mut charged = self_opened_unix_sockets(child_pid);
+    let mut charged = unix_sockets_not_inherited_from_harness(child_pid);
     charged.sort();
     let mut expected = vec!["->(none)".to_owned(), owned_identity];
     expected.sort();
@@ -279,8 +306,8 @@ fn unix_descriptor_census_charges_anonymous_sockets_it_cannot_attribute() {
     );
 
     drop(child.stdin.take().expect("census fixture release lease"));
-    let status = child.wait().expect("reap census fixture");
-    assert!(status.success(), "census fixture failed: {status:?}");
+    let output = wait_child_output(child, PROCESS_DEADLINE);
+    assert!(output.status.success(), "census fixture failed: {output:?}");
     await_process_gone(child_pid);
     drop(harness_anonymous);
 }
@@ -335,14 +362,14 @@ fn unix_descriptor_census_charges_a_listener_rebound_on_a_released_path() {
         "fixture did not rebind the released path: {observed:?}"
     );
     assert_eq!(
-        self_opened_unix_sockets(child_pid),
+        unix_sockets_not_inherited_from_harness(child_pid),
         vec![shared_identity],
         "census must charge the listener the child bound itself: {observed:?}"
     );
 
     drop(child.stdin.take().expect("census fixture release lease"));
-    let status = child.wait().expect("reap census fixture");
-    assert!(status.success(), "census fixture failed: {status:?}");
+    let output = wait_child_output(child, PROCESS_DEADLINE);
+    assert!(output.status.success(), "census fixture failed: {output:?}");
     await_process_gone(child_pid);
     drop((harness_stale, far_end));
 }
@@ -381,26 +408,34 @@ fn unix_descriptor_census_of_a_process_without_unix_descriptors_is_empty() {
         .spawn()
         .expect("launch descriptor-free census fixture");
     let child_pid = child.id();
-    let mut ready = String::new();
-    BufReader::new(child.stdout.take().expect("census fixture readiness pipe"))
-        .read_line(&mut ready)
-        .expect("await census fixture readiness");
+    // A fixture that never reports must fail this test, not hang it.
+    let readiness = child.stdout.take().expect("census fixture readiness pipe");
+    let (sender, reported) = mpsc::channel();
+    let reader = thread::spawn(move || {
+        let mut line = String::new();
+        let _ = sender.send(BufReader::new(readiness).read_line(&mut line).map(|_| line));
+    });
+    let ready = reported
+        .recv_timeout(PROCESS_DEADLINE)
+        .expect("descriptor-free fixture reports readiness within its deadline")
+        .expect("read descriptor-free fixture readiness");
     assert_eq!(ready.trim_end(), "READY");
+    reader.join().expect("readiness reader joins");
 
     let observed = unix_socket_identities(child_pid);
     assert!(
         observed.is_empty(),
         "descriptor-free fixture still owns Unix descriptors: {observed:?}"
     );
-    let opened = self_opened_unix_sockets(child_pid);
+    let opened = unix_sockets_not_inherited_from_harness(child_pid);
     assert!(
         opened.is_empty(),
         "descriptor-free fixture was charged Unix descriptors: {opened:?}"
     );
 
     drop(child.stdin.take().expect("census fixture release lease"));
-    let status = child.wait().expect("reap descriptor-free census fixture");
-    assert!(status.success(), "census fixture failed: {status:?}");
+    let output = wait_child_output(child, PROCESS_DEADLINE);
+    assert!(output.status.success(), "census fixture failed: {output:?}");
     await_process_gone(child_pid);
 }
 
@@ -1496,13 +1531,14 @@ impl ShippingDevCycle {
         assert_eq!(presentation.expect_initial(cycle.host_pid, name).len(), 1);
         assert!(native_windows(cli_pid, TITLE).is_empty());
         assert!(
-            !self_opened_unix_sockets(cycle.host_pid).is_empty(),
-            "host owns no Unix app-link descriptor it opened itself"
+            !unix_sockets_not_inherited_from_harness(cycle.host_pid).is_empty(),
+            "host owns no Unix app-link descriptor of its own"
         );
-        let cli_sockets = self_opened_unix_sockets(cli_pid);
+        let cli_sockets = unix_sockets_not_inherited_from_harness(cli_pid);
         assert!(
             cli_sockets.is_empty(),
-            "CLI {cli_pid} owns Unix descriptors it opened itself: {cli_sockets:?}"
+            "CLI {cli_pid} owns Unix descriptors it did not inherit from this harness: \
+             {cli_sockets:?}"
         );
         if name == "t2-cli" {
             assert_lease_descriptor_ownership(
@@ -2438,11 +2474,11 @@ impl LiveCycle {
             "exact host-owned native window: {windows:?}"
         );
         assert!(
-            !self_opened_unix_sockets(self.host_pid).is_empty(),
+            !unix_sockets_not_inherited_from_harness(self.host_pid).is_empty(),
             "host owns no authenticated Unix app-link descriptor"
         );
         assert!(
-            !self_opened_unix_sockets(self.bun_pid).is_empty(),
+            !unix_sockets_not_inherited_from_harness(self.bun_pid).is_empty(),
             "Bun owns no authenticated Unix app-link descriptor"
         );
         assert!(
@@ -2839,7 +2875,8 @@ fn harness_unix_sockets() -> Vec<String> {
         .collect()
 }
 
-/// The Unix-domain descriptors `pid` opened itself, named for a human.
+/// The Unix-domain descriptors open on `pid` that it did not inherit from this
+/// harness, named for a human.
 ///
 /// A raw `lsof -U` count is not an oracle for app-link ownership. A Unix socket
 /// the launching shell left without `FD_CLOEXEC` reaches every process under test
@@ -2855,38 +2892,65 @@ fn harness_unix_sockets() -> Vec<String> {
 /// prevent. An address is unique among live sockets and `exec` preserves it, so a
 /// match means the same kernel object.
 ///
-/// Membership, not multiset removal. `dup`, `exec` and fd-passing give one socket
-/// several descriptors, and every one of them is the socket the harness holds, so
-/// a second copy is still not something `pid` opened. Removing one address per
-/// match would charge `pid` for `dup`ing a descriptor it merely inherited, which
-/// is a false failure. Nothing is lost: opening a socket always creates a new
-/// kernel object, whose address the harness cannot already hold.
+/// One harness descriptor excuses one target descriptor, not every copy of it.
+/// Counting is not a refinement here, it is the whole choice: a target holding two
+/// descriptors on a socket the harness holds once is the same picture to `lsof`
+/// whether the target `dup`ed something it inherited or opened the socket itself
+/// and passed a copy up. Both are constructible, and neither happens in this
+/// product — nothing here passes descriptors over `SCM_RIGHTS`, and a shell leak
+/// reaches harness and child alike so their counts match and nothing is charged.
+/// Given an ambiguous picture the count rule takes the reading that fails loudly:
+/// excusing every copy silently absolves a socket the target may have opened, and
+/// that silence is the defect KEL-222 exists to remove. It costs a loud
+/// over-charge in the `dup` reading, which is investigable.
 ///
-/// The harness table is read on both sides of the target census and an address
-/// must appear in both to be excused. macOS reissues a freed socket address
-/// immediately and deterministically, so a single harness census could otherwise
-/// excuse a socket `pid` opened after the harness closed the previous tenant of
-/// that address — measured as total, not occasional, when it happens. Requiring
-/// both removes the window rather than relying on the harness closing nothing.
+/// The harness table is read on both sides of the target census, and only what
+/// both readings agree on can excuse anything. macOS reissues freed socket
+/// addresses heavily — 74 of 90 stream-pair addresses returned across three
+/// consecutive runs, and 16 to 27 of 45 for unbound datagrams — so one reading
+/// would excuse a socket `pid` opened at an address whose previous tenant the
+/// harness had just closed. Agreement costs a wider window in which a harness
+/// close over-charges a genuinely inherited descriptor, which is again the loud
+/// direction. Neither behaviour can be pinned without a test whose timing decides
+/// the result, so both are argued from measurement rather than asserted by a test.
 ///
-/// This is an upper bound on what `pid` opened, and deliberately so. `pid` is not
-/// always a direct child — Bun is the guardian's child, so the host or guardian
-/// could inject a descriptor the harness never held, and it would be charged to
-/// Bun. Over-charging is the safe direction for the assertion this oracle owns,
-/// "the CLI opened none", which can then only fail. It is *not* safe for the
-/// positive "this process opened one" assertions, which need to name the app link
-/// rather than count anything; that gap is real and is tracked separately.
-fn self_opened_unix_sockets(pid: u32) -> Vec<String> {
+/// What survives is what `pid` did not inherit *from this harness*, which is why
+/// the name says that and not "opened itself". The two coincide only for a direct
+/// child, whose whole ancestry is the harness: that is the CLI, and the CLI owning
+/// none is the assertion this oracle exists for. For a deeper descendant they
+/// diverge — Bun is the guardian's child, so an intermediate ancestor can pass
+/// down a socket the harness never held, and a grandchild handed a `socketpair`
+/// that way is charged both of its ends. That over-charges, which is safe for "the
+/// CLI owns none" and unsafe for the positive "this process owns one" assertions,
+/// since an injected descriptor satisfies them. Closing it needs those assertions
+/// to name the app link instead of counting anything, and is recorded on KEL-222
+/// rather than half-done here.
+fn unix_sockets_not_inherited_from_harness(pid: u32) -> Vec<String> {
     let before = harness_unix_sockets();
     let observed = unix_descriptors(pid);
-    let after = harness_unix_sockets();
-    observed
-        .into_iter()
-        .filter(|descriptor| {
-            !(before.contains(&descriptor.socket) && after.contains(&descriptor.socket))
-        })
-        .map(|descriptor| descriptor.identity)
-        .collect()
+    let mut after = harness_unix_sockets();
+    // One entry per socket both readings agree the harness held, and no more
+    // copies of it than the second reading still shows.
+    let mut inheritable = Vec::new();
+    for address in before {
+        if let Some(index) = after.iter().position(|held| *held == address) {
+            after.swap_remove(index);
+            inheritable.push(address);
+        }
+    }
+    let mut charged = Vec::new();
+    for descriptor in observed {
+        match inheritable
+            .iter()
+            .position(|held| *held == descriptor.socket)
+        {
+            Some(index) => {
+                inheritable.swap_remove(index);
+            }
+            None => charged.push(descriptor.identity),
+        }
+    }
+    charged
 }
 
 fn lsof_stdin(pid: u32) -> String {

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -9,7 +9,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::os::fd::OwnedFd;
 use std::os::unix::fs::{PermissionsExt, symlink};
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 use std::os::unix::process::{CommandExt as _, ExitStatusExt};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Output, Stdio};
@@ -25,6 +25,13 @@ const DARK_BG: &str = "<style>html,body{background:#111;color:#eee}</style>";
 const TITLE: &str = "KEL96 T1b Fixture";
 const MARKER: &str = "KEL96_T1B_EXACT_RENDERER_7e2d9b";
 const FORWARDED_LOG: &str = "KEL96_T2_FORWARDED_LOG";
+/// What `lsof` reports for a Unix socket that is neither bound nor connected.
+///
+/// This is a placeholder, not an identity: every unbound socket on the machine
+/// reports it, so unlike a `sun_path` or a peer address it can never establish
+/// that two descriptors are the same kernel object (measured on macOS `lsof`
+/// 4.91).
+const ANONYMOUS_UNIX_SOCKET: &str = "->(none)";
 const EVENT_DEADLINE: Duration = Duration::from_secs(15);
 const PROCESS_DEADLINE: Duration = Duration::from_secs(5);
 
@@ -41,18 +48,25 @@ fn keld_dev_helper_process() {
     keld_cli::dev::run_dev(Path::new(&project)).expect("shipping keld dev helper");
 }
 
-/// Fixture child for [`unix_descriptor_census_charges_only_self_opened_sockets`].
+/// Fixture child for the Unix-descriptor census tests.
 ///
 /// Opens exactly one Unix listener of its own, then holds the Unix descriptor
 /// the harness passed down as stdin until the harness closes the far end. That
 /// read is the release signal, so the census always observes a live process
 /// instead of racing its exit. Returns immediately when the harness did not
 /// select it, like [`keld_dev_helper_process`].
+///
+/// `KELD_T2_CENSUS_ANONYMOUS_SOCKET` additionally opens an unbound socket, which
+/// `lsof` reports without an identity. It is opened before the listener so that
+/// the listener's path, which is what the harness waits on, still marks the point
+/// where every descriptor this fixture owns is open.
 #[test]
 fn unix_descriptor_census_fixture_process() {
     let Some(owned) = std::env::var_os("KELD_T2_CENSUS_OWNED_SOCKET") else {
         return;
     };
+    let _anonymous = std::env::var_os("KELD_T2_CENSUS_ANONYMOUS_SOCKET")
+        .map(|_| UnixDatagram::unbound().expect("census fixture unbound Unix socket"));
     let _owned = UnixListener::bind(Path::new(&owned)).expect("census fixture Unix listener");
     let mut released = Vec::new();
     std::io::stdin()
@@ -128,6 +142,70 @@ fn unix_descriptor_census_charges_only_self_opened_sockets() {
     let status = child.wait().expect("reap census fixture");
     assert!(status.success(), "census fixture failed: {status:?}");
     await_process_gone(child_pid);
+}
+
+/// KEL-222: an unbound Unix socket is charged to whoever opened it, because the
+/// census cannot prove it was inherited.
+///
+/// `lsof` reports every unbound Unix socket with the same placeholder instead of
+/// a `sun_path` or a peer address, so that string cannot show that two
+/// descriptors are the same kernel object. Subtracting it would let a process
+/// that opened its own anonymous socket look clean whenever the harness happened
+/// to hold one too — a silent loss of detection power in exactly the direction
+/// this issue exists to close. The expected placeholder is written literally
+/// here, so this test pins the observed `lsof` output rather than agreeing with
+/// whatever constant the census uses.
+#[test]
+fn unix_descriptor_census_charges_anonymous_sockets_it_cannot_attribute() {
+    let harness_anonymous = UnixDatagram::unbound().expect("harness unbound Unix socket");
+    assert!(
+        unix_socket_identities(std::process::id())
+            .iter()
+            .any(|identity| identity == "->(none)"),
+        "harness holds no anonymous Unix socket, so this test collides with nothing"
+    );
+
+    let fixture = tempfile::tempdir().expect("census fixture root");
+    let owned_path = fixture.path().join("owned.sock");
+    let owned_identity = owned_path.to_str().expect("UTF-8 fixture path").to_owned();
+    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+        .args(["--exact", "unix_descriptor_census_fixture_process"])
+        .env("KELD_T2_CENSUS_OWNED_SOCKET", &owned_path)
+        .env("KELD_T2_CENSUS_ANONYMOUS_SOCKET", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("launch Unix-descriptor census fixture");
+    let child_pid = child.id();
+    let deadline = Instant::now() + PROCESS_DEADLINE;
+    while !owned_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "census fixture never bound its own Unix listener"
+        );
+        thread::yield_now();
+    }
+
+    let observed = unix_socket_identities(child_pid);
+    assert!(
+        observed.iter().any(|identity| identity == "->(none)"),
+        "fixture opened no anonymous Unix socket, so there is nothing to attribute: {observed:?}"
+    );
+    let mut charged = self_opened_unix_sockets(child_pid);
+    charged.sort();
+    let mut expected = vec!["->(none)".to_owned(), owned_identity];
+    expected.sort();
+    assert_eq!(
+        charged, expected,
+        "census must charge the child the anonymous socket it opened itself: {observed:?}"
+    );
+
+    drop(child.stdin.take().expect("census fixture release lease"));
+    let status = child.wait().expect("reap census fixture");
+    assert!(status.success(), "census fixture failed: {status:?}");
+    await_process_gone(child_pid);
+    drop(harness_anonymous);
 }
 
 /// KEL-222: owning no Unix descriptor is an empty census, not a census failure.
@@ -2598,9 +2676,22 @@ fn unix_socket_identities(pid: u32) -> Vec<String> {
 /// so the raw count charges the CLI for descriptors it never opened (KEL-222).
 /// The harness is their only ancestor, so its own live descriptor table bounds
 /// everything they can have inherited: whatever survives subtracting it was
-/// opened by `pid`. Two live sockets never share an identity — a `sun_path` is
-/// exclusive while bound and a kernel address is unique while open — so the
-/// subtraction can only ever discount the very descriptor that was inherited.
+/// opened by `pid`.
+///
+/// Subtracting is only safe for a *named* identity: a `sun_path` names the socket
+/// bound to it and every peer accepted on it, and a peer address is unique while
+/// both ends are open, so removing one discounts the inherited descriptor rather
+/// than a coincidental twin. An unbound socket has no identity at all — `lsof`
+/// reports every one of them as [`ANONYMOUS_UNIX_SOCKET`] — so it is never
+/// subtracted and is always charged to `pid`. That keeps an anonymous socket the
+/// process opened itself visible; the cost is charging one it merely inherited,
+/// which fails loudly instead of passing silently.
+///
+/// One residual is inherent to naming a socket by its path: a descriptor stays
+/// bound to its `sun_path` after that path is unlinked, so a harness holding a
+/// stale-bound descriptor could absorb a censused process that rebinds the same
+/// path. This harness binds only fixture paths under its own temporary directory
+/// and never a product session path, so it cannot construct that collision.
 ///
 /// Removing one harness identity per match keeps this a multiset operation,
 /// because a listener and each peer it accepted report the same `sun_path`, and
@@ -2613,6 +2704,10 @@ fn self_opened_unix_sockets(pid: u32) -> Vec<String> {
     let mut inherited = unix_socket_identities(std::process::id());
     let mut opened = Vec::new();
     for identity in unix_socket_identities(pid) {
+        if identity == ANONYMOUS_UNIX_SOCKET {
+            opened.push(identity);
+            continue;
+        }
         match inherited.iter().position(|held| *held == identity) {
             Some(index) => {
                 inherited.swap_remove(index);

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -130,6 +130,56 @@ fn unix_descriptor_census_charges_only_self_opened_sockets() {
     await_process_gone(child_pid);
 }
 
+/// KEL-222: owning no Unix descriptor is an empty census, not a census failure.
+///
+/// Zero is the *passing* value for the CLI, so the census must distinguish "this
+/// process owns none" from "the census could not run". This pins that: the child
+/// closes every Unix descriptor this harness could leak into it, discovered from
+/// the harness's own census rather than hard-coded, so it provably owns none, and
+/// reports readiness on its own pipe so the census never races the `exec`.
+#[test]
+fn unix_descriptor_census_of_a_process_without_unix_descriptors_is_empty() {
+    let mut closes = String::new();
+    for (descriptor, _) in unix_descriptors(std::process::id()) {
+        // 0, 1 and 2 are replaced by the spawn's own stdio redirection.
+        if !matches!(descriptor.as_str(), "0" | "1" | "2") {
+            closes.push_str("exec ");
+            closes.push_str(&descriptor);
+            closes.push_str(">&-; ");
+        }
+    }
+    let mut child = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(format!("{closes}echo READY; exec /bin/cat"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("launch descriptor-free census fixture");
+    let child_pid = child.id();
+    let mut ready = String::new();
+    BufReader::new(child.stdout.take().expect("census fixture readiness pipe"))
+        .read_line(&mut ready)
+        .expect("await census fixture readiness");
+    assert_eq!(ready.trim_end(), "READY");
+
+    let observed = unix_socket_identities(child_pid);
+    assert!(
+        observed.is_empty(),
+        "descriptor-free fixture still owns Unix descriptors: {observed:?}"
+    );
+    let opened = self_opened_unix_sockets(child_pid);
+    assert!(
+        opened.is_empty(),
+        "descriptor-free fixture was charged Unix descriptors: {opened:?}"
+    );
+
+    drop(child.stdin.take().expect("census fixture release lease"));
+    let status = child.wait().expect("reap descriptor-free census fixture");
+    assert!(status.success(), "census fixture failed: {status:?}");
+    await_process_gone(child_pid);
+}
+
 #[test]
 fn shipping_keld_dev_delegates_to_host_and_cli_death_reaps_the_session() {
     let fixture = ProductFixture::new("t2-cli-delegation");
@@ -2492,27 +2542,51 @@ fn await_process_gone(pid: u32) {
     }
 }
 
-/// One identity per Unix-domain descriptor open on `pid`.
+/// Every Unix-domain descriptor open on `pid`, as `(descriptor, identity)`.
 ///
-/// The identity is the `lsof -Fn` name field: the bound `sun_path` for a
-/// listener and for each peer it accepted, or `->0x<kernel address>` for a
-/// connected or paired endpoint. `exec` preserves it byte for byte, so one
-/// kernel socket reports the same identity in a parent and in every child that
-/// inherited the descriptor. Identities repeat, so callers keep the multiset.
-fn unix_socket_identities(pid: u32) -> Vec<String> {
+/// The identity is the `lsof` name field: the bound `sun_path` for a listener
+/// and for each peer it accepted, or `->0x<kernel address>` for a connected or
+/// paired endpoint. `exec` preserves it byte for byte, so one kernel socket
+/// reports the same identity in a parent and in every child that inherited the
+/// descriptor. Identities repeat, so callers keep the multiset.
+///
+/// `lsof` exits 1 only when it cannot locate the pid at all. A live process that
+/// owns no Unix descriptor exits 0 with no rows, so an empty census is a result
+/// and not an error (measured on macOS `lsof` 4.91). Censusing a pid that has
+/// already exited does fail here, which is the intent: treating that as an empty
+/// census would let an ownership assertion pass vacuously against a dead process.
+fn unix_descriptors(pid: u32) -> Vec<(String, String)> {
     let output = Command::new("/usr/sbin/lsof")
-        .args(["-n", "-P", "-a", "-p", &pid.to_string(), "-U", "-Fn"])
+        .args(["-n", "-P", "-a", "-p", &pid.to_string(), "-U", "-Ffn"])
         .output()
         .expect("enumerate Unix descriptors");
     assert!(
         output.status.success(),
         "lsof Unix descriptors for {pid}: {output:?}"
     );
-    String::from_utf8(output.stdout)
-        .expect("lsof output UTF-8")
-        .lines()
-        .filter_map(|line| line.strip_prefix('n'))
-        .map(str::to_owned)
+    let rendered = String::from_utf8(output.stdout).expect("lsof output UTF-8");
+    let mut descriptor = None;
+    let mut descriptors = Vec::new();
+    for line in rendered.lines() {
+        if let Some(fd) = line.strip_prefix('f') {
+            descriptor = Some(fd.to_owned());
+        } else if let Some(name) = line.strip_prefix('n') {
+            descriptors.push((
+                descriptor
+                    .take()
+                    .expect("lsof names a descriptor it listed"),
+                name.to_owned(),
+            ));
+        }
+    }
+    descriptors
+}
+
+/// One identity per Unix-domain descriptor open on `pid`.
+fn unix_socket_identities(pid: u32) -> Vec<String> {
+    unix_descriptors(pid)
+        .into_iter()
+        .map(|(_, identity)| identity)
         .collect()
 }
 

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -53,6 +53,9 @@ fn keld_dev_helper_process() {
 /// `lsof` reports without an identity. It is opened before the listener so that
 /// the listener's path, which is what the harness waits on, still marks the point
 /// where every descriptor this fixture owns is open.
+///
+/// The harness may also hand down the same inherited socket twice, on stdin and
+/// stdout, to stand in for a `dup` of an inherited descriptor.
 #[test]
 fn unix_descriptor_census_fixture_process() {
     let Some(owned) = std::env::var_os("KELD_T2_CENSUS_OWNED_SOCKET") else {
@@ -131,6 +134,87 @@ fn unix_descriptor_census_charges_only_self_opened_sockets() {
     // Closing the far end is the child's release signal; the harness keeps its
     // own copy and the listener until scope end, so the leaked identity stays in
     // the harness table for the whole census above.
+    drop(far_end);
+    let status = child.wait().expect("reap census fixture");
+    assert!(status.success(), "census fixture failed: {status:?}");
+    await_process_gone(child_pid);
+}
+
+/// KEL-222: a second descriptor on an inherited socket is still inherited.
+///
+/// `dup`, `exec` and fd-passing all give one kernel socket several descriptors.
+/// Every one of them is the socket the harness holds, so none of them is something
+/// the censused process opened, however many there are. This pins that: the child
+/// receives the same accepted socket twice, on stdin and on stdout, while the
+/// harness holds exactly one descriptor for it, and must still be charged only the
+/// listener it bound itself. A census that removed one harness address per match
+/// would charge the second copy and fail here.
+///
+/// The second copy lands on stderr rather than stdout because the child's test
+/// harness writes its result line to stdout after the harness has closed the
+/// socket's far end, which would fail the child on `EPIPE`.
+#[test]
+fn unix_descriptor_census_charges_no_extra_copy_of_an_inherited_socket() {
+    let fixture = tempfile::tempdir().expect("census fixture root");
+    let leaked_path = fixture.path().join("leaked.sock");
+    let owned_path = fixture.path().join("owned.sock");
+    let leaked_identity = leaked_path.to_str().expect("UTF-8 fixture path").to_owned();
+    let owned_identity = owned_path.to_str().expect("UTF-8 fixture path").to_owned();
+
+    let leaked_listener = UnixListener::bind(&leaked_path).expect("bind harness leak socket");
+    let far_end = UnixStream::connect(&leaked_path).expect("connect harness leak socket");
+    let (harness_copy, _) = leaked_listener
+        .accept()
+        .expect("accept harness leak socket");
+    let first = harness_copy
+        .try_clone()
+        .expect("duplicate the leaked descriptor for the child");
+    let second = harness_copy
+        .try_clone()
+        .expect("duplicate the leaked descriptor a second time");
+
+    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+        .args(["--exact", "unix_descriptor_census_fixture_process"])
+        .env("KELD_T2_CENSUS_OWNED_SOCKET", &owned_path)
+        // stdin and stderr, not stdout: the test harness writes its result line to
+        // stdout, and the socket's peer is closed before the child exits.
+        .stdin(Stdio::from(OwnedFd::from(first)))
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(OwnedFd::from(second)))
+        .spawn()
+        .expect("launch Unix-descriptor census fixture");
+    let child_pid = child.id();
+    let deadline = Instant::now() + PROCESS_DEADLINE;
+    while !owned_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "census fixture never bound its own Unix listener"
+        );
+        thread::yield_now();
+    }
+
+    // The fixture is only meaningful while the child really holds two descriptors
+    // on the one socket the harness holds once.
+    let observed = unix_socket_identities(child_pid);
+    let copies = observed
+        .iter()
+        .filter(|identity| **identity == leaked_identity)
+        .count();
+    assert_eq!(
+        copies, 2,
+        "fixture did not receive the inherited socket twice: {observed:?}"
+    );
+    assert_eq!(
+        harness_unix_sockets().len(),
+        unix_descriptors(std::process::id()).len(),
+        "harness census disagrees with itself"
+    );
+    assert_eq!(
+        self_opened_unix_sockets(child_pid),
+        vec![owned_identity],
+        "census must charge only the listener the child bound itself: {observed:?}"
+    );
+
     drop(far_end);
     let status = child.wait().expect("reap census fixture");
     assert!(status.success(), "census fixture failed: {status:?}");
@@ -2747,50 +2831,62 @@ fn unix_socket_identities(pid: u32) -> Vec<String> {
         .collect()
 }
 
-/// The Unix-domain descriptors `pid` opened itself, named for a human.
-///
-/// A raw `lsof -U` count is not an oracle for app-link ownership. Every product
-/// process censused here descends from this harness, and a Unix socket the
-/// launching shell left without `FD_CLOEXEC` reaches all of them through `exec`,
-/// so the raw count charges the CLI for descriptors it never opened (KEL-222).
-/// The harness is their only ancestor, so its descriptor table bounds what they
-/// can have inherited: whatever survives subtracting it was opened by `pid`.
-///
-/// The subtraction is keyed on the socket object's own address, never on the
-/// printable name, because names are not identities. Measured on macOS `lsof`
-/// 4.91: every socket that is neither bound nor connected is named `->(none)`,
-/// and a socket keeps reporting its `sun_path` after that path is unlinked, so a
-/// replacement bound to the same path reports the same name. Either would let a
-/// name-keyed subtraction excuse a descriptor `pid` opened itself — the silent
-/// false pass this oracle exists to prevent. An address is unique among live
-/// sockets and `exec` preserves it, so a match means the same kernel object.
-///
-/// Removing one address per match keeps this a multiset operation, because `dup`
-/// and inheritance give one socket several descriptors, and a copy beyond the one
-/// the harness holds must still be charged to `pid`.
-///
-/// Two limits are inherent to comparing two live tables and are left loud rather
-/// than papered over. A descriptor the harness closes after spawning `pid` is no
-/// longer subtractable, so `pid` is charged for something it only inherited: that
-/// fails, and a failure is investigable. And an address freed between the two
-/// censuses could in principle be reissued to a socket `pid` then opens; this is
-/// single-threaded and the two calls are adjacent, so the harness closes nothing
-/// in that window.
-fn self_opened_unix_sockets(pid: u32) -> Vec<String> {
-    let mut inherited: Vec<String> = unix_descriptors(std::process::id())
+/// Every Unix-domain socket open on this harness, by kernel address.
+fn harness_unix_sockets() -> Vec<String> {
+    unix_descriptors(std::process::id())
         .into_iter()
         .map(|descriptor| descriptor.socket)
-        .collect();
-    let mut opened = Vec::new();
-    for descriptor in unix_descriptors(pid) {
-        match inherited.iter().position(|held| *held == descriptor.socket) {
-            Some(index) => {
-                inherited.swap_remove(index);
-            }
-            None => opened.push(descriptor.identity),
-        }
-    }
-    opened
+        .collect()
+}
+
+/// The Unix-domain descriptors `pid` opened itself, named for a human.
+///
+/// A raw `lsof -U` count is not an oracle for app-link ownership. A Unix socket
+/// the launching shell left without `FD_CLOEXEC` reaches every process under test
+/// through `exec`, so the raw count charges the CLI for descriptors it never
+/// opened (KEL-222). Subtracting the harness's own table removes them.
+///
+/// Keyed on the socket object's own address, never on the printable name, because
+/// names are not identities. Measured on macOS `lsof` 4.91: every socket that is
+/// neither bound nor connected is named `->(none)`, and a socket keeps reporting
+/// its `sun_path` after that path is unlinked, so a replacement bound to the same
+/// path reports the same name. Either would let a name-keyed subtraction excuse a
+/// descriptor `pid` opened itself — the silent false pass this oracle exists to
+/// prevent. An address is unique among live sockets and `exec` preserves it, so a
+/// match means the same kernel object.
+///
+/// Membership, not multiset removal. `dup`, `exec` and fd-passing give one socket
+/// several descriptors, and every one of them is the socket the harness holds, so
+/// a second copy is still not something `pid` opened. Removing one address per
+/// match would charge `pid` for `dup`ing a descriptor it merely inherited, which
+/// is a false failure. Nothing is lost: opening a socket always creates a new
+/// kernel object, whose address the harness cannot already hold.
+///
+/// The harness table is read on both sides of the target census and an address
+/// must appear in both to be excused. macOS reissues a freed socket address
+/// immediately and deterministically, so a single harness census could otherwise
+/// excuse a socket `pid` opened after the harness closed the previous tenant of
+/// that address — measured as total, not occasional, when it happens. Requiring
+/// both removes the window rather than relying on the harness closing nothing.
+///
+/// This is an upper bound on what `pid` opened, and deliberately so. `pid` is not
+/// always a direct child — Bun is the guardian's child, so the host or guardian
+/// could inject a descriptor the harness never held, and it would be charged to
+/// Bun. Over-charging is the safe direction for the assertion this oracle owns,
+/// "the CLI opened none", which can then only fail. It is *not* safe for the
+/// positive "this process opened one" assertions, which need to name the app link
+/// rather than count anything; that gap is real and is tracked separately.
+fn self_opened_unix_sockets(pid: u32) -> Vec<String> {
+    let before = harness_unix_sockets();
+    let observed = unix_descriptors(pid);
+    let after = harness_unix_sockets();
+    observed
+        .into_iter()
+        .filter(|descriptor| {
+            !(before.contains(&descriptor.socket) && after.contains(&descriptor.socket))
+        })
+        .map(|descriptor| descriptor.identity)
+        .collect()
 }
 
 fn lsof_stdin(pid: u32) -> String {

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -374,6 +374,37 @@ fn unix_descriptor_census_charges_a_listener_rebound_on_a_released_path() {
     drop((harness_stale, far_end));
 }
 
+/// KEL-222: an empty census must prove the process still has a descriptor table.
+///
+/// `lsof` exits 0 with no rows for a live process owning no Unix socket and also for
+/// one whose table has already been torn down on the way out, and zero is the
+/// *passing* value for the CLI. [`unix_descriptors`] therefore corroborates an empty
+/// census with [`process_has_open_descriptors`]. The exiting window cannot be entered
+/// on demand, so what is pinned here is the corroboration: it answers yes for a live
+/// process and no for one that is gone. A stub that always answers yes fails this
+/// test, and the census then accepts teardown as evidence.
+#[test]
+fn unix_descriptor_census_requires_a_live_descriptor_table() {
+    assert!(
+        process_has_open_descriptors(std::process::id()),
+        "this harness is running, so it has a descriptor table"
+    );
+    let child = Command::new("/usr/bin/true")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("launch a fixture that exits immediately");
+    let pid = child.id();
+    let output = wait_child_output(child, PROCESS_DEADLINE);
+    assert!(output.status.success(), "fixture failed: {output:?}");
+    await_process_gone(pid);
+    assert!(
+        !process_has_open_descriptors(pid),
+        "{pid} has exited and been reaped, so it has no descriptor table"
+    );
+}
+
 /// KEL-222: owning no Unix descriptor is an empty census, not a census failure.
 ///
 /// Zero is the *passing* value for the CLI, so the census must distinguish "this
@@ -2817,16 +2848,60 @@ struct UnixDescriptor {
     identity: String,
 }
 
+/// The `ps` state letters for `pid`, or why they could not be read.
+fn process_state(pid: u32) -> String {
+    let output = Command::new("/bin/ps")
+        .args(["-o", "state=", "-p", &pid.to_string()])
+        .output()
+        .expect("inspect process state");
+    let state = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if state.is_empty() {
+        format!("unreadable (ps exit {:?})", output.status.code())
+    } else {
+        state
+    }
+}
+
+/// Whether `lsof` can still see any open descriptor at all on `pid`.
+///
+/// Not restricted to Unix sockets, and not parsed: `cwd` and the mapped executable
+/// count, so any process whose descriptor table exists answers yes. That makes this
+/// the corroboration an empty Unix census needs — see [`unix_descriptors`].
+fn process_has_open_descriptors(pid: u32) -> bool {
+    let output = Command::new("/usr/sbin/lsof")
+        .args(["-n", "-P", "-p", &pid.to_string(), "-Ff"])
+        .output()
+        .expect("enumerate open descriptors");
+    output.status.success()
+        && String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .any(|line| line.starts_with('f'))
+}
+
 /// Every Unix-domain descriptor open on `pid`.
 ///
-/// `lsof` exits 1 when it cannot report on the pid at all — because it cannot be
-/// located, or cannot be inspected. Being unable to report is distinct from
-/// having nothing to report: a live process that owns no Unix descriptor exits 0
-/// with no rows, so an empty census is a result and not an error (measured on
-/// macOS `lsof` 4.91; its `DIAGNOSTICS` text does not promise this, so the
-/// behaviour is measured rather than specified). Censusing a pid that has already
-/// exited does fail here, which is the intent: treating that as an empty census
-/// would let an ownership assertion pass vacuously against a dead process.
+/// `lsof` exits 1 when it cannot report on the pid at all. Measured on macOS `lsof`
+/// 4.91, that covers a pid that never existed, a zombie, and a pid owned by another
+/// user — the last with empty stderr, so an uninspectable process cannot masquerade
+/// as a clean one.
+///
+/// Exiting 0 with no rows does *not* mean the same thing twice over, and that is the
+/// trap this function has to close. A live process owning no Unix socket reports it
+/// that way, and so does a process in the window after `exit` but before it becomes
+/// a zombie, when its descriptor table is already gone but its proc entry is not.
+/// Zero is the *passing* value for the CLI, so the two must not be conflated:
+/// measured, an unguarded census returned an empty result in 32 of 300 racing trials
+/// for a target that provably owned a listener it had opened itself — a silent false
+/// pass of exactly the assertion this oracle exists to make.
+///
+/// So an empty census has to prove the process still has a table to be empty of.
+/// [`process_has_open_descriptors`] is that proof, and it is not circular: it asks a
+/// wider question than the census does, and `cwd` and the mapped executable answer
+/// it for any live process. Measured across 83 racing trials that produced an empty
+/// Unix census, it rejected all 83, and it stayed silent for live processes both with
+/// and without Unix sockets. The race cannot be reproduced deterministically, so
+/// [`unix_descriptor_census_requires_a_live_descriptor_table`] pins the corroboration
+/// itself rather than the window.
 fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
     let output = Command::new("/usr/sbin/lsof")
         .args(["-n", "-P", "-a", "-p", &pid.to_string(), "-U", "-Fdfn"])
@@ -2834,7 +2909,8 @@ fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
         .expect("enumerate Unix descriptors");
     assert!(
         output.status.success(),
-        "lsof Unix descriptors for {pid}: {output:?}"
+        "lsof cannot report Unix descriptors for {pid} in state {}: {output:?}",
+        process_state(pid)
     );
     let rendered = String::from_utf8(output.stdout).expect("lsof output UTF-8");
     let mut descriptor = None;
@@ -2842,9 +2918,22 @@ fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
     let mut descriptors = Vec::new();
     for line in rendered.lines() {
         if let Some(fd) = line.strip_prefix('f') {
+            // A record `lsof` starts and never names would otherwise be dropped
+            // without a word, and dropping a target's descriptor is the direction
+            // that passes. No real `lsof` output has done this; it is not left to
+            // chance because the cost of being wrong is silence.
+            assert!(
+                descriptor.is_none(),
+                "lsof left descriptor {descriptor:?} of {pid} unnamed: {rendered:?}"
+            );
             descriptor = Some(fd.to_owned());
             socket = None;
         } else if let Some(address) = line.strip_prefix('d') {
+            // Two empty addresses would compare equal and excuse each other.
+            assert!(
+                address.starts_with("0x"),
+                "lsof gave {pid} a socket address that is not one: {address:?}"
+            );
             socket = Some(address.to_owned());
         } else if let Some(name) = line.strip_prefix('n') {
             descriptors.push(UnixDescriptor {
@@ -2855,6 +2944,18 @@ fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
                 identity: name.to_owned(),
             });
         }
+    }
+    assert!(
+        descriptor.is_none(),
+        "lsof left the last descriptor of {pid} unnamed: {rendered:?}"
+    );
+    if descriptors.is_empty() {
+        assert!(
+            process_has_open_descriptors(pid),
+            "{pid} has no descriptor table in state {}, so an empty Unix census is \
+             teardown rather than evidence",
+            process_state(pid)
+        );
     }
     descriptors
 }

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -388,9 +388,10 @@ fn unix_descriptor_census_charges_a_listener_rebound_on_a_released_path() {
 /// process and no for one that is gone. A stub that always answers yes fails this
 /// test, and the census then accepts teardown as evidence.
 ///
-/// This test does not call [`unix_descriptors`] or [`accept_empty_unix_census`].
-/// Deleting the empty-result reject therefore stays green here;
-/// [`empty_unix_census_rejects_a_reaped_pid`] is the load-bearing path.
+/// This test does not call [`unix_descriptors`], so deleting the empty-result reject
+/// stays green here;
+/// [`empty_unix_census_of_a_process_without_a_descriptor_table_is_rejected`] is the
+/// load-bearing path.
 #[test]
 fn unix_descriptor_census_requires_a_live_descriptor_table() {
     let _isolation = census_isolation();
@@ -414,23 +415,28 @@ fn unix_descriptor_census_requires_a_live_descriptor_table() {
     );
 }
 
-/// KEL-222: the empty-census reject must fail a test when it is deleted.
+/// KEL-222: an empty census of a process without a descriptor table is rejected.
 ///
-/// [`unix_descriptor_census_requires_a_live_descriptor_table`] pins
-/// [`process_has_open_descriptors`] itself and never reaches
-/// [`accept_empty_unix_census`]. Measured on this tip before the extraction:
-/// deleting the `if descriptors.is_empty()` corroboration in [`unix_descriptors`]
-/// left all seven `unix_descriptor_census_*` tests green. This test calls the
-/// reject on a reaped pid so that mutation is a red suite. The live-harness call
-/// without `catch_unwind` makes an always-panic stub fail too.
+/// This is the reject that closes the exiting-window false pass, and it has to be
+/// pinned where it lives rather than in a helper beside it. An earlier attempt
+/// extracted the assert and called it directly, which pinned the assert and not the
+/// census: deleting the census's call to it left all eight tests green. Driving
+/// [`unix_descriptors_reported`] with the output instead reaches the same decision
+/// the census makes, so deleting the reject turns this red.
 ///
-/// [`unix_descriptors`] on the same reaped pid must also panic. That is the
-/// earlier `lsof` exit-1 assert, not the empty-result corroboration: a reaped
-/// pid never reaches the empty-result path. It is kept so treating exit 1 as an
-/// empty census cannot land silently.
+/// A reaped pid supplies the state that matters — no table — and the empty output
+/// supplies the census result that `lsof` gives for both a clean process and one
+/// being torn down. The live half of the test is the negative control: the same
+/// empty output for a process that does have a table must be accepted, or the
+/// reject would just be a ban on empty censuses.
 #[test]
-fn empty_unix_census_rejects_a_reaped_pid() {
-    accept_empty_unix_census(std::process::id());
+fn empty_unix_census_of_a_process_without_a_descriptor_table_is_rejected() {
+    let _isolation = census_isolation();
+    assert!(
+        unix_descriptors_reported(std::process::id(), "").is_empty(),
+        "an empty census of this live harness is a result, not an error"
+    );
+
     let child = Command::new("/usr/bin/true")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -441,16 +447,49 @@ fn empty_unix_census_rejects_a_reaped_pid() {
     let output = wait_child_output(child, PROCESS_DEADLINE);
     assert!(output.status.success(), "fixture failed: {output:?}");
     await_process_gone(pid);
-    let rejected = std::panic::catch_unwind(|| accept_empty_unix_census(pid));
+    let rejected = std::panic::catch_unwind(|| unix_descriptors_reported(pid, ""));
     assert!(
         rejected.is_err(),
-        "empty census of reaped {pid} must be rejected, not accepted as evidence"
+        "an empty census of reaped {pid} is teardown and must be rejected"
     );
-    let census = std::panic::catch_unwind(|| unix_descriptors(pid));
+    let censused = std::panic::catch_unwind(|| unix_descriptors(pid));
     assert!(
-        census.is_err(),
-        "unix_descriptors({pid}) of a reaped pid must panic"
+        censused.is_err(),
+        "censusing reaped {pid} must fail on lsof's exit status too"
     );
+}
+
+/// KEL-222: `lsof` output that cannot be trusted fails loudly, never quietly.
+///
+/// The parser's own guards, driven with the output they exist to reject. A record
+/// `lsof` starts and never names would otherwise be dropped in silence, and
+/// dropping one of the target's descriptors is the direction that passes. An
+/// address that is not one matters because two empty strings compare equal and
+/// would excuse each other. Neither shape has been seen in real output, which is
+/// why they are pinned here rather than left to a comment.
+#[test]
+fn untrustworthy_lsof_output_is_rejected() {
+    let _isolation = census_isolation();
+    let pid = std::process::id();
+    assert_eq!(
+        unix_descriptors_reported(pid, "f3\nd0xabc\nn/tmp/one.sock\n").len(),
+        1,
+        "a well-formed record is still accepted"
+    );
+    for (shape, rendered) in [
+        (
+            "a record left unnamed",
+            "f3\nd0xabc\nf5\nd0xdef\nn/tmp/two.sock\n",
+        ),
+        (
+            "the last record left unnamed",
+            "f3\nd0xabc\nn/tmp/one.sock\nf5\nd0xdef\n",
+        ),
+        ("an address that is not one", "f3\nd\nn/tmp/one.sock\n"),
+    ] {
+        let rejected = std::panic::catch_unwind(|| unix_descriptors_reported(pid, rendered));
+        assert!(rejected.is_err(), "{shape} must be rejected: {rendered:?}");
+    }
 }
 
 /// KEL-222: owning no Unix descriptor is an empty census, not a census failure.
@@ -2927,21 +2966,6 @@ fn process_has_open_descriptors(pid: u32) -> bool {
             .any(|line| line.starts_with('f'))
 }
 
-/// Accept an empty Unix-descriptor census only if `pid` still has a table.
-///
-/// This is the load-bearing empty-result reject. [`unix_descriptors`] calls it
-/// when `lsof -U` returns no rows. [`empty_unix_census_rejects_a_reaped_pid`]
-/// calls it on a reaped pid, so deleting this function's assert — or replacing
-/// it with a no-op — turns that test red.
-fn accept_empty_unix_census(pid: u32) {
-    assert!(
-        process_has_open_descriptors(pid),
-        "{pid} has no descriptor table in state {}, so an empty Unix census is \
-         teardown rather than evidence",
-        process_state(pid)
-    );
-}
-
 /// Every Unix-domain descriptor open on `pid`.
 ///
 /// `lsof` exits 1 when it cannot report on the pid at all. Measured on macOS `lsof`
@@ -2965,9 +2989,10 @@ fn accept_empty_unix_census(pid: u32) {
 /// Unix census, it rejected all 83, and it stayed silent for live processes both with
 /// and without Unix sockets. The race cannot be reproduced deterministically, so
 /// [`unix_descriptor_census_requires_a_live_descriptor_table`] pins the corroboration
-/// helper. [`empty_unix_census_rejects_a_reaped_pid`] pins the reject itself:
-/// [`accept_empty_unix_census`] on a reaped pid must panic. The exiting window still
-/// cannot be entered on demand, so a reaped-pid [`unix_descriptors`] panic is the
+/// itself, and
+/// [`empty_unix_census_of_a_process_without_a_descriptor_table_is_rejected`] pins the
+/// census applying it. The exiting window still cannot be entered on demand, so a
+/// reaped pid with an empty report stands in for it: same absent table, same
 /// earlier `lsof` exit-1 assert, not this empty-result path.
 fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
     let output = Command::new("/usr/sbin/lsof")
@@ -2980,6 +3005,19 @@ fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
         process_state(pid)
     );
     let rendered = String::from_utf8(output.stdout).expect("lsof output UTF-8");
+    unix_descriptors_reported(pid, &rendered)
+}
+
+/// The descriptors `lsof` reported for `pid` in `rendered`, or a panic if what it
+/// reported cannot be trusted.
+///
+/// Split from [`unix_descriptors`] at the process boundary so every decision this
+/// census makes is reachable from a test that supplies the output itself. Without
+/// that seam the empty-result reject below was unpinned: deleting it left every
+/// census test green, because the only input that distinguishes teardown from a
+/// clean process is a pid whose table is gone, and a census of one cannot be
+/// arranged on demand.
+fn unix_descriptors_reported(pid: u32, rendered: &str) -> Vec<UnixDescriptor> {
     let mut descriptor = None;
     let mut socket = None;
     let mut descriptors = Vec::new();
@@ -3017,7 +3055,12 @@ fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
         "lsof left the last descriptor of {pid} unnamed: {rendered:?}"
     );
     if descriptors.is_empty() {
-        accept_empty_unix_census(pid);
+        assert!(
+            process_has_open_descriptors(pid),
+            "{pid} has no descriptor table in state {}, so an empty Unix census is \
+             teardown rather than evidence",
+            process_state(pid)
+        );
     }
     descriptors
 }

--- a/crates/keld-host/tests/no_flag_macos.rs
+++ b/crates/keld-host/tests/no_flag_macos.rs
@@ -383,6 +383,10 @@ fn unix_descriptor_census_charges_a_listener_rebound_on_a_released_path() {
 /// on demand, so what is pinned here is the corroboration: it answers yes for a live
 /// process and no for one that is gone. A stub that always answers yes fails this
 /// test, and the census then accepts teardown as evidence.
+///
+/// This test does not call [`unix_descriptors`] or [`accept_empty_unix_census`].
+/// Deleting the empty-result reject therefore stays green here;
+/// [`empty_unix_census_rejects_a_reaped_pid`] is the load-bearing path.
 #[test]
 fn unix_descriptor_census_requires_a_live_descriptor_table() {
     assert!(
@@ -402,6 +406,45 @@ fn unix_descriptor_census_requires_a_live_descriptor_table() {
     assert!(
         !process_has_open_descriptors(pid),
         "{pid} has exited and been reaped, so it has no descriptor table"
+    );
+}
+
+/// KEL-222: the empty-census reject must fail a test when it is deleted.
+///
+/// [`unix_descriptor_census_requires_a_live_descriptor_table`] pins
+/// [`process_has_open_descriptors`] itself and never reaches
+/// [`accept_empty_unix_census`]. Measured on this tip before the extraction:
+/// deleting the `if descriptors.is_empty()` corroboration in [`unix_descriptors`]
+/// left all seven `unix_descriptor_census_*` tests green. This test calls the
+/// reject on a reaped pid so that mutation is a red suite. The live-harness call
+/// without `catch_unwind` makes an always-panic stub fail too.
+///
+/// [`unix_descriptors`] on the same reaped pid must also panic. That is the
+/// earlier `lsof` exit-1 assert, not the empty-result corroboration: a reaped
+/// pid never reaches the empty-result path. It is kept so treating exit 1 as an
+/// empty census cannot land silently.
+#[test]
+fn empty_unix_census_rejects_a_reaped_pid() {
+    accept_empty_unix_census(std::process::id());
+    let child = Command::new("/usr/bin/true")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("launch a fixture that exits immediately");
+    let pid = child.id();
+    let output = wait_child_output(child, PROCESS_DEADLINE);
+    assert!(output.status.success(), "fixture failed: {output:?}");
+    await_process_gone(pid);
+    let rejected = std::panic::catch_unwind(|| accept_empty_unix_census(pid));
+    assert!(
+        rejected.is_err(),
+        "empty census of reaped {pid} must be rejected, not accepted as evidence"
+    );
+    let census = std::panic::catch_unwind(|| unix_descriptors(pid));
+    assert!(
+        census.is_err(),
+        "unix_descriptors({pid}) of a reaped pid must panic"
     );
 }
 
@@ -2878,6 +2921,21 @@ fn process_has_open_descriptors(pid: u32) -> bool {
             .any(|line| line.starts_with('f'))
 }
 
+/// Accept an empty Unix-descriptor census only if `pid` still has a table.
+///
+/// This is the load-bearing empty-result reject. [`unix_descriptors`] calls it
+/// when `lsof -U` returns no rows. [`empty_unix_census_rejects_a_reaped_pid`]
+/// calls it on a reaped pid, so deleting this function's assert — or replacing
+/// it with a no-op — turns that test red.
+fn accept_empty_unix_census(pid: u32) {
+    assert!(
+        process_has_open_descriptors(pid),
+        "{pid} has no descriptor table in state {}, so an empty Unix census is \
+         teardown rather than evidence",
+        process_state(pid)
+    );
+}
+
 /// Every Unix-domain descriptor open on `pid`.
 ///
 /// `lsof` exits 1 when it cannot report on the pid at all. Measured on macOS `lsof`
@@ -2901,7 +2959,10 @@ fn process_has_open_descriptors(pid: u32) -> bool {
 /// Unix census, it rejected all 83, and it stayed silent for live processes both with
 /// and without Unix sockets. The race cannot be reproduced deterministically, so
 /// [`unix_descriptor_census_requires_a_live_descriptor_table`] pins the corroboration
-/// itself rather than the window.
+/// helper. [`empty_unix_census_rejects_a_reaped_pid`] pins the reject itself:
+/// [`accept_empty_unix_census`] on a reaped pid must panic. The exiting window still
+/// cannot be entered on demand, so a reaped-pid [`unix_descriptors`] panic is the
+/// earlier `lsof` exit-1 assert, not this empty-result path.
 fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
     let output = Command::new("/usr/sbin/lsof")
         .args(["-n", "-P", "-a", "-p", &pid.to_string(), "-U", "-Fdfn"])
@@ -2950,12 +3011,7 @@ fn unix_descriptors(pid: u32) -> Vec<UnixDescriptor> {
         "lsof left the last descriptor of {pid} unnamed: {rendered:?}"
     );
     if descriptors.is_empty() {
-        assert!(
-            process_has_open_descriptors(pid),
-            "{pid} has no descriptor table in state {}, so an empty Unix census is \
-             teardown rather than evidence",
-            process_state(pid)
-        );
+        accept_empty_unix_census(pid);
     }
     descriptors
 }


### PR DESCRIPTION
## Summary

`crates/keld-host/tests/no_flag_macos.rs` counted Unix descriptors with `lsof -U` to
assert app-link ownership, so shell-leaked descriptors on fds 3 and 4 were charged to
the CLI and two tests failed `left: 2, right: 0`. The census now charges each
descriptor to the process that opened it, keyed on the socket's kernel address, and
six new tests plus a negative control prove it still catches a CLI-owned app link.

## Spec refs

No spec change. Architecture 01 §5 process/ownership model unchanged; this is a test
oracle correcting itself against the existing app-link ownership contract, so no
`docs/agents/spec-template.md` spec is required. Linear: KEL-222.

## Tests

- `just ci` exit 0 — `687 tests run: 687 passed (1 slow), 4 skipped`
- 20 consecutive runs of the ten affected tests — 20/20 pass
- The two originally failing tests pass both from a shell still leaking fds 3 and 4
  and in a clean descriptor environment (`3>&- 4>&-`)
- Negative control: a CLI mutated to bind an app link makes the oracle fail, naming
  the socket; reverted, `git status` clean
- Seven `unix_descriptor_census_*` tests pin the oracle itself, each failure-first
- Every wait these tests added is deadline-bounded, so a stuck fixture fails
  rather than hanging

## Platforms

macOS only — the changed file is `no_flag_macos.rs`, gated to macOS. Verified on
real hardware: CENTILLIONAIREs-Mac-mini.local, macOS 26.5.1 build 25F80, arm64,
Apple M4 (Mac16,10). Linux and Windows are unaffected and were not run locally.

## Perf impact

None on the product; the diff is test-only. The oracle adds two `lsof` invocations, and a third only when a census comes back empty,
per census, in tests that already spawn GUI processes; total suite time is unchanged
within noise (`687 tests` in 62.3s).

## What broke

`crates/keld-host/tests/no_flag_macos.rs` asserted app-link ownership by counting
Unix-domain descriptors with `lsof -U` and requiring the CLI's count to be zero. A
count is not an ownership oracle. The shell that launches the test suite leaves two
Unix sockets open on fds 3 and 4 without `FD_CLOEXEC`, so every process under test
inherits them through `exec` and the CLI was charged for descriptors it never
opened. Two tests failed with `left: 2, right: 0`.

The trap in this bug is that almost any fix makes the assertion pass. The oracle
exists to catch a CLI that opens an app link, and a fix that stops counting the
right things passes silently forever.

## The fix

Charge each Unix descriptor to whoever opened it, by subtracting the harness's own
descriptor table from the target's. Keyed on `lsof`'s `d` field — the kernel
address of the socket object — never on the printable name.

The obvious cheaper fix, filtering descriptors by the session's app-link path, was
tried first and **rejected on measurement**. The host *binds* the app link, so its
descriptor is named `<session>/app-link.sock`, but Bun *connects*, so `lsof` names
Bun's descriptors by peer kernel address (`->0xf1c87ee6178c9ce9`). A path filter
returns zero for Bun and turns the existing `assert!(… > 0)` into an unconditional
failure, rescuable only by deleting an assertion or adding a second oracle for the
same question. Both are forbidden.

Names are not identities, which is why the key is the address. Measured on macOS
`lsof` 4.91: every socket that is neither bound nor connected is named `->(none)`,
and a socket keeps reporting its `sun_path` after that path is unlinked, so a
replacement bound to the same path reports the same name. Either collision would
let a name-keyed subtraction excuse a socket the target opened itself. Addresses
collide in neither case, are unique among live sockets (3004 live sockets, 3004
distinct addresses), and survive `exec` byte-for-byte.

Two further properties are load-bearing and were established by adversarial review
rather than by assumption:

- **One harness descriptor excuses one target descriptor, not every copy of it.**
  A target holding two descriptors on a socket the harness holds once is the same
  picture to `lsof` whether it `dup`ed something it inherited or opened the socket
  itself and passed a copy up over `SCM_RIGHTS`. Counts cannot separate those, and
  neither happens in this product — nothing passes descriptors over `SCM_RIGHTS`,
  and a shell leak reaches harness and child alike so their counts already match.
  So this is a choice of failure direction: the count rule over-charges loudly in
  the `dup` reading, while excusing every copy would silently absolve a socket the
  target may have opened, and that silence is the defect this issue exists to
  remove.
- **An empty census must prove the process still has a descriptor table.** `lsof`
  exits 0 with no rows both for a live process owning no Unix socket and for one in
  the window after `exit` but before it becomes a zombie, when its table is already
  gone. Zero is the passing value for the CLI, so conflating those two is a silent
  false pass, and it was one: 32 of 300 racing trials returned an empty census for a
  target that provably owned a listener it had opened itself. An empty census is now
  corroborated by asking whether `lsof` sees any open descriptor at all, which `cwd`
  and the mapped executable answer for any live process. `kill -0` would not do, as
  it succeeds on a zombie. Re-run against the fix, the same reproducer gives 300 loud
  failures and none silent, and a live target is still charged correctly in 60 of 60.
- **The harness table is read on both sides of the target census**, and only what
  both readings agree on can excuse anything. Address reuse is heavy — 74 of 90
  stream-pair addresses returned across three consecutive runs, 16 to 27 of 45 for
  unbound datagrams — so one reading would excuse a socket the target opened at an
  address whose previous tenant the harness had just closed. The cost is a wider
  window in which a harness close over-charges an inherited descriptor, which is
  again the loud direction. Neither behaviour can be pinned without a test whose
  timing decides the result, and the code says so rather than implying otherwise.

The helper is named for what the subtraction proves: not what a process opened, but
what it did not inherit *from this harness*. Those coincide only for a direct child,
whose whole ancestry is the harness. The CLI is one, which is why the assertion this
issue owns is sound. Bun is the guardian's child, and a grandchild handed a
`socketpair` by an intermediate ancestor is charged both of its ends — measured, not
feared. Over-charging is the safe direction for "the CLI
opened none", which can then only fail. It is not safe for the positive "this
process opened one" assertions; that gap predates this change and is recorded on
KEL-222 rather than widened here.

## Detection power, proven not asserted

Failing test first, then the fix. Every assertion was strengthened, none weakened:
the two `> 0` count assertions became "owns an app-link descriptor it opened
itself", and the CLI assertion now names the offending sockets in its message.

**Negative control on this exact tip.** A five-line mutation in
`crates/keld-cli/src/dev.rs` makes the CLI bind an app link it must not own. The
repaired oracle fails, naming it:

```
CLI 7553 owns Unix descriptors it did not inherit from this harness: ["/tmp/kel222-cli-app-link-7553.sock"]
```

The mutation is reverted; `git status` is clean.

**Mutation results.** Keying the census on the printable name instead of the
address fails both collision tests. Removing the subtraction entirely fails three.
Excusing every copy of a harness-held address fails the copy test. Censusing an
exited pid cannot pass vacuously. The copy test's fixture is guarded by address
rather than name, and both ways of rotting that fixture — handing down two
different sockets that share one `sun_path`, or letting the harness hold a second
copy — now fail the test instead of quietly disarming it.

Seven census tests now pin the oracle itself, each with a fixture child process:
self-opened attribution, anonymous sockets that cannot be attributed by name, a
listener rebound on a released path, a copy of a socket the harness does not hold,
the `lsof` exit contract for a process owning no Unix descriptors, and the
corroboration that keeps an empty census from being read as teardown.

## Verification

- `just ci` — exit 0; `687 tests run: 687 passed (1 slow), 4 skipped`
- 20 consecutive runs of the ten affected tests — 20/20 pass
- The two originally failing tests pass from a shell that still leaks fds 3 and 4
  (`f3 d0x380cfbbd639d18e3`, `f4 d0x880f9b92bb16823d`) and in a clean descriptor
  environment (`3>&- 4>&-`)
- Negative control red on this tip, then reverted

## Review gates

`unsafe`: none. Public API: none. Permission model: none. Dependency addition:
none. Wire protocol: none.

Diff is confined to `crates/keld-host/tests/no_flag_macos.rs`.

## Known adjacent defect, not fixed here

One `just ci` run killed two macOS GUI tests with SIGTERM under load (system load
7.51, WindowServer at 38%). The diff contains no signal-handling change; the
mechanism is most likely process-group id reuse in `ShippingLaunchCleanup::drop`,
which sends `-TERM` to recorded groups. It is pre-existing and out of scope. It is
reported rather than hidden behind a retry, a sleep or an `#[ignore]`.

Refs KEL-222
