### PR TITLE
test(wv): prove Windows media guard installation

### DIFF
--- a/crates/keld-wv/Cargo.toml
+++ b/crates/keld-wv/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[features]
+# Explicit development fixture; absent from the shipping default build.
+media-acceptance = []
+
 [dependencies]
 # Media-capture default-deny (KEL-59): evaluate `web.camera` / `web.microphone`
 # on the live WKWebView permission callback. Sibling crate, not an upward edge.

--- a/crates/keld-wv/src/media.rs
+++ b/crates/keld-wv/src/media.rs
@@ -62,6 +62,21 @@ pub const WEB_MEDIA_ORIGIN: &str = "*";
 /// slice (spec 03).
 const WEBVIEW_MEDIA_GENERATION: u32 = 0;
 
+/// Stable fixture fingerprint for the parsed manifest bytes represented by the
+/// guard's canonical debug form. Both Linux and Windows acceptance emit this
+/// value so their external runners can reject a substituted manifest.
+#[cfg(any(
+    all(target_os = "linux", debug_assertions),
+    all(target_os = "windows", feature = "media-acceptance", test)
+))]
+pub(crate) fn manifest_fingerprint(manifest: &PermissionsManifest) -> u64 {
+    format!("{manifest:?}")
+        .bytes()
+        .fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| {
+            (hash ^ u64::from(byte)).wrapping_mul(0x100_0000_01b3)
+        })
+}
+
 /// Media kinds the platform backends map their permission callbacks onto.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MediaPermission {
@@ -110,7 +125,7 @@ pub fn media_permission_decision(
     principal: Option<Principal>,
     capability: &str,
 ) -> Decision {
-    match principal {
+    let decision = match principal {
         Some(webview @ Principal::Webview { .. }) => {
             evaluate(manifest, webview, capability, WEB_MEDIA_ORIGIN)
         }
@@ -118,7 +133,12 @@ pub fn media_permission_decision(
             capability: capability.to_owned(),
             presented,
         }),
-    }
+    };
+    #[cfg(all(target_os = "windows", feature = "media-acceptance", test))]
+    crate::webview2::media_acceptance::observe_adapter_decision(
+        manifest, principal, capability, &decision,
+    );
+    decision
 }
 
 /// Whether `kind` is allowed by `manifest` for `principal`.
