### PR TITLE
docs(intake): collect the commit, platform and tool versions CONTRIBUTING asks for

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -16,6 +16,21 @@ body:
       label: Related issue (optional)
       description: Public issue/PR link or an existing KEL-n if known. Leave blank otherwise.
       placeholder: KEL-00
+  - type: input
+    id: commit
+    attributes:
+      label: Keld commit
+      description: Output of `git rev-parse HEAD`, or the tag or installed version you ran. State unknown if you cannot determine it.
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: OS/architecture
+      description: Operating system with version, and CPU architecture.
+      placeholder: macOS 26.5, arm64
+    validations:
+      required: true
   - type: textarea
     id: expected
     attributes:
@@ -34,7 +49,15 @@ body:
     id: reproduce
     attributes:
       label: Reproduce
-      description: Commands and platform (OS + version). Bind port 0 / temp dirs if relevant.
+      description: Exact commands and steps. Bind port 0 / temp dirs if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: tools
+    attributes:
+      label: Relevant tool versions
+      description: Output of `rustc --version` and `cargo --version` for Rust reports, `cargo nextest --version` for workspace tests, and `bun --revision` for Bun-dependent behavior. State not applicable when none apply.
+      render: shell
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` (lines 14–16) tells public reporters to include "your Keld commit, OS/architecture, exact command, expected result, actual output and relevant tool versions", but `.github/ISSUE_TEMPLATE/bug.yml` collected only the command, expected result and actual output. There was no commit field and no tool-versions field, and the platform was asked for only as a clause inside the required `Reproduce` free-text box, which also omitted CPU architecture. Root `AGENTS.md` treats a docs/behaviour mismatch as a bug in one of the two; the guide is the canonical public-intake owner, so the form was the defect.
- Adds `commit`, `platform` and `tools` fields and removes the now-duplicated platform clause from `Reproduce`, so each item the guide asks for is collected exactly once.
- Field shapes reuse what the template already establishes rather than introducing a new style: single-line `input` for short values (as `linear` does), and a `render: shell` textarea whose description lists the exact commands (as `gate` does). No new field beyond what `CONTRIBUTING.md` asks for.

Requiredness follows the accepted scope in KEL-179 comment `8058ebd1` — "Add small required context fields (unknown/not-applicable allowed), retain reproduction details and remove the duplicated platform instruction from that field. No product boundary change or new test that only mirrors form prose." Each of the three descriptions names the honest escape value (`unknown`, `not applicable`), which keeps the guide's conditional tool scoping satisfiable instead of forcing a fabricated answer.

## Spec refs

No boundary change. No handle ownership, crash ownership or principal minting is touched. The owning contract is `CONTRIBUTING.md` § Find a useful change; `tools/atomic_protocol.rs` `check_public_intake` and `tools/ci_hygiene.rs` `check_issue_templates` own the template's structural invariants and both still pass.

## Review gates

- `unsafe`: none
- public API: none — the changed surface is the public GitHub intake form, not a published Rust/TypeScript item or generated contract. `CONTRIBUTING.md` remains the single owner of what reporters must supply; this form is its consumer and was brought back into agreement rather than given its own policy.
- permission model: none
- dependency addition: none
- wire protocol: none

## Tests

`just ci` — exit **100**, failing only at the `test` recipe on two pre-existing `keld-host::no_flag_macos` failures that are unrelated to this diff (see Platforms). Every gate before it passed:

```
agents-md ok
atomic-protocol            test result: ok. 30 passed; 0 failed
agent-context              test result: ok. 14 passed; 0 failed
ci-router-test             ci-required contract tests ok / dependency metadata contract tests ok
hooks-test                 hooks checkout trust-boundary test ok
doc-placeholders-test      test result: ok. 14 passed; 0 failed
doc-placeholders-check     doc-placeholders ok: 68 document(s), 13 known placeholder(s) all in use
mermaid-test               test result: ok. 7 passed; 0 failed
mermaid-check              mermaid-docs ok: 9 diagram(s) validated
mermaid-render-check       mermaid-render ok: 9 diagram(s), official CLI 11.16.0 image
                           sha256:29077c6bd02f14bdfdd5fee552d9c00fe68d4fab3cd84952d21e2d1faf2fadaf
