### PR TITLE
test(runtime): pin capture retention ceiling value

### DIFF
--- a/crates/keld-runtime/src/lib.rs
+++ b/crates/keld-runtime/src/lib.rs
@@ -4778,6 +4778,23 @@ mod tests {
         assert_eq!(termination.stdout_len, ledger.stdout_len_at_last_crash);
     }
 
+    /// KEL-225: pin the public ceiling *value*. Boundedness tests compare
+    /// retained length to [`CAPTURE_MAX_RETAINED_BYTES`] and size fixtures from
+    /// the same symbols, so scaling the constants used to stay green. This
+    /// literal cannot track the production definition.
+    #[test]
+    fn capture_max_retained_bytes_is_the_documented_host_ceiling() {
+        assert_eq!(
+            CAPTURE_MAX_RETAINED_BYTES, 327_680,
+            "CAPTURE_MAX_RETAINED_BYTES is the host-memory budget for one \
+             untrusted child stream: 64 KiB pinned head + 192 KiB sliding tail \
+             + 64 KiB compaction slack (KEL-134). Changing the public CAPTURE_* \
+             constants is a contract change and must be an explicit decision; \
+             the self-referential `<= CAPTURE_MAX_RETAINED_BYTES` assertions \
+             still pass if the ceiling is silently doubled"
+        );
+    }
+
     /// KEL-134 storage bound, isolated from process spawning.
     ///
     /// This is the negative control for the retention cap: raising
@@ -5206,7 +5223,13 @@ mod tests {
         // Two orders of magnitude past the retention ceiling, still ~1s of pipe
         // traffic. Large enough that unbounded retention is unmistakable.
         let target_bytes = CAPTURE_MAX_RETAINED_BYTES * 200;
-        let rss_growth_ceiling = 32 * 1024 * 1024;
+        // Host RSS is not 1:1 with retained bytes: the soak process also holds
+        // the supervisor, pipes, and allocator slack. Bound growth to 100× the
+        // documented per-stream ceiling so the budget tracks the quantity it
+        // guards instead of a stale 32 MiB constant. Unmutated macOS peak
+        // growth was ~2 MiB; 100× (≈31.25 MiB) keeps the previous host-memory
+        // intent.
+        let rss_growth_ceiling = CAPTURE_MAX_RETAINED_BYTES * 100;
         let baseline_rss = process_rss_bytes();
         #[cfg(unix)]
         assert!(


### PR DESCRIPTION
## Summary
- Pin `CAPTURE_MAX_RETAINED_BYTES` to the literal `327_680` so doubling the public `CAPTURE_*` constants turns a test red. Boundedness assertions that compare retained length to the same symbol stay as they are.
- Derive the soak RSS growth budget from that ceiling (`CAPTURE_MAX_RETAINED_BYTES * 100`, ≈31.25 MiB) instead of a hard-coded 32 MiB, so the host-memory oracle tracks the quantity it guards.
- Production capture behavior and the public `CAPTURE_*` values are unchanged. This is not a KEL-134 reopen.

## Spec refs
No boundary change

## Review gates
none

## Tests
- Failure-first (throwaway 2× of `CAPTURE_HEAD_BYTES` / `CAPTURE_TAIL_BYTES` / `CAPTURE_COMPACTION_SLACK_BYTES`, then restore): `tests::capture_max_retained_bytes_is_the_documented_host_ceiling` red with `left: 655360` / `right: 327680`.
- Restored constants: the same pin and `continuous_output_soak_keeps_memory_bounded` both pass.
- `just ci` inventory on this tip (`95ca44a`), macOS 26.5.1 arm64:
  - `agents-md`, `atomic-protocol`, `agent-context`, `ci-router-test`, `hooks-test`, `doc-placeholders-*`, `mermaid-*`, `product-status-*`, `llms-*`, `hygiene`, `typescript` (41 pass / 0 fail): passed
  - `cargo fmt --all --check`: passed
  - `cargo clippy --workspace --all-targets -- -D warnings`: passed
  - `cargo nextest run --workspace --profile ci`: fail-fast stopped on the two known `keld-host::no_flag_macos` KEL-222 / PR #215 leaks (`host_unix_sockets(cli_pid)` 2 != 0). Those two pass under `3>&- 4>&-`. Not fixed here (host off-limits). Remainder excluding those two: 679 passed, 6 skipped.
  - `just doc` and `just deny`: passed (`advisories ok, bans ok, licenses ok, sources ok`)

## Platforms
CI-only: the new oracle is an in-process literal over retained bytes. Exercised on macOS 26.5.1 arm64. Windows/Linux 2× mutation unmeasured (issue not-verified #2). Real-OS acceptance is not-applicable per KEL-225 AC4.

## Perf impact
none

## Linear
KEL-225