@@ -370,11 +390,7 @@ fn trace_linux_policy_decision(
     let Ok(mut trace) = OpenOptions::new().create(true).append(true).open(path) else {
         return;
     };
-    let manifest_fingerprint = format!("{manifest:?}")
-        .bytes()
-        .fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| {
-            (hash ^ u64::from(byte)).wrapping_mul(0x100_0000_01b3)
-        });
+    let manifest_fingerprint = manifest_fingerprint(manifest);
     let _ = writeln!(
         trace,
         "policy nonce={nonce} capability={capability} principal=webview:{id}:{generation} manifest_fnv1a64={manifest_fingerprint:016x} decision={decision} response={response} pid={}",
@@ -406,7 +422,7 @@ mod tests {
             .split_once("fn install_guarded_media_permissions(")
             .expect("Windows guard installer exists")
             .1
-            .split_once("Ok(GuardInstalled(()))")
+            .split_once("Ok(GuardInstalled(webview))")
             .expect("guard installer returns its navigation witness")
             .0;
         assert!(
@@ -427,6 +443,16 @@ mod tests {
 
     fn camera_grant() -> PermissionsManifest {
         parse_manifest(r#"{"app":{"web":{"camera":["*"]}}}"#).expect("camera grant")
+    }
+
+    #[cfg(all(target_os = "windows", feature = "media-acceptance"))]
+    #[test]
+    fn acceptance_manifest_fingerprints_are_fixed_external_identities() {
+        let empty = PermissionsManifest::default();
+        let app_grants = parse_manifest(r#"{"app":{"web":{"camera":["*"],"microphone":["*"]}}}"#)
+            .expect("acceptance app grants");
+        assert_eq!(manifest_fingerprint(&empty), 0xe117_3119_75d9_f419);
+        assert_eq!(manifest_fingerprint(&app_grants), 0x1fb6_f771_494b_3631);
     }
 
     #[test]

--- a/crates/keld-wv/src/webview2/media_acceptance.rs
+++ b/crates/keld-wv/src/webview2/media_acceptance.rs
@@ -1,0 +1,904 @@
+//! Opt-in Windows fixture. This module is absent from default shipping builds.
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::cell::RefCell;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use keld_guard::{Decision, PermissionsManifest, Principal};
+use tao::platform::windows::EventLoopBuilderExtWindows;
+use webview2_com::Microsoft::Web::WebView2::Win32::{
+    COREWEBVIEW2_PERMISSION_KIND, COREWEBVIEW2_PERMISSION_KIND_CAMERA,
+    COREWEBVIEW2_PERMISSION_KIND_MICROPHONE, COREWEBVIEW2_PERMISSION_STATE,
+    COREWEBVIEW2_PERMISSION_STATE_ALLOW, COREWEBVIEW2_PERMISSION_STATE_DEFAULT,
+    COREWEBVIEW2_PERMISSION_STATE_DENY, ICoreWebView2Environment5, ICoreWebView2Environment7,
+    ICoreWebView2PermissionRequestedEventArgs,
+};
+use webview2_com::{BrowserProcessExitedEventHandler, WebMessageReceivedEventHandler};
+use windows::Win32::Foundation::{E_UNEXPECTED, LPARAM, WPARAM};
+use windows::Win32::System::Com::CoTaskMemFree;
+use windows::Win32::System::Threading::GetCurrentThreadId;
+use windows::Win32::UI::WindowsAndMessaging::{PostThreadMessageW, WM_NULL};
+use windows::core::{Interface, PWSTR};
+
+use super::{
+    AppWindowCommand, COINIT_APARTMENTTHREADED, CoInitializeEx, CoreWebView2EnvironmentOptions,
+    E_POINTER, EventLoopBuilder, NavTarget, PermissionRequestedEventHandler, WebEngine,
+    WebView2Engine, WebviewSpec, WvError, create_environment_with_options, runtime_version,
+    wait_with_pump, webview_media_principal,
+};
+use crate::{LogicalSize, media::manifest_fingerprint};
+use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2;
+
+#[derive(Default)]
+struct Evidence {
+    active: bool,
+    manifest: Option<PermissionsManifest>,
+    registration: Option<(usize, i64)>,
+    adapter_decisions: Vec<(u64, Option<Principal>, String, String, u32)>,
+    effects: Vec<(i32, i32, i32, i32, String, usize, u32)>,
+}
+
+thread_local! {
+    static EVIDENCE: RefCell<Evidence> = RefCell::new(Evidence::default());
+}
+
+pub(super) fn fixture_manifest() -> PermissionsManifest {
+    EVIDENCE.with_borrow_mut(|e| e.manifest.take().unwrap_or_default())
+}
+
+pub(super) fn observe_registration(identity: usize, token: i64) {
+    EVIDENCE.with_borrow_mut(|e| {
+        if e.active {
+            e.registration = Some((identity, token));
+        }
+    });
+}
+
+pub(crate) fn observe_adapter_decision(
+    manifest: &PermissionsManifest,
+    principal: Option<Principal>,
+    capability: &str,
+    decision: &Decision,
+) {
+    EVIDENCE.with_borrow_mut(|evidence| {
+        if evidence.active {
+            let code = match decision {
+                Decision::Allow => "allow",
+                Decision::Deny(reason) => reason.code(),
+            };
+            // SAFETY: querying the current thread needs no handles or initialization.
+            let tid = unsafe { GetCurrentThreadId() };
+            evidence.adapter_decisions.push((
+                manifest_fingerprint(manifest),
+                principal,
+                capability.to_owned(),
+                code.to_owned(),
+                tid,
+            ));
+        }
+    });
+}
+
+pub(super) fn observe_production_effect(
+    kind: COREWEBVIEW2_PERMISSION_KIND,
+    before: COREWEBVIEW2_PERMISSION_STATE,
+    requested: COREWEBVIEW2_PERMISSION_STATE,
+    after: COREWEBVIEW2_PERMISSION_STATE,
+    uri: String,
+    sender_identity: usize,
+) {
+    EVIDENCE.with_borrow_mut(|evidence| {
+        if evidence.active {
+            // SAFETY: the current-thread query has no preconditions.
+            let tid = unsafe { GetCurrentThreadId() };
+            evidence.effects.push((
+                kind.0,
+                before.0,
+                requested.0,
+                after.0,
+                uri,
+                sender_identity,
+                tid,
+            ));
+        }
+    });
+}
+
+pub(super) fn permission_uri(
+    args: &ICoreWebView2PermissionRequestedEventArgs,
+) -> windows::core::Result<String> {
+    let mut pointer = PWSTR::null();
+    // SAFETY: the callback owns live args and this is a writable LPWSTR output.
+    unsafe { args.Uri(&raw mut pointer) }?;
+    if pointer.is_null() {
+        return Err(windows::core::Error::from(E_POINTER));
+    }
+    // SAFETY: successful Uri returned one COM-allocated NUL-terminated string.
+    let value = unsafe { pointer.to_string() };
+    // SAFETY: release that allocation exactly once after decoding it.
+    unsafe { CoTaskMemFree(Some(pointer.as_ptr().cast())) };
+    Ok(value?)
+}
+
+fn failure(detail: impl std::fmt::Display) -> WvError {
+    WvError::Webview(format!("media acceptance: {detail}"))
+}
+
+fn send_and_wake<T>(sender: &mpsc::Sender<T>, value: T) -> windows::core::Result<()> {
+    sender
+        .send(value)
+        .map_err(|_| windows::core::Error::from(E_UNEXPECTED))?;
+    // SAFETY: callbacks run on the owning UI STA after tao created its queue.
+    // GetMessage can dispatch a sent COM message without returning. A posted
+    // WM_NULL makes wait_with_pump return to its receiver check even in that case.
+    // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmessagew
+    unsafe { PostThreadMessageW(GetCurrentThreadId(), WM_NULL, WPARAM(0), LPARAM(0)) }
+}
+
+fn owned_string(pointer: PWSTR) -> Result<String, WvError> {
+    if pointer.is_null() {
+        return Err(failure("COM returned a null string"));
+    }
+    // SAFETY: callers pass successful WebView2 LPWSTR getter output. Decode before
+    // releasing its single COM allocation, including on UTF-16 decode failure.
+    let value = unsafe { pointer.to_string() };
+    // SAFETY: this is the allocation returned by the successful getter above.
+    unsafe { CoTaskMemFree(Some(pointer.as_ptr().cast())) };
+    value.map_err(failure)
+}
+
+fn same_directory(actual: &str, expected: &Path) -> Result<(), WvError> {
+    let actual = std::fs::canonicalize(actual).map_err(failure)?;
+    let expected = std::fs::canonicalize(expected).map_err(failure)?;
+    if actual != expected {
+        return Err(failure(format!(
+            "UDF override: actual={} expected={}",
+            actual.display(),
+            expected.display()
+        )));
+    }
+    Ok(())
+}
+
+/// Runs one real `WebView2` media-callback case on the libtest-owned Windows UI thread.
+///
+/// Enabled only in the libtest executable by the non-default `media-acceptance`
+/// development feature. `KELD_MEDIA_KIND`, `KELD_MEDIA_MODE`, and
+/// `KELD_MEDIA_MANIFEST` select the row. Controls install no Keld adapter and must be
+/// rejected by the same provenance oracle. Fake capture devices
+/// are confined to a newly created, read-back-verified fixture profile. No fake-UI
+/// flag is used; force-allow replaces only this fixture's callback to qualify its
+/// synthetic devices. The fixture exits 124 if its process deadline expires.
+/// This proves callback provenance, not profile
+/// restart/revocation or absence of every transient platform prompt.
+///
+/// # Errors
+/// Returns an error for missing runtime, API/identity/receipt failures, unexpected
+/// JavaScript behavior, a control accepted by the oracle, or incomplete cleanup.
+fn run_media_acceptance() -> Result<(), WvError> {
+    let kind = std::env::var("KELD_MEDIA_KIND")
+        .map_err(|_| failure("KELD_MEDIA_KIND must be camera or microphone"))?;
+    let mode = std::env::var("KELD_MEDIA_MODE").map_err(|_| {
+        failure("KELD_MEDIA_MODE must be guarded, removed-guard, adapter-bypass, or force-allow")
+    })?;
+    let (constraints, track_kind) = match kind.as_str() {
+        "camera" => ("{video:true}", "video"),
+        "microphone" => ("{audio:true}", "audio"),
+        _ => return Err(failure("unknown media kind")),
+    };
+    if !matches!(
+        mode.as_str(),
+        "guarded" | "removed-guard" | "adapter-bypass" | "force-allow"
+    ) {
+        return Err(failure("unknown control mode"));
+    }
+    let manifest_case = std::env::var("KELD_MEDIA_MANIFEST")
+        .map_err(|_| failure("KELD_MEDIA_MANIFEST must be empty or app-grants"))?;
+    let manifest = match manifest_case.as_str() {
+        "empty" => PermissionsManifest::default(),
+        "app-grants" => {
+            keld_guard::parse_manifest(r#"{"app":{"web":{"camera":["*"],"microphone":["*"]}}}"#)
+                .map_err(failure)?
+        }
+        _ => return Err(failure("unknown manifest case")),
+    };
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(failure)?
+        .as_nanos();
+    let directory = std::env::temp_dir().join(format!("keld-media-{}-{nonce}", std::process::id()));
+    std::fs::create_dir(&directory).map_err(failure)?;
+    println!("KELD_MEDIA_PROFILE {}", directory.display());
+    let result = run_case(
+        &kind,
+        &mode,
+        constraints,
+        track_kind,
+        nonce,
+        &directory,
+        manifest,
+    );
+    // run_case must finish the browser-release barrier before returning success.
+    // On error preserve the exact directory for diagnosis; never retry removal.
+    if result.is_ok() {
+        std::fs::remove_dir_all(&directory).map_err(failure)?;
+    } else {
+        eprintln!("KELD_MEDIA_RETAINED {}", directory.display());
+    }
+    result
+}
+
+fn blank_spec() -> WebviewSpec {
+    WebviewSpec {
+        title: "Keld media acceptance".to_owned(),
+        initial: NavTarget::Html("<!doctype html><title>setup</title>".to_owned()),
+        size: LogicalSize {
+            width: 640.0,
+            height: 480.0,
+        },
+    }
+}
+
+fn media_spec(url: String) -> WebviewSpec {
+    WebviewSpec {
+        title: "Keld media acceptance".to_owned(),
+        initial: NavTarget::Url(url),
+        size: LogicalSize {
+            width: 640.0,
+            height: 480.0,
+        },
+    }
+}
+
+fn destroy_primers(
+    engine: &mut WebView2Engine,
+    count: usize,
+) -> Result<Option<crate::WebviewId>, WvError> {
+    let blank = blank_spec();
+    let mut last = None;
+    for _ in 0..count {
+        let primer = engine.create(&blank)?;
+        engine.destroy(primer)?;
+        if !matches!(
+            engine.navigate(primer, NavTarget::Html(String::new())),
+            Err(WvError::UnknownWebview { .. })
+        ) {
+            return Err(failure("destroyed view remained navigable"));
+        }
+        last = Some(primer);
+    }
+    Ok(last)
+}
+
+fn run_case(
+    kind: &str,
+    mode: &str,
+    constraints: &str,
+    track_kind: &str,
+    nonce: u128,
+    directory: &Path,
+    manifest: PermissionsManifest,
+) -> Result<(), WvError> {
+    let runtime = runtime_version()?;
+    let mut event_loop = EventLoopBuilder::<AppWindowCommand>::with_user_event();
+    // The ignored libtest entrypoint runs on a harness worker. Windows supports
+    // a dedicated UI/message thread; every COM object and callback remains on
+    // this same fixture thread.
+    event_loop.with_any_thread(true);
+    let event_loop = event_loop.build();
+    // SAFETY: all COM work is confined to this fixture-owned UI STA.
+    unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) }
+        .ok()
+        .map_err(failure)?;
+    // SAFETY: thread ID query is unconditional.
+    let tid = unsafe { GetCurrentThreadId() };
+    let (done_tx, done_rx) = mpsc::channel::<()>();
+    let watchdog = thread::spawn(move || {
+        if done_rx.recv_timeout(Duration::from_secs(30)) == Err(mpsc::RecvTimeoutError::Timeout) {
+            // This opt-in fixture is a disposable process. A process deadline also
+            // bounds nested creation/cleanup pumps; one consumed WM_QUIT cannot do so.
+            eprintln!("KELD_MEDIA_TIMEOUT: fixture exceeded 30 seconds; profile retained");
+            std::process::exit(124);
+        }
+    });
+    let environment = fixture_environment(directory)?;
+    let mut engine = WebView2Engine::from_environment(event_loop, environment.clone());
+    let primer_count = if kind == "camera" { 1 } else { 2 };
+    let last_primer = destroy_primers(&mut engine, primer_count)?;
+    let listener = TcpListener::bind("127.0.0.1:0").map_err(failure)?;
+    let address = listener.local_addr().map_err(failure)?;
+    let url = format!("http://{address}/{nonce}/");
+    let expected_origin = format!("http://{address}/");
+    let html = format!(
+        r"<!doctype html><script>
+(async()=>{{await fetch('/{nonce}/release',{{cache:'no-store'}});
+try{{const stream=await navigator.mediaDevices.getUserMedia({constraints});
+const matching=stream.getTracks().filter(track=>track.kind==='{track_kind}'&&track.readyState==='live');
+if(matching.length===0)throw new DOMException('no requested live track','KeldNoLiveTrack');
+for(const track of stream.getTracks())track.stop();
+chrome.webview.postMessage('{nonce}:resolved:{track_kind}:'+matching.length+':'+matching.every(track=>track.readyState==='ended'));
+}}catch(error){{chrome.webview.postMessage('{nonce}:'+window.isSecureContext+':'+error.name)}}}})();
+</script>"
+    );
+    let (release_tx, release_rx) = mpsc::channel();
+    let server = serve_page(listener, html, nonce, release_rx);
+    let expected_manifest = manifest_fingerprint(&manifest);
+    EVIDENCE.with_borrow_mut(|e| {
+        *e = Evidence {
+            active: true,
+            manifest: Some(manifest),
+            ..Evidence::default()
+        };
+    });
+    // Use the production constructor's first navigation. The page blocks on
+    // its nonce-bound release request until the independent observers exist.
+    let media_id = engine.create(&media_spec(url.clone()))?;
+    if last_primer == Some(media_id) {
+        return Err(failure("view id was reused"));
+    }
+    let principal = webview_media_principal(media_id);
+    let view = engine.view(media_id)?;
+    let mut browser_pid = 0;
+    // SAFETY: live view and writable process id on the creating STA.
+    unsafe { view.webview.BrowserProcessId(&raw mut browser_pid) }.map_err(failure)?;
+    println!(
+        "KELD_MEDIA_VIEW id={} browser_pid={browser_pid}",
+        media_id.0
+    );
+    let environment5: ICoreWebView2Environment5 = environment.cast().map_err(failure)?;
+    let (exit_rx, exit_token) = observe_browser_exit(&environment5, browser_pid)?;
+    let registration = EVIDENCE.with_borrow(|e| e.registration);
+    let Some((identity, token)) = registration else {
+        return Err(failure("production constructor did not register media"));
+    };
+    if identity != super::canonical_webview_identity(&view.webview).map_err(failure)? {
+        return Err(failure("registration belongs to another view"));
+    }
+    if mode != "guarded" {
+        // SAFETY: token was recorded from this live view's actual registration.
+        unsafe { view.webview.remove_PermissionRequested(token) }.map_err(failure)?;
+    }
+    let message_rx = observe_request(&view.webview, mode, &url)?;
+    release_tx
+        .send(())
+        .map_err(|_| failure("HTTP release receiver closed"))?;
+    let result = wait_with_pump(message_rx).map_err(failure)?;
+    println!("KELD_MEDIA_PROMISE {result:?}");
+    let server_result = server.join().map_err(|_| failure("HTTP server panicked"))?;
+    engine.destroy(media_id)?;
+    println!("KELD_MEDIA_CLOSED waiting_for={browser_pid}");
+    drop(engine);
+    wait_with_pump(exit_rx).map_err(failure)??;
+    // SAFETY: remove this environment's callback only after its matching exit.
+    unsafe { environment5.remove_BrowserProcessExited(exit_token) }.map_err(failure)?;
+    drop(environment5);
+    drop(environment);
+    let _ = done_tx.send(());
+    watchdog.join().map_err(|_| failure("watchdog panicked"))?;
+    server_result.map_err(failure)?;
+    validate(Validation {
+        kind,
+        mode,
+        nonce,
+        principal,
+        tid,
+        manifest: expected_manifest,
+        origin: &expected_origin,
+        registration_identity: identity,
+        view_id: media_id.0,
+        browser_pid,
+        result: &result?,
+        runtime: &runtime,
+    })
+}
+
+#[derive(Clone, Copy)]
+struct Validation<'a> {
+    kind: &'a str,
+    mode: &'a str,
+    nonce: u128,
+    principal: Principal,
+    tid: u32,
+    manifest: u64,
+    origin: &'a str,
+    registration_identity: usize,
+    view_id: u32,
+    browser_pid: u32,
+    result: &'a str,
+    runtime: &'a str,
+}
+
+fn validate(input: Validation<'_>) -> Result<(), WvError> {
+    let Validation {
+        kind,
+        mode,
+        nonce,
+        principal,
+        tid,
+        manifest: expected_manifest,
+        origin: expected_origin,
+        registration_identity,
+        view_id,
+        browser_pid,
+        result,
+        runtime,
+    } = input;
+    let evidence = EVIDENCE.with_borrow_mut(std::mem::take);
+    let capability = format!("web.{kind}");
+    let expected_kind = if kind == "camera" {
+        COREWEBVIEW2_PERMISSION_KIND_CAMERA.0
+    } else {
+        COREWEBVIEW2_PERMISSION_KIND_MICROPHONE.0
+    };
+    let manifest_ok =
+        evidence.adapter_decisions.first().map(|row| row.0) == Some(expected_manifest);
+    let adapter_ok = evidence.adapter_decisions
+        == vec![(
+            expected_manifest,
+            Some(principal),
+            capability,
+            "KELD-GUARD006".to_owned(),
+            tid,
+        )];
+    let effect_ok = evidence.effects
+        == vec![(
+            expected_kind,
+            COREWEBVIEW2_PERMISSION_STATE_DEFAULT.0,
+            COREWEBVIEW2_PERMISSION_STATE_DENY.0,
+            COREWEBVIEW2_PERMISSION_STATE_DENY.0,
+            expected_origin.to_owned(),
+            registration_identity,
+            tid,
+        )];
+    let origin_ok = evidence.effects.len() == 1 && evidence.effects[0].4 == expected_origin;
+    let denial_js_ok = result == format!("{nonce}:true:NotAllowedError");
+    let accepted = manifest_ok && adapter_ok && effect_ok && origin_ok && denial_js_ok;
+    let control_ok = mode != "guarded"
+        && evidence.adapter_decisions.is_empty()
+        && control_matches(
+            ControlExpectation {
+                mode,
+                nonce,
+                result,
+                kind: expected_kind,
+                origin: expected_origin,
+                registration_identity,
+                tid,
+            },
+            &evidence.effects,
+        );
+    let js_ok = if mode == "force-allow" {
+        allow_result_matches(expected_kind, nonce, result)
+    } else {
+        denial_js_ok
+    };
+    let case_ok = accepted || control_ok;
+    let (observed_kind, before, requested, after, origin_uri, sender_identity) = evidence
+        .effects
+        .first()
+        .map_or((-1, -1, -1, -1, "missing", 0), |effect| {
+            (
+                effect.0,
+                effect.1,
+                effect.2,
+                effect.3,
+                effect.4.as_str(),
+                effect.5,
+            )
+        });
+    let (adapter_principal, adapter_capability, adapter_decision, adapter_tid) =
+        observed_adapter(&evidence);
+    println!(
+        "KELD_MEDIA_RESULT kind={kind} mode={mode} nonce={nonce} runtime={runtime} host_pid={} browser_pid={browser_pid} view_id={view_id} tid={tid} manifest_fnv1a64={expected_manifest:016x} adapter_principal={adapter_principal} adapter_capability={adapter_capability} adapter_decision={adapter_decision} adapter_tid={adapter_tid} permission_kind={observed_kind} before={before} requested={requested} after={after} origin_uri={origin_uri} registration_identity={registration_identity:x} sender_identity={sender_identity:x} outcome={result} manifest={manifest_ok} adapter={adapter_ok} effect={effect_ok} origin={origin_ok} js={js_ok} control={control_ok} accepted={accepted} case_ok={case_ok}",
+        std::process::id()
+    );
+    if mode == "guarded" && !accepted {
+        return Err(failure(format!(
+            "guarded oracle failed; js={result}; adapter_decisions={:?}; effects={:?}",
+            evidence.adapter_decisions, evidence.effects
+        )));
+    }
+    if mode != "guarded" && !control_ok {
+        return Err(failure(
+            "negative control did not isolate a missing adapter invocation",
+        ));
+    }
+    Ok(())
+}
+
+fn observed_adapter(evidence: &Evidence) -> (String, &str, &str, u32) {
+    evidence.adapter_decisions.first().map_or(
+        (String::from("none"), "none", "none", 0),
+        |decision| {
+            let principal = match decision.1 {
+                Some(Principal::Webview { id, generation }) => {
+                    format!("webview:{id}:{generation}")
+                }
+                Some(Principal::AppProcess) => String::from("app"),
+                Some(Principal::Plugin { id }) => format!("plugin:{id}"),
+                None => String::from("none"),
+            };
+            (
+                principal,
+                decision.2.as_str(),
+                decision.3.as_str(),
+                decision.4,
+            )
+        },
+    )
+}
+
+#[derive(Clone, Copy)]
+struct ControlExpectation<'a> {
+    mode: &'a str,
+    nonce: u128,
+    result: &'a str,
+    kind: i32,
+    origin: &'a str,
+    registration_identity: usize,
+    tid: u32,
+}
+
+fn control_matches(
+    expected: ControlExpectation<'_>,
+    effects: &[(i32, i32, i32, i32, String, usize, u32)],
+) -> bool {
+    let state = match expected.mode {
+        "force-allow" => COREWEBVIEW2_PERMISSION_STATE_ALLOW,
+        _ => COREWEBVIEW2_PERMISSION_STATE_DENY,
+    };
+    let js_ok = if expected.mode == "force-allow" {
+        allow_result_matches(expected.kind, expected.nonce, expected.result)
+    } else {
+        expected.result == format!("{}:true:NotAllowedError", expected.nonce)
+    };
+    effects
+        == [(
+            expected.kind,
+            COREWEBVIEW2_PERMISSION_STATE_DEFAULT.0,
+            state.0,
+            state.0,
+            expected.origin.to_owned(),
+            expected.registration_identity,
+            expected.tid,
+        )]
+        && js_ok
+}
+
+fn allow_result_matches(kind: i32, nonce: u128, result: &str) -> bool {
+    let track_kind = if kind == COREWEBVIEW2_PERMISSION_KIND_CAMERA.0 {
+        "video"
+    } else if kind == COREWEBVIEW2_PERMISSION_KIND_MICROPHONE.0 {
+        "audio"
+    } else {
+        return false;
+    };
+    let prefix = format!("{nonce}:resolved:{track_kind}:");
+    let Some(tail) = result.strip_prefix(&prefix) else {
+        return false;
+    };
+    let Some((count, ended)) = tail.split_once(':') else {
+        return false;
+    };
+    count.parse::<usize>().is_ok_and(|count| count > 0) && ended == "true"
+}
+
+fn observe_request(
+    view: &ICoreWebView2,
+    mode: &str,
+    expected_url: &str,
+) -> Result<mpsc::Receiver<Result<String, WvError>>, WvError> {
+    let mut control_token = 0;
+    if mode != "guarded" {
+        let registered_identity = super::canonical_webview_identity(view).map_err(failure)?;
+        let control_state = match mode {
+            "force-allow" => COREWEBVIEW2_PERMISSION_STATE_ALLOW,
+            "adapter-bypass" => super::webview2_permission_state(false),
+            // Fixture-only completion after observing DEFAULT. The product
+            // guard is absent; this callback prevents an unattended prompt
+            // from becoming synchronization or acceptance evidence.
+            _ => COREWEBVIEW2_PERMISSION_STATE_DENY,
+        };
+        // Negative controls use one fixture callback after the production
+        // registration is removed. It records DEFAULT, applies the control
+        // state, and reads it back before returning, so no event-handler order
+        // assumption contributes to the oracle.
+        // SAFETY: live view and event arguments on the UI STA.
+        unsafe {
+            view.add_PermissionRequested(
+                &PermissionRequestedEventHandler::create(Box::new(move |sender, args| {
+                    let args = args.ok_or_else(|| windows::core::Error::from(E_POINTER))?;
+                    let Ok(Some(sender_identity)) = sender
+                        .as_ref()
+                        .map(super::canonical_webview_identity)
+                        .transpose()
+                    else {
+                        return args.SetState(COREWEBVIEW2_PERMISSION_STATE_DENY);
+                    };
+                    if sender_identity != registered_identity {
+                        return args.SetState(COREWEBVIEW2_PERMISSION_STATE_DENY);
+                    }
+                    let mut kind = COREWEBVIEW2_PERMISSION_KIND::default();
+                    let mut before = COREWEBVIEW2_PERMISSION_STATE_DEFAULT;
+                    let mut after = COREWEBVIEW2_PERMISSION_STATE_DEFAULT;
+                    args.PermissionKind(&raw mut kind)?;
+                    args.State(&raw mut before)?;
+                    args.SetState(control_state)?;
+                    args.State(&raw mut after)?;
+                    let uri = permission_uri(&args)?;
+                    println!(
+                        "KELD_MEDIA_CONTROL kind={} before={} requested={} after={} uri={uri}",
+                        kind.0, before.0, control_state.0, after.0
+                    );
+                    // SAFETY: current-thread query has no preconditions.
+                    let tid = GetCurrentThreadId();
+                    EVIDENCE.with_borrow_mut(|e| {
+                        e.effects.push((
+                            kind.0,
+                            before.0,
+                            control_state.0,
+                            after.0,
+                            uri,
+                            sender_identity,
+                            tid,
+                        ));
+                    });
+                    Ok(())
+                })),
+                &raw mut control_token,
+            )
+        }
+        .map_err(failure)?;
+    }
+    let expected_url = expected_url.to_owned();
+    let (message_tx, message_rx) = mpsc::channel();
+    let mut message_token = 0;
+    // SAFETY: view remains live until message completion and controller shutdown.
+    unsafe {
+        view.add_WebMessageReceived(
+            &WebMessageReceivedEventHandler::create(Box::new(move |_, args| {
+                println!("KELD_MEDIA_MESSAGE_RECEIVED");
+                let args = args.ok_or_else(|| windows::core::Error::from(E_POINTER))?;
+                let mut source = PWSTR::null();
+                args.Source(&raw mut source)?;
+                let source = owned_string(source);
+                let mut value = PWSTR::null();
+                args.TryGetWebMessageAsString(&raw mut value)?;
+                let result = source.and_then(|source| {
+                    if source == expected_url {
+                        owned_string(value)
+                    } else {
+                        // The string still belongs to this callback on mismatch.
+                        let _ = owned_string(value);
+                        Err(failure("message came from the wrong source"))
+                    }
+                });
+                send_and_wake(&message_tx, result)?;
+                Ok(())
+            })),
+            &raw mut message_token,
+        )
+    }
+    .map_err(failure)?;
+    Ok(message_rx)
+}
+
+fn fixture_environment(directory: &Path) -> Result<super::ICoreWebView2Environment, WvError> {
+    let options = CoreWebView2EnvironmentOptions::default();
+    // SAFETY: options is not shared or published yet. This documented development
+    // switch supplies devices without changing the permission-request decision.
+    // https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/webview-features-flags
+    unsafe {
+        options.set_additional_browser_arguments("--use-fake-device-for-media-stream".to_owned());
+    };
+    let environment = create_environment_with_options(directory, options)?;
+    let environment7: ICoreWebView2Environment7 = environment.cast().map_err(failure)?;
+    let mut actual = PWSTR::null();
+    // SAFETY: live environment on its STA; writable LPWSTR output is COM-owned.
+    unsafe { environment7.UserDataFolder(&raw mut actual) }.map_err(failure)?;
+    same_directory(&owned_string(actual)?, directory)?;
+    Ok(environment)
+}
+
+fn serve_page(
+    listener: TcpListener,
+    html: String,
+    nonce: u128,
+    release: mpsc::Receiver<()>,
+) -> thread::JoinHandle<std::io::Result<()>> {
+    thread::spawn(move || -> std::io::Result<()> {
+        let page = format!("/{nonce}/");
+        let gate = format!("/{nonce}/release");
+        let mut served_page = false;
+        loop {
+            let (mut stream, _) = listener.accept()?;
+            stream.set_read_timeout(Some(Duration::from_secs(3)))?;
+            stream.set_write_timeout(Some(Duration::from_secs(3)))?;
+            let mut request = [0_u8; 4096];
+            let count = stream.read(&mut request)?;
+            let first = std::str::from_utf8(&request[..count])
+                .ok()
+                .and_then(|request| request.lines().next())
+                .unwrap_or_default();
+            let path = first
+                .strip_prefix("GET ")
+                .and_then(|rest| rest.split_once(' '))
+                .map(|(path, _)| path)
+                .unwrap_or_default();
+            if path == page {
+                served_page = true;
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{html}",
+                    html.len()
+                )?;
+            } else if path == gate && served_page {
+                release
+                    .recv_timeout(Duration::from_secs(10))
+                    .map_err(std::io::Error::other)?;
+                write!(
+                    stream,
+                    "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                )?;
+                return Ok(());
+            } else {
+                write!(
+                    stream,
+                    "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                )?;
+            }
+        }
+    })
+}
+
+fn matching_browser_exit(expected: u32, actual: u32, normal: bool) -> bool {
+    expected != 0 && expected == actual && normal
+}
+
+fn observe_browser_exit(
+    environment: &ICoreWebView2Environment5,
+    expected_pid: u32,
+) -> Result<(mpsc::Receiver<Result<(), WvError>>, i64), WvError> {
+    use webview2_com::Microsoft::Web::WebView2::Win32::{
+        COREWEBVIEW2_BROWSER_PROCESS_EXIT_KIND, COREWEBVIEW2_BROWSER_PROCESS_EXIT_KIND_NORMAL,
+    };
+    let (tx, rx) = mpsc::channel();
+    let mut token = 0;
+    // SAFETY: environment retains callback on its STA. Match the newest browser PID
+    // before cleanup: a delayed primer exit cannot release the final view's profile.
+    // https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2environment5
+    unsafe {
+        environment.add_BrowserProcessExited(
+            &BrowserProcessExitedEventHandler::create(Box::new(move |_, args| {
+                let args = args.ok_or_else(|| windows::core::Error::from(E_POINTER))?;
+                let mut pid = 0;
+                let mut kind = COREWEBVIEW2_BROWSER_PROCESS_EXIT_KIND::default();
+                args.BrowserProcessId(&raw mut pid)?;
+                args.BrowserProcessExitKind(&raw mut kind)?;
+                println!(
+                    "KELD_MEDIA_BROWSER_EXIT pid={pid} expected={expected_pid} kind={}",
+                    kind.0
+                );
+                if matching_browser_exit(
+                    expected_pid,
+                    pid,
+                    kind == COREWEBVIEW2_BROWSER_PROCESS_EXIT_KIND_NORMAL,
+                ) {
+                    send_and_wake(&tx, Ok(()))?;
+                } else if pid == expected_pid {
+                    send_and_wake(&tx, Err(failure("final browser exited abnormally")))?;
+                }
+                Ok(())
+            })),
+            &raw mut token,
+        )
+    }
+    .map_err(failure)?;
+    Ok((rx, token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "real Windows WebView2 media acceptance subprocess"]
+    fn windows_media_acceptance_subprocess() -> Result<(), WvError> {
+        run_media_acceptance()
+    }
+
+    #[test]
+    fn stale_or_abnormal_browser_exit_cannot_release_profile() {
+        assert!(!matching_browser_exit(20, 10, true));
+        assert!(!matching_browser_exit(20, 20, false));
+        assert!(!matching_browser_exit(0, 0, true));
+        assert!(matching_browser_exit(20, 20, true));
+    }
+    #[test]
+    fn controls_require_exact_platform_state_kind_and_thread() {
+        let kind = COREWEBVIEW2_PERMISSION_KIND_CAMERA.0;
+        let state = COREWEBVIEW2_PERMISSION_STATE_DEFAULT.0;
+        let origin = "http://127.0.0.1:41000";
+        assert!(control_matches(
+            ControlExpectation {
+                mode: "removed-guard",
+                nonce: 7,
+                result: "7:true:NotAllowedError",
+                kind,
+                origin,
+                registration_identity: 11,
+                tid: 3,
+            },
+            &[(
+                kind,
+                state,
+                COREWEBVIEW2_PERMISSION_STATE_DENY.0,
+                COREWEBVIEW2_PERMISSION_STATE_DENY.0,
+                origin.to_owned(),
+                11,
+                3
+            )]
+        ));
+        for tuple in [
+            (
+                kind,
+                state,
+                COREWEBVIEW2_PERMISSION_STATE_DEFAULT.0,
+                COREWEBVIEW2_PERMISSION_STATE_DENY.0,
+                origin.to_owned(),
+                11,
+                3,
+            ),
+            (
+                COREWEBVIEW2_PERMISSION_KIND_MICROPHONE.0,
+                state,
+                COREWEBVIEW2_PERMISSION_STATE_DENY.0,
+                COREWEBVIEW2_PERMISSION_STATE_DENY.0,
+                origin.to_owned(),
+                11,
+                3,
+            ),
+            (
+                kind,
+                state,
+                COREWEBVIEW2_PERMISSION_STATE_DENY.0,
+                COREWEBVIEW2_PERMISSION_STATE_DENY.0,
+                origin.to_owned(),
+                11,
+                9,
+            ),
+        ] {
+            assert!(!control_matches(
+                ControlExpectation {
+                    mode: "removed-guard",
+                    nonce: 7,
+                    result: "7:true:NotAllowedError",
+                    kind,
+                    origin,
+                    registration_identity: 11,
+                    tid: 3,
+                },
+                &[tuple]
+            ));
+        }
+    }
+
+    #[test]
+    fn allow_requires_a_requested_live_track_that_was_stopped() {
+        let camera = COREWEBVIEW2_PERMISSION_KIND_CAMERA.0;
+        assert!(allow_result_matches(camera, 7, "7:resolved:video:1:true"));
+        for result in [
+            "7:resolved:video:0:true",
+            "7:resolved:video:1:false",
+            "7:resolved:audio:1:true",
+            "7:resolved",
+        ] {
+            assert!(!allow_result_matches(camera, 7, result), "{result}");
+        }
+    }
+}

--- a/crates/keld-wv/src/webview2/mod.rs
+++ b/crates/keld-wv/src/webview2/mod.rs
@@ -31,7 +31,8 @@
 //!
 // SAFETY: this module speaks to WebView2 over COM. The WebView2 threading
 // contract is a single-threaded apartment: the environment, controller, and
-// webview are created on the process main thread (tao's event-loop thread),
+// webview are created on the shipping process main thread (tao's event-loop thread);
+// the ignored media-acceptance libtest uses one dedicated Windows UI thread,
 // and every later use — resize, navigate, eval, devtools, drop — happens on
 // that same thread inside engine methods or tao's event loop, satisfying both
 // the COM contract and the crate `AGENTS.md` "UI-thread-only mutations"
@@ -42,6 +43,9 @@
 // COM-allocated out-string is released exactly once with `CoTaskMemFree`.
 #![allow(unsafe_code)]
 #![deny(unsafe_op_in_unsafe_fn)]
+
+#[cfg(all(feature = "media-acceptance", test))]
+pub(crate) mod media_acceptance;
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -58,11 +62,13 @@ use tao::platform::run_return::EventLoopExtRunReturn;
 use tao::platform::windows::WindowExtWindows;
 use tao::window::{Window, WindowBuilder};
 
+#[cfg(all(feature = "media-acceptance", test))]
+use webview2_com::Microsoft::Web::WebView2::Win32::COREWEBVIEW2_PERMISSION_STATE_DEFAULT;
 use webview2_com::Microsoft::Web::WebView2::Win32::{
     COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC, COREWEBVIEW2_PERMISSION_KIND,
-    COREWEBVIEW2_PERMISSION_STATE_ALLOW, COREWEBVIEW2_PERMISSION_STATE_DENY,
-    CreateCoreWebView2EnvironmentWithOptions, ICoreWebView2, ICoreWebView2Controller,
-    ICoreWebView2Environment, ICoreWebView2EnvironmentOptions,
+    COREWEBVIEW2_PERMISSION_STATE, COREWEBVIEW2_PERMISSION_STATE_ALLOW,
+    COREWEBVIEW2_PERMISSION_STATE_DENY, CreateCoreWebView2EnvironmentWithOptions, ICoreWebView2,
+    ICoreWebView2Controller, ICoreWebView2Environment, ICoreWebView2EnvironmentOptions,
 };
 use webview2_com::{
     CoreWebView2EnvironmentOptions, CreateCoreWebView2ControllerCompletedHandler,
@@ -72,7 +78,7 @@ use webview2_com::{
 };
 use windows::Win32::Foundation::{E_POINTER, E_UNEXPECTED, HWND, RECT};
 use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx};
-use windows::core::{BOOL, HSTRING};
+use windows::core::{BOOL, HSTRING, IUnknown, Interface};
 
 use keld_guard::{PermissionsManifest, Principal};
 
@@ -167,8 +173,14 @@ fn user_data_dir() -> std::path::PathBuf {
 /// first controller creation (`learn.microsoft.com`, `WebView2` process
 /// model).
 fn create_environment() -> Result<ICoreWebView2Environment, WvError> {
-    let options = CoreWebView2EnvironmentOptions::default();
-    let user_data = HSTRING::from(user_data_dir().as_os_str());
+    create_environment_with_options(&user_data_dir(), CoreWebView2EnvironmentOptions::default())
+}
+
+fn create_environment_with_options(
+    directory: &std::path::Path,
+    options: CoreWebView2EnvironmentOptions,
+) -> Result<ICoreWebView2Environment, WvError> {
+    let user_data = HSTRING::from(directory.as_os_str());
     let (tx, rx) = mpsc::channel();
 
     // SAFETY: called on the engine thread with a live STA (module note). The
@@ -251,7 +263,20 @@ fn create_controller(
 /// [`navigate_initial`] demands it, so "content ran before the guard existed"
 /// is a compile error rather than a review catch. Only
 /// [`install_guarded_media_permissions`] mints one.
-struct GuardInstalled(());
+struct GuardInstalled<'view>(&'view ICoreWebView2);
+
+fn webview2_permission_state(allowed: bool) -> COREWEBVIEW2_PERMISSION_STATE {
+    if allowed {
+        COREWEBVIEW2_PERMISSION_STATE_ALLOW
+    } else {
+        COREWEBVIEW2_PERMISSION_STATE_DENY
+    }
+}
+
+fn canonical_webview_identity(webview: &ICoreWebView2) -> windows::core::Result<usize> {
+    let identity: IUnknown = webview.cast()?;
+    Ok(identity.as_raw() as usize)
+}
 
 /// Registers the default-deny media-capture handler backed by `keld-guard`
 /// (KEL-59 parity with the macOS backend).
@@ -266,31 +291,79 @@ fn install_guarded_media_permissions(
     webview: &ICoreWebView2,
     manifest: PermissionsManifest,
     principal: Principal,
-) -> Result<GuardInstalled, WvError> {
+) -> Result<GuardInstalled<'_>, WvError> {
+    let registered_identity = canonical_webview_identity(webview)
+        .map_err(|error| WvError::Webview(format!("permission identity: {error}")))?;
     // Built outside the registration's `unsafe` block so the COM calls inside
     // the callback carry their own SAFETY proofs instead of inheriting one
     // lexically.
-    let handler = PermissionRequestedEventHandler::create(Box::new(move |_, args| {
+    let handler = PermissionRequestedEventHandler::create(Box::new(move |sender, args| {
         // Fail closed: without args no state can be set, and `Ok(())` would
         // silently hand the decision back to WebView2's own prompt
         // (default-ask). An error at least refuses to report success.
         let Some(args) = args else {
             return Err(windows::core::Error::from(E_POINTER));
         };
+        let Ok(Some(sender_identity)) = sender.as_ref().map(canonical_webview_identity).transpose()
+        else {
+            // SAFETY: failure to canonicalize the sender is an identity
+            // failure, so complete the request as denied.
+            return unsafe { args.SetState(COREWEBVIEW2_PERMISSION_STATE_DENY) };
+        };
+        if sender_identity != registered_identity {
+            // SAFETY: live callback args; a foreign/missing sender must never
+            // fall through to WebView2's DEFAULT prompt behavior.
+            return unsafe { args.SetState(COREWEBVIEW2_PERMISSION_STATE_DENY) };
+        }
 
         let mut kind = COREWEBVIEW2_PERMISSION_KIND::default();
         // SAFETY: `args` is live for the duration of the callback; the
         // out-pointer is valid.
-        unsafe { args.PermissionKind(&raw mut kind) }?;
+        if unsafe { args.PermissionKind(&raw mut kind) }.is_err() {
+            // SAFETY: the same live callback args accept a by-value state.
+            // Enforcing DENY takes precedence over propagating a getter error
+            // that could leave WebView2 on DEFAULT/prompt behavior.
+            return unsafe { args.SetState(COREWEBVIEW2_PERMISSION_STATE_DENY) };
+        }
+        #[cfg(all(feature = "media-acceptance", test))]
+        let before = {
+            let mut before = COREWEBVIEW2_PERMISSION_STATE_DEFAULT;
+            // SAFETY: same live callback arguments and writable enum output.
+            if unsafe { args.State(&raw mut before) }.is_err() {
+                // SAFETY: keep the evidence-only getter fail-closed too.
+                return unsafe { args.SetState(COREWEBVIEW2_PERMISSION_STATE_DENY) };
+            }
+            before
+        };
 
-        let state =
-            if media_permission_allowed(&manifest, Some(principal), webview2_media_kind(kind)) {
-                COREWEBVIEW2_PERMISSION_STATE_ALLOW
-            } else {
-                COREWEBVIEW2_PERMISSION_STATE_DENY
-            };
+        let state = webview2_permission_state(media_permission_allowed(
+            &manifest,
+            Some(principal),
+            webview2_media_kind(kind),
+        ));
         // SAFETY: same liveness as above; `SetState` takes the enum by value.
-        unsafe { args.SetState(state) }
+        unsafe { args.SetState(state) }?;
+        #[cfg(all(feature = "media-acceptance", test))]
+        {
+            let mut readback = COREWEBVIEW2_PERMISSION_STATE_DEFAULT;
+            // SAFETY: the callback still owns the same live args. Reading the
+            // value here proves the state before this callback returns.
+            if unsafe { args.State(&raw mut readback) }.is_err() {
+                return Ok(());
+            }
+            let Ok(uri) = media_acceptance::permission_uri(&args) else {
+                return Ok(());
+            };
+            media_acceptance::observe_production_effect(
+                kind,
+                before,
+                state,
+                readback,
+                uri,
+                sender_identity,
+            );
+        }
+        Ok(())
     }));
 
     let mut token = 0_i64;
@@ -299,6 +372,8 @@ fn install_guarded_media_permissions(
     // events on the creating thread.
     let registered = unsafe { webview.add_PermissionRequested(&handler, &raw mut token) };
     registered.map_err(|err| WvError::Webview(format!("permission handler: {err}")))?;
+    #[cfg(all(feature = "media-acceptance", test))]
+    media_acceptance::observe_registration(registered_identity, token);
 
     // Windows WebView2 (KEL-168): an unhandled new-window request creates a
     // popup outside Keld's principal, permission, and lifecycle accounting.
@@ -316,18 +391,15 @@ fn install_guarded_media_permissions(
     // WebView2 retains the COM handler and invokes it on that same thread.
     unsafe { webview.add_NewWindowRequested(&popup_handler, &raw mut token) }
         .map_err(|err| WvError::Webview(format!("popup handler: {err}")))?;
-    Ok(GuardInstalled(()))
+    Ok(GuardInstalled(webview))
 }
 
 /// Performs the first navigation of a freshly created webview.
 ///
 /// Takes [`GuardInstalled`] so the type system enforces the crate rule that no
 /// content runs before the permission guard is registered.
-fn navigate_initial(
-    webview: &ICoreWebView2,
-    _guard: &GuardInstalled,
-    target: &NavTarget,
-) -> Result<(), WvError> {
+fn navigate_initial(guard: &GuardInstalled<'_>, target: &NavTarget) -> Result<(), WvError> {
+    let webview = guard.0;
     // SAFETY: `webview` lives on this thread; both calls take an HSTRING by
     // reference that outlives the call.
     let loaded = match target {
@@ -459,7 +531,14 @@ impl WebView2Engine {
         // deliberately ignored (the pattern wry uses for the same call).
         let _ = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
         let environment = create_environment()?;
-        Ok(Self {
+        Ok(Self::from_environment(event_loop, environment))
+    }
+
+    fn from_environment(
+        event_loop: EventLoop<AppWindowCommand>,
+        environment: ICoreWebView2Environment,
+    ) -> Self {
+        Self {
             event_loop: Some(event_loop),
             environment,
             views: BTreeMap::new(),
@@ -468,7 +547,7 @@ impl WebView2Engine {
             navigation_ready: Arc::new(AtomicBool::new(false)),
             navigation_failed: Arc::new(AtomicBool::new(false)),
             app_window_created: false,
-        })
+        }
     }
 
     /// Runs the event loop until the user closes the last window, then
@@ -784,9 +863,13 @@ impl WebEngine for WebView2Engine {
         // Empty manifest → deny everything (KEL-59). KEL-73: mint the webview
         // id first so capture cannot inherit AppProcess grants.
         let id = self.next_id;
+        #[cfg(not(all(feature = "media-acceptance", test)))]
+        let manifest = PermissionsManifest::default();
+        #[cfg(all(feature = "media-acceptance", test))]
+        let manifest = media_acceptance::fixture_manifest();
         let guard = install_guarded_media_permissions(
             &view.webview,
-            PermissionsManifest::default(),
+            manifest,
             webview_media_principal(WebviewId(id)),
         )?;
 
@@ -831,7 +914,7 @@ impl WebEngine for WebView2Engine {
             )?;
         }
 
-        navigate_initial(&view.webview, &guard, &spec.initial)?;
+        navigate_initial(&guard, &spec.initial)?;
 
         // Keyboard focus lands in the page, matching what wry's build did and
         // what a single-webview window should do.
@@ -934,8 +1017,9 @@ pub fn run_hello(spec: &WebviewSpec) -> Result<(), WvError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        WebView2Engine, app_window_slot_available, initial_navigation_failure_is_fatal,
-        runtime_version,
+        COREWEBVIEW2_PERMISSION_STATE_ALLOW, COREWEBVIEW2_PERMISSION_STATE_DENY, WebView2Engine,
+        app_window_slot_available, initial_navigation_failure_is_fatal, runtime_version,
+        webview2_permission_state,
     };
     use crate::error::WvError;
 
@@ -992,6 +1076,18 @@ mod tests {
     fn only_initial_navigation_failure_is_startup_fatal() {
         assert!(initial_navigation_failure_is_fatal(false));
         assert!(!initial_navigation_failure_is_fatal(true));
+    }
+
+    #[test]
+    fn permission_mapper_preserves_allow_and_deny() {
+        assert_eq!(
+            webview2_permission_state(true),
+            COREWEBVIEW2_PERMISSION_STATE_ALLOW
+        );
+        assert_eq!(
+            webview2_permission_state(false),
+            COREWEBVIEW2_PERMISSION_STATE_DENY
+        );
     }
 
     /// KEL-63: the profile must be per-user, not beside the executable.

--- a/crates/keld-wv/tests/windows_media_guard.ps1
+++ b/crates/keld-wv/tests/windows_media_guard.ps1
@@ -1,0 +1,194 @@
+param(
+    [Parameter(Mandatory = $true)][string]$BinaryPath,
+    [Parameter(Mandatory = $true)][string]$EvidenceDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+$sourceBinary = (Resolve-Path -LiteralPath $BinaryPath).Path
+$evidenceRoot = [IO.Path]::GetFullPath($EvidenceDirectory)
+if (Test-Path -LiteralPath $evidenceRoot) {
+    throw 'Evidence directory must be new; previous results must not be overwritten.'
+}
+[void](New-Item -ItemType Directory -Path $evidenceRoot)
+$binary = Join-Path $evidenceRoot 'keld_wv_media_test.exe'
+Copy-Item -LiteralPath $sourceBinary -Destination $binary
+$sourceBinaryHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $sourceBinary).Hash.ToLowerInvariant()
+$binaryHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $binary).Hash.ToLowerInvariant()
+if ($binaryHash -ne $sourceBinaryHash) {
+    throw "Fixture executable copy mismatch: source=$sourceBinaryHash evidence=$binaryHash"
+}
+$results = @()
+$seenNonces = @{}
+$seenRows = @{}
+foreach ($kind in @('camera', 'microphone')) {
+    foreach ($mode in @('guarded', 'removed-guard', 'adapter-bypass', 'force-allow')) {
+        $manifestCases = if ($mode -eq 'guarded') { @('empty', 'app-grants') } else { @('app-grants') }
+        foreach ($manifestCase in $manifestCases) {
+            $rowKey = "$kind/$mode/$manifestCase"
+            if ($seenRows.ContainsKey($rowKey)) { throw "Duplicate fixture row: $rowKey" }
+            $seenRows[$rowKey] = $true
+            $log = Join-Path $evidenceRoot "$kind-$mode-$manifestCase.log"
+            $stderrLog = Join-Path $evidenceRoot "$kind-$mode-$manifestCase.stderr.log"
+            $start = [Diagnostics.ProcessStartInfo]::new()
+            $start.FileName = $binary
+            $start.Arguments = 'webview2::media_acceptance::tests::windows_media_acceptance_subprocess --ignored --exact --nocapture --test-threads=1'
+            $start.EnvironmentVariables['KELD_MEDIA_KIND'] = $kind
+            $start.EnvironmentVariables['KELD_MEDIA_MODE'] = $mode
+            $start.EnvironmentVariables['KELD_MEDIA_MANIFEST'] = $manifestCase
+            $start.UseShellExecute = $false
+            $start.CreateNoWindow = $true
+            $start.RedirectStandardOutput = $true
+            $start.RedirectStandardError = $true
+            $process = [Diagnostics.Process]::Start($start)
+            [int]$childPid = $process.Id
+            $stdout = $process.StandardOutput.ReadToEndAsync()
+            $stderr = $process.StandardError.ReadToEndAsync()
+            try {
+                if (-not $process.WaitForExit(45000)) {
+                    $process.Kill()
+                    $process.WaitForExit()
+                    throw "Fixture exceeded external deadline: $log; profile may require cleanup."
+                }
+                # Complete redirected-stream draining before reading ExitCode.
+                $process.WaitForExit()
+                [int]$exitCode = $process.ExitCode
+                [IO.File]::WriteAllText($log, $stdout.Result)
+                [IO.File]::WriteAllText($stderrLog, $stderr.Result)
+            } finally {
+                $process.Dispose()
+            }
+            $output = @(Get-Content -LiteralPath $log)
+            if ($exitCode -ne 0) {
+                throw "Media fixture failed ($rowKey): exit $exitCode; see $log"
+            }
+            $receipts = @($output | Where-Object { "$_" -like 'KELD_MEDIA_RESULT *' })
+            if ($receipts.Count -ne 1) { throw "Expected exactly one result receipt: $log" }
+            $receipt = "$($receipts[0])"
+            $pattern = '^KELD_MEDIA_RESULT kind=(?<kind>camera|microphone) mode=(?<mode>guarded|removed-guard|adapter-bypass|force-allow) nonce=(?<nonce>[0-9]+) runtime=(?<runtime>[^ ]+) host_pid=(?<host>[0-9]+) browser_pid=(?<browser>[0-9]+) view_id=(?<view>[0-9]+) tid=(?<tid>[0-9]+) manifest_fnv1a64=(?<manifest_hash>[0-9a-f]{16}) adapter_principal=(?<adapter_principal>[^ ]+) adapter_capability=(?<adapter_capability>[^ ]+) adapter_decision=(?<adapter_decision>[^ ]+) adapter_tid=(?<adapter_tid>[0-9]+) permission_kind=(?<permission_kind>-?[0-9]+) before=(?<before>-?[0-9]+) requested=(?<requested>-?[0-9]+) after=(?<after>-?[0-9]+) origin_uri=(?<origin_uri>[^ ]+) registration_identity=(?<registration_identity>[0-9a-f]+) sender_identity=(?<sender_identity>[0-9a-f]+) outcome=(?<outcome>[^ ]+) manifest=(?<manifest>true|false) adapter=(?<adapter>true|false) effect=(?<effect>true|false) origin=(?<origin>true|false) js=(?<js>true|false) control=(?<control>true|false) accepted=(?<accepted>true|false) case_ok=(?<case_ok>true|false)$'
+            if ($receipt -notmatch $pattern) { throw "Malformed result receipt: $log" }
+            $parsed = [pscustomobject]@{
+                kind = $Matches.kind; mode = $Matches.mode; nonce = $Matches.nonce
+                runtime = $Matches.runtime; host = $Matches.host; browser = $Matches.browser
+                view = $Matches.view; tid = $Matches.tid; manifest_hash = $Matches.manifest_hash
+                adapter_principal = $Matches.adapter_principal
+                adapter_capability = $Matches.adapter_capability
+                adapter_decision = $Matches.adapter_decision; adapter_tid = $Matches.adapter_tid
+                permission_kind = $Matches.permission_kind; before = $Matches.before
+                requested = $Matches.requested; after = $Matches.after; origin_uri = $Matches.origin_uri
+                registration_identity = $Matches.registration_identity
+                sender_identity = $Matches.sender_identity; outcome = $Matches.outcome
+                manifest = $Matches.manifest; adapter = $Matches.adapter; effect = $Matches.effect
+                origin = $Matches.origin; js = $Matches.js; control = $Matches.control
+                accepted = $Matches.accepted; case_ok = $Matches.case_ok
+            }
+            if ($parsed.kind -ne $kind -or $parsed.mode -ne $mode) {
+                throw "Receipt row identity mismatch: $rowKey"
+            }
+            if ($seenNonces.ContainsKey($parsed.nonce)) { throw "Reused fixture nonce: $($parsed.nonce)" }
+            $seenNonces[$parsed.nonce] = $true
+            $profileReceipts = @($output | Where-Object { "$_" -like '*KELD_MEDIA_PROFILE *' })
+            if ($profileReceipts.Count -ne 1) { throw "Expected exactly one profile receipt: $log" }
+            $profilePath = [IO.Path]::GetFullPath(("$($profileReceipts[0])" -split 'KELD_MEDIA_PROFILE ', 2)[1])
+            $expectedProfileLeaf = "keld-media-$childPid-$($parsed.nonce)"
+            if ((Split-Path -Leaf $profilePath) -ne $expectedProfileLeaf) {
+                throw "Profile identity mismatch: expected=$expectedProfileLeaf actual=$profilePath"
+            }
+            if (Test-Path -LiteralPath $profilePath) {
+                throw "Fixture profile survived successful process teardown: $profilePath"
+            }
+            $expectedHash = if ($manifestCase -eq 'empty') { 'e117311975d9f419' } else { '1fb6f771494b3631' }
+            $expectedView = if ($kind -eq 'camera') { 2 } else { 3 }
+            $expectedPermissionKind = if ($kind -eq 'camera') { 2 } else { 1 }
+            $expectedRequested = if ($mode -eq 'force-allow') { 1 } else { 2 }
+            $expectedEffect = if ($mode -eq 'force-allow') { 'false' } else { 'true' }
+            $expectedJs = 'true'
+            $expectedAdapter = if ($mode -eq 'guarded') { 'true' } else { 'false' }
+            $expectedManifest = $expectedAdapter
+            $expectedControl = if ($mode -eq 'guarded') { 'false' } else { 'true' }
+            $expectedAccepted = $expectedAdapter
+            $expectedPrincipal = if ($mode -eq 'guarded') { "webview:$expectedView`:0" } else { 'none' }
+            $expectedCapability = if ($mode -eq 'guarded') { "web.$kind" } else { 'none' }
+            $expectedDecision = if ($mode -eq 'guarded') { 'KELD-GUARD006' } else { 'none' }
+            $expectedAdapterTid = if ($mode -eq 'guarded') { [int]$parsed.tid } else { 0 }
+            if ($parsed.manifest_hash -ne $expectedHash -or
+                [int]$parsed.view -ne $expectedView -or
+                [int]$parsed.permission_kind -ne $expectedPermissionKind -or
+                [int]$parsed.before -ne 0 -or
+                [int]$parsed.requested -ne $expectedRequested -or
+                [int]$parsed.after -ne $expectedRequested -or
+                $parsed.adapter_principal -ne $expectedPrincipal -or
+                $parsed.adapter_capability -ne $expectedCapability -or
+                $parsed.adapter_decision -ne $expectedDecision -or
+                [int]$parsed.adapter_tid -ne $expectedAdapterTid -or
+                $parsed.manifest -ne $expectedManifest -or
+                $parsed.adapter -ne $expectedAdapter -or
+                $parsed.effect -ne $expectedEffect -or
+                $parsed.origin -ne 'true' -or
+                $parsed.js -ne $expectedJs -or
+                $parsed.control -ne $expectedControl -or
+                $parsed.accepted -ne $expectedAccepted -or
+                $parsed.case_ok -ne 'true') {
+                throw "Unexpected exact oracle fields: $rowKey; $receipt"
+            }
+            if ([int]$parsed.host -ne $childPid -or [int]$parsed.browser -le 0 -or [int]$parsed.tid -le 0) {
+                throw "Invalid process/thread identity: $rowKey; $receipt"
+            }
+            if ($parsed.registration_identity -eq '0' -or
+                $parsed.sender_identity -ne $parsed.registration_identity) {
+                throw "Permission callback sender did not match the registered view: $rowKey; $receipt"
+            }
+            if ($parsed.runtime -notmatch '^[0-9]+(\.[0-9]+)+$' -or
+                $parsed.origin_uri -notmatch '^http://127\.0\.0\.1:[0-9]+/$') {
+                throw "Invalid runtime/origin identity: $rowKey; $receipt"
+            }
+            if ($mode -eq 'force-allow') {
+                $trackKind = if ($kind -eq 'camera') { 'video' } else { 'audio' }
+                $escapedNonce = [Regex]::Escape($parsed.nonce)
+                if ($parsed.outcome -notmatch "^$escapedNonce`:resolved`:$trackKind`:[1-9][0-9]*`:true$") {
+                    throw "Allow row lacked a stopped requested-kind live track: $rowKey; $receipt"
+                }
+            } elseif ($parsed.outcome -ne "$($parsed.nonce):true:NotAllowedError") {
+                throw "Deny row returned the wrong JavaScript outcome: $rowKey; $receipt"
+            }
+            $results += [pscustomobject]@{
+                kind = $kind; mode = $mode; manifest_case = $manifestCase
+                nonce = $parsed.nonce; view_id = [int]$parsed.view
+                host_pid = [int]$parsed.host; browser_pid = [int]$parsed.browser
+                permission_kind = [int]$parsed.permission_kind
+                initial_state = [int]$parsed.before; requested_state = [int]$parsed.requested
+                returned_state = [int]$parsed.after; origin_uri = $parsed.origin_uri
+                manifest_fnv1a64 = $parsed.manifest_hash
+                adapter_principal = $parsed.adapter_principal
+                adapter_capability = $parsed.adapter_capability
+                adapter_decision = $parsed.adapter_decision; adapter_tid = [int]$parsed.adapter_tid
+                registration_identity = $parsed.registration_identity
+                sender_identity = $parsed.sender_identity; outcome = $parsed.outcome
+                profile_path = $profilePath; profile_removed = $true
+                exit_code = $exitCode; receipt = $receipt
+                log_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $log).Hash.ToLowerInvariant()
+                stderr_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $stderrLog).Hash.ToLowerInvariant()
+            }
+            Write-Output $receipt
+        }
+    }
+}
+if ($results.Count -ne 10 -or $seenRows.Count -ne 10 -or $seenNonces.Count -ne 10) {
+    throw "Expected exact ten-row matrix; rows=$($results.Count) keys=$($seenRows.Count) nonces=$($seenNonces.Count)"
+}
+$finalBinaryHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $binary).Hash.ToLowerInvariant()
+if ($finalBinaryHash -ne $binaryHash) {
+    throw "Fixture executable changed during the matrix: initial=$binaryHash final=$finalBinaryHash"
+}
+$record = [ordered]@{
+    schema = 'keld.windows-media-fixture/v1'
+    source_executable = $sourceBinary
+    executable = $binary
+    executable_sha256 = $binaryHash
+    system = [Environment]::OSVersion.VersionString
+    device = [Environment]::MachineName
+    capture_device = 'WebView2 synthetic development device'
+    scope = 'raw WebView2 callback receipt: adapter input; removed-product-guard plus fixture-only completion after DEFAULT; adapter-bypass; same-callback explicit state; loopback origin; synthetic capture control; bounded teardown. No physical-device, saved-grant, snapshot, or revocation pass.'
+    rows = $results
+}
+[IO.File]::WriteAllText((Join-Path $evidenceRoot 'result.json'), ($record | ConvertTo-Json -Depth 5))
+Write-Output "Windows media fixture: $($results.Count) rows passed; evidence $evidenceRoot"


### PR DESCRIPTION
## Summary
- bind first navigation to a borrowed guard witness for the exact WebView2 instance
- add a private, opt-in libtest fixture that exercises the production permission callback on real WebView2
- emit and externally validate adapter, canonical COM identity, permission state/origin, synthetic capture, process, and teardown receipts

## Spec refs
- KEL-132/T1
- docs/specs/kel132-webview-gpu-media.md
- No architecture boundary change: handle ownership, crash ownership, and principal minting are unchanged
- KEL-228 separately owns the required CI workflow integration under the CI shared-file rule

## Review gates
- unsafe: passed independent exact-tip review on 2845c6f
- public API: none; all fixture seams are crate-private and cfg(all(feature = media-acceptance, test))
- permission model: passed independent exact-tip review
- dependency addition: none
- wire protocol: none

## Tests
- cargo fmt --all --check
- cargo clippy -p keld-wv --features media-acceptance --all-targets -- -D warnings
- cargo test -p keld-wv --features media-acceptance: 27 passed, 1 intentionally ignored real-OS entrypoint
- real WebView2 matrix: 10/10 rows passed; result SHA-256 bef94f3026116e61b429a47bde3fc6ed353587dab6e796e6e76b2cf4622a263b; evidence executable SHA-256 2c81c1d2dd71013341ce6ad5003ffbf81b4189c3c365228dbd296240bab51fa1
- failure-first mutations: no-op registration, hard-coded principal, constant-Deny mapper, DEFAULT mapper, and zero-track acceptance all failed their owning oracle
- exact final just ci: passed; 629 workspace tests passed, 4 configured skips; warning-denied workspace Clippy, rustfmt, rustdoc, TypeScript, docs/render, hygiene, router and dependency gates passed

## Platforms
- Windows 11 build 26200 on RAMANI; WebView2 runtime 152.0.4191.66; documented synthetic camera and microphone devices
- Windows camera/microphone physical rows remain supplemental and unclaimed
- macOS and Linux implementation rows are not claimed by this PR

## Perf impact
- No performance claim. Default builds exclude the fixture. The production callback adds one canonical IUnknown identity query on the cold permission-request path.