### PR TITLE
test(runtime): cover FIONREAD-failure wake in retire_unix_capture

### DIFF
--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -1640,6 +1640,7 @@ struct UnixCaptureFaults {
     read_interruptions: AtomicU8,
     wake_interruptions: AtomicU8,
     fionread_interruptions: AtomicU8,
+    fionread_failures: AtomicU8,
     poll_calls: AtomicU8,
     read_calls: AtomicU8,
     wake_calls: AtomicU8,
@@ -1914,6 +1915,9 @@ fn retire_unix_capture(control: Option<&UnixCaptureControl>) -> std::io::Result<
             control.faults.fionread_calls.fetch_add(1, Ordering::AcqRel);
             if consume_test_interruption(&control.faults.fionread_interruptions) {
                 return Err(rustix::io::Errno::INTR);
+            }
+            if consume_test_interruption(&control.faults.fionread_failures) {
+                return Err(rustix::io::Errno::BADF);
             }
         }
         rustix::io::ioctl_fionread(&control.reader)
@@ -4019,6 +4023,39 @@ mod tests {
             0
         );
         assert_eq!(control.faults.wake_interruptions.load(Ordering::Acquire), 0);
+        drop(writer);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_capture_retirement_wakes_the_worker_when_fionread_fails() {
+        let (reader, writer) = UnixStream::pair().expect("native capture pipe");
+        let output = Arc::new(Mutex::new(
+            CaptureState::new(&[]).expect("empty marker set"),
+        ));
+        let (worker, control) = spawn_capture_thread(reader, output, "fionread-fail", true)
+            .expect("spawn capture worker");
+        await_atomic_at_least(&control.faults.poll_calls, 1, "capture worker entered poll");
+        control.faults.fionread_failures.store(1, Ordering::Release);
+
+        let error = retire_unix_capture(Some(&control))
+            .expect_err("injected FIONREAD failure must surface a typed error");
+        assert_eq!(
+            error.raw_os_error(),
+            Some(rustix::io::Errno::BADF.raw_os_error())
+        );
+        assert_eq!(control.faults.fionread_failures.load(Ordering::Acquire), 0);
+        assert!(control.faults.fionread_calls.load(Ordering::Acquire) >= 1);
+
+        let (done_tx, done_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let result = join_capture_thread(Some(worker), "fionread-fail");
+            let _ = done_tx.send(result);
+        });
+        let joined = done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("FIONREAD-failure wake must unblock the parked capture worker");
+        joined.expect("capture worker exits after FIONREAD-failure wake");
         drop(writer);
     }
 


### PR DESCRIPTION
## Summary
- The FIONREAD `Err` arm in `retire_unix_capture` already writes the wake byte; nothing exercised it, so deleting that write left the suite green.
- This adds `fionread_failures` to the existing `UnixCaptureFaults` injector and a regression that parks the worker, injects a non-INTR ioctl failure, and requires the typed error plus `join_capture_thread` completion.

## Spec refs
No boundary change

## Review gates
none

## Tests
- Failure-first throwaway (`/tmp/keld-kel-223-ff`) with the wake write deleted: `tests::unix_capture_retirement_wakes_the_worker_when_fionread_fails` FAILED in 2.01s (`Timeout`).
- Same test with the wake present: `ok` in 0.00s.
- `cargo fmt --all --check` passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- `just ci` ran the exact inventory through `test`; `test` exited 100 on two `keld-host::no_flag_macos` failures (`shipping_keld_dev_delegates_to_host_and_cli_death_reaps_the_session`, `shipping_keld_dev_lease_loss_reaps_the_recovered_generation`) asserting `host_unix_sockets(cli_pid) == 0` with left=2. KEL-222 owns that Cursor-leaked fd 3/4 census; assertions were not weakened.
- `cargo nextest run --workspace --profile ci --no-fail-fast`: 681 tests run, 679 passed, 2 failed (the same two), 4 skipped. New test PASS.
- `just doc` exit 0; `just deny` exit 0 (`advisories ok, bans ok, licenses ok, sources ok`).
- Preceding `just ci` recipes (`agents-md`, `atomic-protocol`, `agent-context`, `ci-router-test`, `hooks-test`, `doc-placeholders`, mermaid, `product-status`, `llms`, hygiene, typescript, `fmt-check`, clippy) passed.

## Platforms
- Exercised: macOS 26.5.1 arm64 (`CENTILLIONAIREs-Mac-mini.local`) Unix unit test.
- CI automation: the `#[cfg(unix)]` test runs on macOS and Linux CI; Windows does not compile this path.
- Unverified: Linux and Windows product devices (acceptance is CI-only).

## Perf impact
none

## Linear
https://linear.app/gyldlab-keld/issue/KEL-223/testruntime-the-fionread-failure-wake-in-retire-unix-capture-is