product-status-test        test result: ok. 82 passed; 0 failed
product-status-check       target/product-status/product-status check .   (silent, exit 0)
llms-test                  test result: ok. 8 passed; 0 failed
llms-check                 target/llms-docs/llms-docs check .             (silent, exit 0)
hygiene                    CI workflow security semantics ok
typescript                 bun install --frozen-lockfile / bun run typecheck / bun test  (93 passed; 0 failed)
fmt-check                  cargo fmt --all --check                        (silent, exit 0)
clippy                     cargo clippy --workspace --all-targets -- -D warnings  (no warnings)
test                       Summary [47.063s] 485/680 tests run: 483 passed, 2 failed, 4 skipped
                           error: recipe `test` failed on line 202 with exit code 100
```

`doc` and `deny` never ran under `just ci` because `test` aborts the dependency chain, so they were run separately rather than reported unrun:

```
just doc    → Finished `dev` profile ... Generated target/doc/keld_cli/index.html and 14 other files   DOC_EXIT=0
just deny   → advisories ok, bans ok, licenses ok, sources ok                                          DENY_EXIT=0
            (pre-existing benign warning[license-not-encountered] for tao v0.35.3 / wry v0.56.1)
```

No new test. Comment `8058ebd1` explicitly excludes "a new test that only mirrors form prose", and no checker string-matches this file's field text — `rg 'Keld commit|OS/architecture|Relevant tool versions|platform \(OS|Verification gate' tools/ .github/workflows/ justfile` returns no matches — so the template's real contract is the structural one already enforced by `atomic-protocol` and `hygiene`, both of which ran green above. The structural invariants were also checked directly on the new file: exactly one top-level `body:`, exactly one `CONTRIBUTING.md` link, eight unique `id`s, and `platform (OS + version)` count 1 → 0.

## Platforms

- macOS 26.x arm64 (`CENTILLIONAIREs-Mac-mini.local`): full local gate run as above.
- The two failures — `shipping_keld_dev_delegates_to_host_and_cli_death_reaps_the_session` and `shipping_keld_dev_lease_loss_reaps_the_recovered_generation` — both panic at `crates/keld-host/tests/no_flag_macos.rs:1135` on `assert_eq!(host_unix_sockets(cli_pid), 0)` with `left: 2, right: 0`. They are **not caused by this diff**, which changes one YAML form and no Rust: the Cursor shell hands every child two non-close-on-exec Unix-domain sockets on fds 3 and 4, and the CLI under test inherits them, so the descriptor census sees 2 instead of 0. Closing those fds makes the same commit pass the whole suite:

  ```
  just test 3>&- 4>&-
  Summary [49.595s] 680 tests run: 680 passed, 4 skipped
  TEST_FDCLOSED_EXIT=0
  ```

  KEL-222 owns that repair (PR #215, `crates/keld-host/tests/no_flag_macos.rs`). These failures are attributed, not passing, and not caused here.
- No real-OS/device acceptance criterion applies. GitHub renders the issue form server-side from the merged `main` template; no Keld host, webview or OS API is exercised. Remaining OS handoff: none.
- Windows and Linux: unverified locally and not required — the diff is platform-independent YAML with no Rust, TypeScript or platform code path.

## Perf impact

none

## Linear

KEL-227 (child of KEL-177). Approval trail: KEL-179 comment `8058ebd1`. Branched from `origin/main` `9ad79936f7b999b960846c850c83790306525c17`.

## Rollback

Revert this single-file commit. The form returns to the prior five fields and re-opens the documented gap; no data migration, generated artifact or contract is involved.

## Review record

**CodeRabbit reviewed this exact tip.** GitHub-side review completed at 2026-09-10T15:09:44Z on commit `0c0ddd055af7e4f722dbde0ee8783bcb854dc4b3`; its own record reads "Reviewing files that changed from the base of the PR and between 9ad79936f7b999b960846c850c83790306525c17 and 0c0ddd055af7e4f722dbde0ee8783bcb854dc4b3", result "No actionable comments were generated". Zero review threads. The CodeRabbit CLI independently reviewed the same tree earlier: `{"type":"complete","status":"review_completed","findings":0,"reviewedFiles":[".github/ISSUE_TEMPLATE/bug.yml"]}`.

The bot's **first** attempt was rate limited and set the `CodeRabbit` check to `state=success description=Review rate limited` with a "Review limit reached" comment. That green check was not a review and was not counted as one; the review above was requested after the limit lifted.

**Isolated adversarial substitute** was also run, because the rate-limited pass could not be treated as review. Two reviewers, separate named lenses, neither given the author's rationale, each required to verify by running behavior rather than trusting the PR body:

- Lens *public-intake contract conformance and repository-checker breakage*: no findings. It independently mapped all six `CONTRIBUTING.md` items to exactly one field each with no gap and no duplication, and independently confirmed by running `just atomic-protocol`, `just hygiene`, `just ci-router-test`, `just agent-context`, `just llms-check` (all exit 0) that no checker is broken, that `.github/ISSUE_TEMPLATE/bug.yml` is not an agent-instruction file under `tools/agent_context.rs` `is_instruction_path`, and that it is not in the `tools/llms_docs.rs` `SOURCES` allowlist. It also confirmed `tools/ci_changes.sh` routes this path to the hygiene lane (`hygiene=true`), matching the CI result above.
- Lens *GitHub issue-forms schema validity and reporter completion cost*: one warning, refuted (below). It otherwise validated every new key against GitHub's published schema and against SchemaStore's `github-issue-forms.json` (`additionalProperties: false`, validates clean), confirmed all eight `id`s legal and unique, confirmed each new `description` parses to exactly its raw text with no YAML surprise, and confirmed no information is now requested twice.

**Finding raised, and refuted by an independent refuter:** that newly-required `platform` lacks the "state unknown" escape its sibling new required fields carry, so some reporter would be forced to abandon the form or type something false. **Refuted:** the mechanism does not exist. GitHub's schema gives `input` no content or format validation at all — `required` is documented solely as "Prevents form submission until element is completed" — and `platform` is free text, so a reporter who cannot pin their architecture types `macOS, not sure which chip` and submits successfully. The escape sentences confer no submission capability that `platform` lacks. Nothing in `tools/` or `.github/workflows/` reads these field ids, labels or descriptions, so nothing breaks.

What the refutation did improve is the articulation of *why* the phrasing differs, which is recorded here as intent rather than left to read as oversight. The template uses four deliberate patterns, and each new field lands in the one the guide's own scoping dictates:

1. Data that may legitimately be absent → not `required` at all: `linear` ("Leave blank otherwise"), `gate` ("if you ran them").
2. An ask the guide scopes **conditionally** → required, with the condition named: `tools`. The guide asks for tool versions only "for Rust reports", "for workspace tests" and "for Bun-dependent behavior", so "State not applicable when none apply" is the only faithful rendering of that ask, not a courtesy.
3. An unconditional ask whose artifact can still be genuinely unobtainable → required, with the residual case named: `commit`. The description already offers `git rev-parse HEAD`, a tag, or an installed version; "State unknown if you cannot determine it" covers only the leftover case of a prebuilt install carrying no VCS metadata.
4. An unconditional ask that is a property of the reporter's own machine → required, no escape: `platform`. The guide asks for OS/architecture with no condition attached, it is obtainable with `uname -sm`, and the placeholder `macOS 26.5, arm64` already shows the expected shape. Adding an "unknown" escape here would invite a blank answer to an unconditional ask and would weaken the one field that discriminates Keld's platform-specific paths.
