### PR TITLE
test(wv): calibrate Windows media fixture bounds

### DIFF
--- a/crates/keld-wv/src/webview2/media_acceptance.rs
+++ b/crates/keld-wv/src/webview2/media_acceptance.rs
@@ -34,6 +34,10 @@ use super::{
 use crate::{LogicalSize, media::manifest_fingerprint};
 use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2;
 
+const FIXTURE_DEADLINE: Duration = Duration::from_mins(1);
+const WATCHDOG_PROBE_DEADLINE: Duration = Duration::from_millis(100);
+const PARENT_DEADLINE_MARGIN: Duration = Duration::from_secs(30);
+
 #[derive(Default)]
 struct Evidence {
     active: bool,
@@ -181,6 +185,42 @@ fn same_directory(actual: &str, expected: &Path) -> Result<(), WvError> {
 /// Returns an error for missing runtime, API/identity/receipt failures, unexpected
 /// JavaScript behavior, a control accepted by the oracle, or incomplete cleanup.
 fn run_media_acceptance() -> Result<(), WvError> {
+    let watchdog_probe = std::env::var("KELD_MEDIA_WATCHDOG_PROBE").ok();
+    match watchdog_probe.as_deref() {
+        Some("work") => run_with_watchdog(WATCHDOG_PROBE_DEADLINE, block_watchdog_probe),
+        None => run_with_watchdog(FIXTURE_DEADLINE, run_media_acceptance_inner),
+        Some(_) => Err(failure("unknown watchdog probe mode")),
+    }
+}
+
+fn run_with_watchdog<T>(
+    deadline: Duration,
+    work: impl FnOnce() -> Result<T, WvError>,
+) -> Result<T, WvError> {
+    let (done_tx, watchdog) = spawn_watchdog(deadline);
+    let result = work();
+    let _ = done_tx.send(());
+    watchdog.join().map_err(|_| failure("watchdog panicked"))?;
+    result
+}
+
+fn block_watchdog_probe() -> Result<(), WvError> {
+    println!("KELD_MEDIA_PHASE watchdog-probe-work-block");
+    let _ = std::io::stdout().flush();
+    let (_block_tx, block_rx) = mpsc::channel::<()>();
+    let _ = block_rx.recv();
+    Err(failure("watchdog probe returned before process exit"))
+}
+
+fn run_media_acceptance_inner() -> Result<(), WvError> {
+    let parent_deadline = std::env::var("KELD_MEDIA_PARENT_DEADLINE_MS")
+        .map_err(|_| failure("KELD_MEDIA_PARENT_DEADLINE_MS is required"))?;
+    if !parent_deadline_is_valid(&parent_deadline) {
+        return Err(failure(format!(
+            "parent deadline must be at least {} milliseconds",
+            (FIXTURE_DEADLINE + PARENT_DEADLINE_MARGIN).as_millis()
+        )));
+    }
     let kind = std::env::var("KELD_MEDIA_KIND")
         .map_err(|_| failure("KELD_MEDIA_KIND must be camera or microphone"))?;
     let mode = std::env::var("KELD_MEDIA_MODE").map_err(|_| {
@@ -270,9 +310,33 @@ fn destroy_primers(
         ) {
             return Err(failure("destroyed view remained navigable"));
         }
+        println!("KELD_MEDIA_PHASE primer-destroyed id={}", primer.0);
         last = Some(primer);
     }
     Ok(last)
+}
+
+fn spawn_watchdog(deadline: Duration) -> (mpsc::Sender<()>, thread::JoinHandle<()>) {
+    let (done_tx, done_rx) = mpsc::channel::<()>();
+    let watchdog = thread::spawn(move || {
+        if done_rx.recv_timeout(deadline) == Err(mpsc::RecvTimeoutError::Timeout) {
+            // This opt-in fixture is a disposable process. A process deadline also
+            // bounds nested creation/cleanup pumps; one consumed WM_QUIT cannot do so.
+            eprintln!(
+                "KELD_MEDIA_TIMEOUT: fixture exceeded {} seconds; inspect any KELD_MEDIA_PROFILE receipt",
+                deadline.as_secs_f64()
+            );
+            let _ = std::io::stderr().flush();
+            std::process::exit(124);
+        }
+    });
+    (done_tx, watchdog)
+}
+
+fn parent_deadline_is_valid(value: &str) -> bool {
+    value.parse::<u64>().is_ok_and(|milliseconds| {
+        Duration::from_millis(milliseconds) >= FIXTURE_DEADLINE + PARENT_DEADLINE_MARGIN
+    })
 }
 
 fn run_case(
@@ -297,19 +361,12 @@ fn run_case(
         .map_err(failure)?;
     // SAFETY: thread ID query is unconditional.
     let tid = unsafe { GetCurrentThreadId() };
-    let (done_tx, done_rx) = mpsc::channel::<()>();
-    let watchdog = thread::spawn(move || {
-        if done_rx.recv_timeout(Duration::from_secs(30)) == Err(mpsc::RecvTimeoutError::Timeout) {
-            // This opt-in fixture is a disposable process. A process deadline also
-            // bounds nested creation/cleanup pumps; one consumed WM_QUIT cannot do so.
-            eprintln!("KELD_MEDIA_TIMEOUT: fixture exceeded 30 seconds; profile retained");
-            std::process::exit(124);
-        }
-    });
     let environment = fixture_environment(directory)?;
+    println!("KELD_MEDIA_PHASE environment-ready");
     let mut engine = WebView2Engine::from_environment(event_loop, environment.clone());
     let primer_count = if kind == "camera" { 1 } else { 2 };
     let last_primer = destroy_primers(&mut engine, primer_count)?;
+    println!("KELD_MEDIA_PHASE primers-destroyed count={primer_count}");
     let listener = TcpListener::bind("127.0.0.1:0").map_err(failure)?;
     let address = listener.local_addr().map_err(failure)?;
     let url = format!("http://{address}/{nonce}/");
@@ -364,6 +421,7 @@ chrome.webview.postMessage('{nonce}:resolved:{track_kind}:'+matching.length+':'+
         unsafe { view.webview.remove_PermissionRequested(token) }.map_err(failure)?;
     }
     let message_rx = observe_request(&view.webview, mode, &url)?;
+    println!("KELD_MEDIA_PHASE observers-ready");
     release_tx
         .send(())
         .map_err(|_| failure("HTTP release receiver closed"))?;
@@ -378,8 +436,6 @@ chrome.webview.postMessage('{nonce}:resolved:{track_kind}:'+matching.length+':'+
     unsafe { environment5.remove_BrowserProcessExited(exit_token) }.map_err(failure)?;
     drop(environment5);
     drop(environment);
-    let _ = done_tx.send(());
-    watchdog.join().map_err(|_| failure("watchdog panicked"))?;
     server_result.map_err(failure)?;
     validate(Validation {
         kind,
@@ -899,6 +955,14 @@ mod tests {
             "7:resolved",
         ] {
             assert!(!allow_result_matches(camera, 7, result), "{result}");
+        }
+    }
+
+    #[test]
+    fn parent_deadline_stays_above_the_complete_child_bound() {
+        assert!(parent_deadline_is_valid("90000"));
+        for value in ["89999", "60000", "invalid"] {
+            assert!(!parent_deadline_is_valid(value), "{value}");
         }
     }
 }

--- a/crates/keld-wv/tests/windows_media_guard.ps1
+++ b/crates/keld-wv/tests/windows_media_guard.ps1
@@ -3,6 +3,131 @@ param(
     [Parameter(Mandatory = $true)][string]$EvidenceDirectory
 )
 
+function Write-MediaProcessLogs {
+    param(
+        [string]$StdoutPath,
+        [string]$StderrPath,
+        [IO.TextWriter]$Writer = [Console]::Out
+    )
+    $Writer.WriteLine('KELD_MEDIA_STDOUT_BEGIN')
+    $Writer.WriteLine([IO.File]::ReadAllText($StdoutPath))
+    $Writer.WriteLine('KELD_MEDIA_STDOUT_END')
+    $Writer.WriteLine('KELD_MEDIA_STDERR_BEGIN')
+    $Writer.WriteLine([IO.File]::ReadAllText($StderrPath))
+    $Writer.WriteLine('KELD_MEDIA_STDERR_END')
+}
+
+function Invoke-MediaProcess {
+    param(
+        [Diagnostics.ProcessStartInfo]$Start,
+        [string]$StdoutPath,
+        [string]$StderrPath,
+        [int]$DeadlineMilliseconds,
+        [IO.TextWriter]$Writer = [Console]::Out
+    )
+    $process = [Diagnostics.Process]::Start($Start)
+    [int]$childPid = $process.Id
+    $stdout = $process.StandardOutput.ReadToEndAsync()
+    $stderr = $process.StandardError.ReadToEndAsync()
+    $outerTimedOut = $false
+    try {
+        if (-not $process.WaitForExit($DeadlineMilliseconds)) {
+            $outerTimedOut = $true
+            try {
+                $process.Kill()
+            } catch [InvalidOperationException] {
+                if (-not $process.HasExited) { throw }
+            }
+            $process.WaitForExit()
+        }
+        # Complete redirected-stream draining before reading ExitCode.
+        $process.WaitForExit()
+        [int]$exitCode = $process.ExitCode
+        [IO.File]::WriteAllText($StdoutPath, $stdout.Result)
+        [IO.File]::WriteAllText($StderrPath, $stderr.Result)
+    } finally {
+        $process.Dispose()
+    }
+    if ($outerTimedOut -or $exitCode -ne 0) {
+        Write-MediaProcessLogs -StdoutPath $StdoutPath -StderrPath $StderrPath -Writer $Writer
+    }
+    [pscustomobject]@{
+        child_pid = $childPid
+        exit_code = $exitCode
+        outer_timed_out = $outerTimedOut
+        stdout_text = [IO.File]::ReadAllText($StdoutPath)
+        stderr_text = [IO.File]::ReadAllText($StderrPath)
+    }
+}
+
+function Invoke-MediaWatchdogProbe {
+    param([string]$Binary, [string]$EvidenceRoot)
+    $stdoutPath = Join-Path $EvidenceRoot 'watchdog-probe.log'
+    $stderrPath = Join-Path $EvidenceRoot 'watchdog-probe.stderr.log'
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = $Binary
+    $start.Arguments = 'webview2::media_acceptance::tests::windows_media_acceptance_subprocess --ignored --exact --nocapture --test-threads=1'
+    $start.EnvironmentVariables['KELD_MEDIA_WATCHDOG_PROBE'] = 'work'
+    $start.UseShellExecute = $false
+    $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $writer = [IO.StringWriter]::new()
+    $execution = Invoke-MediaProcess -Start $start -StdoutPath $stdoutPath -StderrPath $stderrPath -DeadlineMilliseconds 5000 -Writer $writer
+    $consoleText = $writer.ToString()
+    $writer.Dispose()
+    [Console]::Out.Write($consoleText)
+    $expectedPhase = 'KELD_MEDIA_PHASE watchdog-probe-work-block'
+    if ($execution.outer_timed_out -or $execution.exit_code -ne 124 -or
+        -not $execution.stdout_text.Contains($expectedPhase) -or
+        -not $execution.stderr_text.Contains('KELD_MEDIA_TIMEOUT: fixture exceeded 0.1 seconds') -or
+        -not $consoleText.Contains('KELD_MEDIA_STDOUT_BEGIN') -or
+        -not $consoleText.Contains('KELD_MEDIA_STDOUT_END') -or
+        -not $consoleText.Contains('KELD_MEDIA_STDERR_BEGIN') -or
+        -not $consoleText.Contains('KELD_MEDIA_STDERR_END') -or
+        -not $consoleText.Contains($expectedPhase) -or
+        -not $consoleText.Contains('KELD_MEDIA_TIMEOUT: fixture exceeded 0.1 seconds')) {
+        throw "Watchdog probe failed: outerTimedOut=$($execution.outer_timed_out) exit=$($execution.exit_code)"
+    }
+    [pscustomobject]@{
+        mode = 'work'
+        exit_code = $execution.exit_code
+        outer_timed_out = $execution.outer_timed_out
+        stdout_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $stdoutPath).Hash.ToLowerInvariant()
+        stderr_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $stderrPath).Hash.ToLowerInvariant()
+    }
+}
+
+function Invoke-MediaOuterDeadlineProbe {
+    param([string]$EvidenceRoot)
+    $stdoutPath = Join-Path $EvidenceRoot 'outer-deadline-probe.log'
+    $stderrPath = Join-Path $EvidenceRoot 'outer-deadline-probe.stderr.log'
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = Join-Path $env:SystemRoot 'System32/WindowsPowerShell/v1.0/powershell.exe'
+    $start.Arguments = '-NoProfile -Command "[Console]::Out.WriteLine(''KELD_MEDIA_PHASE outer-probe-block''); [Console]::Out.Flush(); $gate = [Threading.ManualResetEventSlim]::new($false); $gate.Wait()"'
+    $start.UseShellExecute = $false
+    $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $writer = [IO.StringWriter]::new()
+    $execution = Invoke-MediaProcess -Start $start -StdoutPath $stdoutPath -StderrPath $stderrPath -DeadlineMilliseconds 5000 -Writer $writer
+    $consoleText = $writer.ToString()
+    $writer.Dispose()
+    [Console]::Out.Write($consoleText)
+    if (-not $execution.outer_timed_out -or $execution.exit_code -eq 0 -or
+        -not $consoleText.Contains('KELD_MEDIA_PHASE outer-probe-block') -or
+        -not $consoleText.Contains('KELD_MEDIA_STDOUT_BEGIN') -or
+        -not $consoleText.Contains('KELD_MEDIA_STDERR_END')) {
+        throw "Outer deadline probe failed: outerTimedOut=$($execution.outer_timed_out) exit=$($execution.exit_code)"
+    }
+    [pscustomobject]@{
+        exit_code = $execution.exit_code
+        outer_timed_out = $execution.outer_timed_out
+        stdout_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $stdoutPath).Hash.ToLowerInvariant()
+        stderr_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $stderrPath).Hash.ToLowerInvariant()
+    }
+}
+
 $ErrorActionPreference = 'Stop'
 $sourceBinary = (Resolve-Path -LiteralPath $BinaryPath).Path
 $evidenceRoot = [IO.Path]::GetFullPath($EvidenceDirectory)
@@ -17,9 +142,12 @@ $binaryHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $binary).Hash.ToLower
 if ($binaryHash -ne $sourceBinaryHash) {
     throw "Fixture executable copy mismatch: source=$sourceBinaryHash evidence=$binaryHash"
 }
+$watchdogProbe = Invoke-MediaWatchdogProbe -Binary $binary -EvidenceRoot $evidenceRoot
+$outerDeadlineProbe = Invoke-MediaOuterDeadlineProbe -EvidenceRoot $evidenceRoot
 $results = @()
 $seenNonces = @{}
 $seenRows = @{}
+$outerDeadlineMilliseconds = 90000
 foreach ($kind in @('camera', 'microphone')) {
     foreach ($mode in @('guarded', 'removed-guard', 'adapter-bypass', 'force-allow')) {
         $manifestCases = if ($mode -eq 'guarded') { @('empty', 'app-grants') } else { @('app-grants') }
@@ -35,31 +163,20 @@ foreach ($kind in @('camera', 'microphone')) {
             $start.EnvironmentVariables['KELD_MEDIA_KIND'] = $kind
             $start.EnvironmentVariables['KELD_MEDIA_MODE'] = $mode
             $start.EnvironmentVariables['KELD_MEDIA_MANIFEST'] = $manifestCase
+            $start.EnvironmentVariables['KELD_MEDIA_PARENT_DEADLINE_MS'] = "$outerDeadlineMilliseconds"
+            [void]$start.EnvironmentVariables.Remove('KELD_MEDIA_WATCHDOG_PROBE')
             $start.UseShellExecute = $false
             $start.CreateNoWindow = $true
             $start.RedirectStandardOutput = $true
             $start.RedirectStandardError = $true
-            $process = [Diagnostics.Process]::Start($start)
-            [int]$childPid = $process.Id
-            $stdout = $process.StandardOutput.ReadToEndAsync()
-            $stderr = $process.StandardError.ReadToEndAsync()
-            try {
-                if (-not $process.WaitForExit(45000)) {
-                    $process.Kill()
-                    $process.WaitForExit()
-                    throw "Fixture exceeded external deadline: $log; profile may require cleanup."
-                }
-                # Complete redirected-stream draining before reading ExitCode.
-                $process.WaitForExit()
-                [int]$exitCode = $process.ExitCode
-                [IO.File]::WriteAllText($log, $stdout.Result)
-                [IO.File]::WriteAllText($stderrLog, $stderr.Result)
-            } finally {
-                $process.Dispose()
-            }
+            $execution = Invoke-MediaProcess -Start $start -StdoutPath $log -StderrPath $stderrLog -DeadlineMilliseconds $outerDeadlineMilliseconds
+            [int]$childPid = $execution.child_pid
             $output = @(Get-Content -LiteralPath $log)
-            if ($exitCode -ne 0) {
-                throw "Media fixture failed ($rowKey): exit $exitCode; see $log"
+            if ($execution.outer_timed_out) {
+                throw "Fixture exceeded external deadline: $log; profile may require cleanup."
+            }
+            if ($execution.exit_code -ne 0) {
+                throw "Media fixture failed ($rowKey): exit $($execution.exit_code); see $log"
             }
             $receipts = @($output | Where-Object { "$_" -like 'KELD_MEDIA_RESULT *' })
             if ($receipts.Count -ne 1) { throw "Expected exactly one result receipt: $log" }
@@ -164,7 +281,7 @@ foreach ($kind in @('camera', 'microphone')) {
                 registration_identity = $parsed.registration_identity
                 sender_identity = $parsed.sender_identity; outcome = $parsed.outcome
                 profile_path = $profilePath; profile_removed = $true
-                exit_code = $exitCode; receipt = $receipt
+                exit_code = $execution.exit_code; receipt = $receipt
                 log_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $log).Hash.ToLowerInvariant()
                 stderr_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $stderrLog).Hash.ToLowerInvariant()
             }
@@ -188,6 +305,8 @@ $record = [ordered]@{
     device = [Environment]::MachineName
     capture_device = 'WebView2 synthetic development device'
     scope = 'raw WebView2 callback receipt: adapter input; removed-product-guard plus fixture-only completion after DEFAULT; adapter-bypass; same-callback explicit state; loopback origin; synthetic capture control; bounded teardown. No physical-device, saved-grant, snapshot, or revocation pass.'
+    watchdog_probe = $watchdogProbe
+    outer_deadline_probe = $outerDeadlineProbe
     rows = $results
 }
 [IO.File]::WriteAllText((Join-Path $evidenceRoot 'result.json'), ($record | ConvertTo-Json -Depth 5))


### PR DESCRIPTION
## Summary
- bound the entire private WebView2 media fixture with a provisional 60-second child watchdog and a validated 90-second parent margin
- preserve stdout/stderr on timeout and nonzero exits through one shared process owner
- add deletion-sensitive child-work, parent-fallback, console-emission, and deadline-race probes

## Spec refs
- KEL-229
- KEL-132/T1 follow-up after PR #224 Windows exit 124
- No boundary change

## Review gates
- unsafe: none
- public API: none
- permission model: none
- dependency addition: none
- wire protocol: none

## Tests
- feature rustfmt, all-target Clippy with warnings denied, and unit tests: 28 passed, 1 intentional real-OS ignore
- two consecutive final real matrices: 10/10 rows each, no retries
- child work probe: 100 ms event block -> exit 124 before parent fallback
- outer probe: ManualResetEventSlim block -> parent 5-second kill
- captured console assertions require all stdout/stderr delimiters and sentinel content
- timeout/exit race reproducer confirmed already-exited Kill is handled while genuine kill failures propagate
- exact final just ci: 629 workspace tests passed, 4 configured skips; rustfmt, workspace Clippy/rustdoc warnings denied, TypeScript, docs/render, router/hygiene/dependency gates passed
- independent exact-tip bounds, oracle, and adversarial reviews clean

## Platforms
- Windows 11 build 26200, PowerShell 5.1/.NET Framework 4.8, WebView2 152.0.4191.66
- GitHub Windows Server 2025 rerun through dependent PR #224 remains required after merge

## Perf impact
- Test-only. Adds roughly five seconds for the persistent parent-fallback probe and retains bounded per-row limits; no retry, sleep synchronization, or shipping runtime effect.