### PR TITLE
fix(cli): quit stock app after last window closes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -50,6 +50,13 @@ max-threads = 1
 filter = "binary(linux_strict_boundary)"
 test-group = "linux-strict-boundary"
 
+# KEL-185's temporary hosted-entrypoint probe must publish its validated,
+# redacted identity record even when the diagnostic test passes. This is one
+# named test only; the stock lifecycle acceptance rows keep default output.
+[[profile.ci.overrides]]
+filter = "binary(bun_echo) & test(created_template_entrypoint_identity_precedes_the_main_guard)"
+success-output = "immediate"
+
 # These rows each own a real Wayland/WebKitGTK app session plus a strict Bun
 # process tree. The product does not require independent test processes to
 # contend for one desktop compositor. Preserve every deadline and assertion,

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ do not establish release support:
 |---|---|---|
 | macOS / WKWebView | Native window, app link, recovery, ordered Quit/CLI-loss cleanup | Stock app native Close remains unverified; complete strict profiles and release packaging |
 | Windows / WebView2 | Native window, named-pipe app link, recovery, Ctrl-C cleanup and relaunch | Stock app native Close remains incomplete; remaining strict admission and release packaging |
-| Ubuntu/Debian x86_64 / WebKitGTK / Wayland | Window, authenticated link, strict Bun generations, recovery | Two native-Close/cleanup/relaunch runs passed on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228) at source `a843b32` on Ubuntu 26.04.1 x86_64 / GNOME 50.1 Wayland with Bun 1.4.2 and WebKitGTK 2.52.6; X11 product runs, other distributions/architectures, and release packaging remain unverified |
+| Ubuntu/Debian x86_64 / WebKitGTK / Wayland | Window, authenticated link, strict Bun generations, recovery | Native Close/cleanup/relaunch qualified on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228) for Ubuntu 26.04.1 / GNOME Wayland; X11 product runs, other distributions/architectures, and release packaging remain unverified |
 
 ## Try it
 
@@ -55,15 +55,11 @@ and the [Ubuntu build/create/doctor/window/Ctrl-C/relaunch run](https://github.c
 Both used Bun 1.4.0; Windows used interactive PowerShell. These dated interrupt runs remain
 separate from native-Close acceptance.
 
-**Qualified Linux native Close:** two untouched stock-app runs on the
-[PR #228 candidate](https://github.com/gyldlab/keld/pull/228), source `a843b32`, passed
-native Close, cleanup, and relaunch on Ubuntu 26.04.1 x86_64 with GNOME 50.1 Wayland,
-Bun 1.4.2, and WebKitGTK 2.52.6. Both CLI processes exited 0; all 20 observed pidfds
-exited, both distinct launch stages disappeared, and no forced cleanup was used. This
-qualifies that recorded Linux environment and candidate only; root is capturing fresh
-native evidence on the final rebased PR head. The earlier
+The [qualified Linux native-Close evidence](docs/onboarding/README.md#qualified-linux-native-close-evidence)
+for [PR #228](https://github.com/gyldlab/keld/pull/228), source `a843b32`, updates the
+historical failure status for that tested environment only. The earlier
 [Ubuntu/Wayland failure record](https://github.com/gyldlab/keld/issues/167#issuecomment-5575535917)
-remains historical. The [lifecycle issue](https://github.com/gyldlab/keld/issues/176)
+remains linked as history. The [lifecycle issue](https://github.com/gyldlab/keld/issues/176)
 tracks the stock-app correction. The Rust executables are built from source; there is
 no npm installation or packaged app release yet.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ do not establish release support:
 |---|---|---|
 | macOS / WKWebView | Native window, app link, recovery, ordered Quit/CLI-loss cleanup | Stock app native Close remains unverified; complete strict profiles and release packaging |
 | Windows / WebView2 | Native window, named-pipe app link, recovery, Ctrl-C cleanup and relaunch | Stock app native Close remains incomplete; remaining strict admission and release packaging |
-| Ubuntu/Debian x86_64 / WebKitGTK / Wayland | Window, authenticated link, strict Bun generations, recovery | Stock app native Close fails the latest Wayland acceptance; X11 product run, other distributions/architectures, release packaging |
+| Ubuntu/Debian x86_64 / WebKitGTK / Wayland | Window, authenticated link, strict Bun generations, recovery | Two native-Close/cleanup/relaunch runs passed on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228) at source `a843b32` on Ubuntu 26.04.1 x86_64 / GNOME 50.1 Wayland with Bun 1.4.2 and WebKitGTK 2.52.6; X11 product runs, other distributions/architectures, and release packaging remain unverified |
 
 ## Try it
 
@@ -52,15 +52,19 @@ The expected result is a `hello-keld` window. Captured Bun output, including
 `IPC echo ok`, appears at shutdown. Maintainer-recorded, source-pinned public evidence
 covers the [Windows build/window/Ctrl-C/relaunch run](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
 and the [Ubuntu build/create/doctor/window/Ctrl-C/relaunch run](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871).
-Both used Bun 1.4.0; Windows used interactive PowerShell. These interrupt runs do not
-pass the separate native-Close criterion.
+Both used Bun 1.4.0; Windows used interactive PowerShell. These dated interrupt runs remain
+separate from native-Close acceptance.
 
-**Known Linux lifecycle gap:** on the
-[tested Ubuntu/Wayland candidate](https://github.com/gyldlab/keld/issues/167#issuecomment-5575535917),
-native Close removes the renderer but leaves the host, Bun, and launch stage running. Ctrl-C
-cleaned up that session; this separate interrupt result does not pass normal-close
-acceptance. The [lifecycle issue](https://github.com/gyldlab/keld/issues/176) tracks
-the required stock-app fix. The Rust executables are built from source; there is
+**Qualified Linux native Close:** two untouched stock-app runs on the
+[PR #228 candidate](https://github.com/gyldlab/keld/pull/228), source `a843b32`, passed
+native Close, cleanup, and relaunch on Ubuntu 26.04.1 x86_64 with GNOME 50.1 Wayland,
+Bun 1.4.2, and WebKitGTK 2.52.6. Both CLI processes exited 0; all 20 observed pidfds
+exited, both distinct launch stages disappeared, and no forced cleanup was used. This
+qualifies that recorded Linux environment and candidate only; root is capturing fresh
+native evidence on the final rebased PR head. The earlier
+[Ubuntu/Wayland failure record](https://github.com/gyldlab/keld/issues/167#issuecomment-5575535917)
+remains historical. The [lifecycle issue](https://github.com/gyldlab/keld/issues/176)
+tracks the stock-app correction. The Rust executables are built from source; there is
 no npm installation or packaged app release yet.
 
 ## Evidence

--- a/crates/keld-cli/src/create.rs
+++ b/crates/keld-cli/src/create.rs
@@ -297,8 +297,16 @@ mod tests {
             "{main}"
         );
         assert!(
-            main.contains("await new Promise(() => {})"),
-            "KEL-30: stay alive for host window duration: {main}"
+            main.contains("await quitAfterLastWindowClosed(session)"),
+            "KEL-185: stock app must consume LastWindowClosed on its app-link: {main}"
+        );
+        assert!(
+            main.contains("session.receive(lifecycleReplyWaiter(corr))"),
+            "KEL-185: stock app must await the correlated Quit Reply: {main}"
+        );
+        assert!(
+            !main.contains("await new Promise(() => {})"),
+            "KEL-185: stock app must not park forever after echo: {main}"
         );
         assert!(!main.contains("{{name}}"), "{main}");
 

--- a/crates/keld-cli/templates/hello/src/kipc.ts
+++ b/crates/keld-cli/templates/hello/src/kipc.ts
@@ -172,6 +172,25 @@ export class AppLinkSession {
   }
 
   /**
+   * Waits without a request deadline for an unsolicited host Event.
+   *
+   * A healthy window may stay open indefinitely, so LastWindowClosed cannot
+   * use the bounded Echo/Quit response wait. Reader close, socket failure, and
+   * validation errors still fail this same directed read and close the session.
+   */
+  async receiveWhileIdle(want: ReceivePolicy, park?: ReceivePolicy): Promise<DecodedFrame> {
+    if (this.#closed) {
+      throw kipcError("KELD-IPC-001", "session is closed");
+    }
+    try {
+      return await this.#directed.receive(want, park);
+    } catch (err) {
+      this.close();
+      throw err;
+    }
+  }
+
+  /**
    * One serialized frame write on this HELLO'd link. Callers own channel,
    * correlation, and payload codecs (KEL-185 sends Quit here; this method does not).
    */

--- a/crates/keld-cli/templates/hello/src/main-body.ts
+++ b/crates/keld-cli/templates/hello/src/main-body.ts
@@ -4,9 +4,54 @@
  * HELLO handshake + echo Call/Reply — no shelling out to a second Rust
  * process. Full schema-driven codegen (`keld gen`, `@keld/schema`) is a later
  * slice. `AppLinkSession` holds one HELLO'd connection so further CALLs do not
- * handshake again. The process stays alive for the host-owned hello window
- * duration; `keld dev` reaps it after the window returns.
+ * handshake again. The stock lifecycle consumer waits for the host's final
+ * window event, sends Quit on that same connection, then exits after its Reply.
  */
+import {
+  LIFECYCLE_CHANNEL,
+  lifecycleReplyWaiter,
+} from "./kipc-transport.ts";
+
+function decodeStockLifecycleEvent(payload: Uint8Array): "ready" | "last-window-closed" {
+  if (payload.length !== 1) {
+    throw kipcError("KELD-IPC-003", "lifecycle event must be one postcard enum byte");
+  }
+  if (payload[0] === 0) return "ready";
+  if (payload[0] === 1) return "last-window-closed";
+  throw kipcError("KELD-IPC-003", `unknown LifecycleEvent discriminant ${payload[0]}`);
+}
+
+function assertStockQuitReply(payload: Uint8Array): void {
+  if (payload.length !== 1 || payload[0] !== 0) {
+    throw kipcError("KELD-IPC-003", "Quit Reply must contain LifecycleResponse::Quit");
+  }
+}
+
+async function quitAfterLastWindowClosed(session: AppLinkSession): Promise<void> {
+  while (true) {
+    const frame = await session.receiveWhileIdle(RECEIVE_POLICIES.lifecycleEventReceiver);
+    if (frame.header.kind === FrameKind.Ping) {
+      await session.writeFrame(
+        FrameKind.Ping,
+        frame.header.channel,
+        frame.header.corr,
+        new Uint8Array(),
+      );
+      continue;
+    }
+    if (decodeStockLifecycleEvent(frame.payload) === "ready") continue;
+
+    const corr = session.allocCorr();
+    await session.writeFrame(FrameKind.Call, LIFECYCLE_CHANNEL, corr, encodeVarint(0));
+    const reply = await session.receive(lifecycleReplyWaiter(corr));
+    if (reply.header.kind === FrameKind.Err) {
+      throw kipcError("KELD-IPC-005", "host rejected the stock lifecycle Quit Call");
+    }
+    assertStockQuitReply(reply.payload);
+    return;
+  }
+}
+
 if (import.meta.main) {
   const link = process.env.KELD_APP_LINK;
   if (!link) {
@@ -21,9 +66,9 @@ if (import.meta.main) {
     const response = await session.echo({ message: "keld", count: 1 });
     console.log(`ipc-echo ok: message=${JSON.stringify(response.message)} count=${response.count}`);
     console.log("{{name}}: main process ready (IPC echo ok)");
-    // Stay alive while the host owns the hello window. The host supervisor
-    // kills this child on window close (KEL-30 concurrent app-link).
-    await new Promise(() => {});
+    await quitAfterLastWindowClosed(session);
+    session.close();
+    process.exit(0);
   } finally {
     session.close();
   }

--- a/crates/keld-cli/tests/bun_echo.rs
+++ b/crates/keld-cli/tests/bun_echo.rs
@@ -2,12 +2,95 @@
 
 #![allow(clippy::expect_used)] // extra test crate: expect is the assertion oracle
 
+use std::io::{Read, Write};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Child, Command, Output, Stdio};
 use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use keld_cli::create::create_project;
 use keld_cli::echo_link::EchoServer;
+use keld_ipc::link::{read_frame, write_frame};
+use keld_ipc::{
+    APP_LINK_IO_DEADLINE, AppLinkDeadlines, BootstrapListener, ChannelId, CorrelationId,
+    ECHO_CHANNEL, EchoRequest, EchoResponse, FrameHeader, FrameKind, LIFECYCLE_CHANNEL,
+    LifecycleEvent, LifecycleRequest, LifecycleResponse,
+};
+
+fn wait_for_output(mut child: Child, timeout: Duration) -> Result<Output, String> {
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                return child
+                    .wait_with_output()
+                    .map_err(|error| format!("collect child output: {error}"));
+            }
+            Ok(None) if started.elapsed() < timeout => thread::yield_now(),
+            Ok(None) => {
+                let _ = child.kill();
+                let output = child
+                    .wait_with_output()
+                    .map_err(|error| format!("reap timed-out child: {error}"))?;
+                return Err(format!(
+                    "child did not exit within {timeout:?}; stdout={} stderr={}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            Err(error) => return Err(format!("poll child exit: {error}")),
+        }
+    }
+}
+
+fn send_ready_then_reply_to_stock_echo<S: Read + Write>(stream: &mut S) -> CorrelationId {
+    let ready = keld_ipc::codec::encode(&LifecycleEvent::Ready).expect("encode Ready");
+    write_frame(
+        stream,
+        FrameKind::Event,
+        0,
+        LIFECYCLE_CHANNEL,
+        CorrelationId(0),
+        &ready,
+    )
+    .expect("send Ready before Echo Reply");
+
+    let (echo_header, echo_payload) = read_frame(stream).expect("read Echo Call");
+    assert_eq!(echo_header.kind, FrameKind::Call);
+    assert_eq!(echo_header.flags, 0);
+    assert_eq!(echo_header.channel, ECHO_CHANNEL);
+    assert_ne!(echo_header.corr, CorrelationId(0));
+    let request: EchoRequest = keld_ipc::codec::decode(&echo_payload).expect("decode Echo");
+    assert_eq!(request.message, "keld");
+    assert_eq!(request.count, 1);
+    let echo_reply = keld_ipc::codec::encode(&EchoResponse {
+        message: request.message,
+        count: request.count,
+    })
+    .expect("encode Echo Reply");
+    write_frame(
+        stream,
+        FrameKind::Reply,
+        0,
+        ECHO_CHANNEL,
+        echo_header.corr,
+        &echo_reply,
+    )
+    .expect("send Echo Reply");
+    echo_header.corr
+}
+
+fn spawn_generated_main(project: &Path, link: &str) -> Child {
+    Command::new("bun")
+        .args(["run", "src/main.ts"])
+        .current_dir(project)
+        .env("KELD_APP_LINK", link)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn generated main under Bun")
+}
 
 #[test]
 fn bun_main_runs_ipc_echo_with_unique_fields() {
@@ -191,6 +274,208 @@ fn created_template_main_runs_ipc_echo() {
         !stdout.contains("{{name}}"),
         "unsubstituted template leaked: stdout={stdout}"
     );
+}
+
+/// KEL-185 regression: the untouched generated main must consume the host's
+/// lifecycle event and answer Quit on its already-authenticated app-link.
+///
+/// The Rust server is the wire oracle. It deliberately sends `Ready` before
+/// the Echo Reply, then requires `LastWindowClosed`, a correlated `Quit`, its
+/// Reply, and EOF. A second `HELLO`, a competing reader, or the old permanent
+/// park fails at the exact frame where it appears. The timeout only reaps a faulty child.
+#[test]
+fn created_template_quits_after_last_window_closed_on_the_same_link() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_project(dir.path(), "app").expect("create");
+    let project = dir.path().join("app");
+
+    let listener = BootstrapListener::bind().expect("bind app-link");
+    let link = listener.app_link();
+    let server = thread::spawn(move || {
+        let mut stream = listener
+            .accept_authenticated()
+            .expect("accept app-link")
+            .expect("client must authenticate");
+        stream
+            .set_app_link_deadlines(Some(APP_LINK_IO_DEADLINE))
+            .expect("set app-link deadlines");
+
+        let echo_corr = send_ready_then_reply_to_stock_echo(&mut stream);
+
+        // Window lifetime is intentionally longer than the request/reply I/O
+        // deadline. The timeout is the contract measurement: no message is
+        // expected, and the sender stays live so disconnect cannot satisfy it.
+        let (_idle_guard, idle_window) = mpsc::channel::<()>();
+        assert!(matches!(
+            idle_window.recv_timeout(APP_LINK_IO_DEADLINE + Duration::from_millis(250)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        let ping_channel = ChannelId(91);
+        let ping_corr = CorrelationId(0x185);
+        write_frame(
+            &mut stream,
+            FrameKind::Ping,
+            0,
+            ping_channel,
+            ping_corr,
+            &[],
+        )
+        .expect("send lifecycle liveness Ping");
+        let (ping_header, ping_payload) = read_frame(&mut stream).expect("read echoed Ping");
+        assert_eq!(ping_header.kind, FrameKind::Ping);
+        assert_eq!(ping_header.flags, 0);
+        assert_eq!(ping_header.channel, ping_channel);
+        assert_eq!(ping_header.corr, ping_corr);
+        assert!(ping_payload.is_empty());
+
+        let closed =
+            keld_ipc::codec::encode(&LifecycleEvent::LastWindowClosed).expect("encode close");
+        write_frame(
+            &mut stream,
+            FrameKind::Event,
+            0,
+            LIFECYCLE_CHANNEL,
+            CorrelationId(0),
+            &closed,
+        )
+        .expect("send LastWindowClosed");
+
+        let (quit_header, quit_payload) = read_frame(&mut stream).expect("read Quit Call");
+        assert_eq!(quit_header.kind, FrameKind::Call, "no second HELLO");
+        assert_eq!(quit_header.flags, 0);
+        assert_eq!(quit_header.channel, LIFECYCLE_CHANNEL);
+        assert_ne!(quit_header.corr, CorrelationId(0));
+        assert_ne!(quit_header.corr, echo_corr);
+        let request: LifecycleRequest =
+            keld_ipc::codec::decode(&quit_payload).expect("decode Quit Call");
+        assert_eq!(request, LifecycleRequest::Quit);
+        let quit_reply =
+            keld_ipc::codec::encode(&LifecycleResponse::Quit).expect("encode Quit Reply");
+        write_frame(
+            &mut stream,
+            FrameKind::Reply,
+            0,
+            LIFECYCLE_CHANNEL,
+            quit_header.corr,
+            &quit_reply,
+        )
+        .expect("send correlated Quit Reply");
+
+        let mut trailing = [0_u8; 1];
+        assert_eq!(
+            stream.read(&mut trailing).expect("read client EOF"),
+            0,
+            "client must close after consuming the Quit Reply"
+        );
+    });
+
+    let child = spawn_generated_main(&project, &link);
+    let output = wait_for_output(child, Duration::from_secs(10)).expect("generated main must exit");
+    server.join().expect("wire server");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "generated main failed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("ipc-echo ok: message=\"keld\" count=1"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("app: main process ready (IPC echo ok)"),
+        "{stdout}"
+    );
+}
+
+/// A peer that starts a lifecycle frame and then stalls must not turn the
+/// idle-event exception into an unbounded read. The first header byte starts
+/// the adapter's absolute frame deadline; Bun must fail and close the link.
+#[test]
+fn created_template_rejects_a_stalled_lifecycle_frame() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_project(dir.path(), "app").expect("create");
+    let project = dir.path().join("app");
+
+    let listener = BootstrapListener::bind().expect("bind app-link");
+    let link = listener.app_link();
+    let server = thread::spawn(move || {
+        let mut stream = listener
+            .accept_authenticated()
+            .expect("accept app-link")
+            .expect("client must authenticate");
+        stream
+            .set_app_link_deadlines(Some(APP_LINK_IO_DEADLINE))
+            .expect("set app-link deadlines");
+        send_ready_then_reply_to_stock_echo(&mut stream);
+
+        let header = FrameHeader {
+            kind: FrameKind::Event,
+            flags: 0,
+            channel: LIFECYCLE_CHANNEL,
+            corr: CorrelationId(0),
+            len: 1,
+        }
+        .encode();
+        stream
+            .write_all(&header[..1])
+            .expect("send first byte of a lifecycle frame");
+        stream
+            .flush()
+            .expect("make the stalled frame byte observable");
+        stream
+            .set_app_link_read_deadline(Some(APP_LINK_IO_DEADLINE + Duration::from_secs(2)))
+            .expect("bound EOF observation");
+        let mut trailing = [0_u8; 1];
+        assert_eq!(
+            stream
+                .read(&mut trailing)
+                .expect("client closes after frame timeout"),
+            0,
+            "timed-out client must close its app-link"
+        );
+    });
+
+    let child = spawn_generated_main(&project, &link);
+    let output = wait_for_output(child, Duration::from_secs(10)).expect("bounded client failure");
+    server.join().expect("wire server");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "stalled frame must fail: {stderr}"
+    );
+    assert!(stderr.contains("KELD-IPC-006"), "{stderr}");
+}
+
+/// Peer close while the stock app is waiting for a lifecycle Event remains a
+/// hard link failure. It must reject and reap rather than returning to a park.
+#[test]
+fn created_template_reaps_after_early_lifecycle_link_close() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_project(dir.path(), "app").expect("create");
+    let project = dir.path().join("app");
+
+    let listener = BootstrapListener::bind().expect("bind app-link");
+    let link = listener.app_link();
+    let server = thread::spawn(move || {
+        let mut stream = listener
+            .accept_authenticated()
+            .expect("accept app-link")
+            .expect("client must authenticate");
+        stream
+            .set_app_link_deadlines(Some(APP_LINK_IO_DEADLINE))
+            .expect("set app-link deadlines");
+        send_ready_then_reply_to_stock_echo(&mut stream);
+    });
+
+    let child = spawn_generated_main(&project, &link);
+    server.join().expect("wire server");
+    let output = wait_for_output(child, Duration::from_secs(5)).expect("bounded client failure");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "early close must fail: {stderr}");
+    assert!(stderr.contains("KELD-IPC-001"), "{stderr}");
 }
 
 #[test]

--- a/crates/keld-cli/tests/bun_echo.rs
+++ b/crates/keld-cli/tests/bun_echo.rs
@@ -204,6 +204,36 @@ fn spawn_generated_main(project: &Path, link: &str) -> ObservedChild {
     )
 }
 
+fn add_entrypoint_diagnostic(project: &Path) {
+    const GUARD: &str = "if (import.meta.main) {";
+    const DIAGNOSTIC: &str = r#"console.error("KEL185_ENTRYPOINT_DIAGNOSTIC " + JSON.stringify({
+  schema: "kel185-entrypoint-diagnostic/v1",
+  bunVersion: Bun.version,
+  bunRevision: Bun.revision,
+  execPath: process.execPath,
+  pid: process.pid,
+  cwd: process.cwd(),
+  argv: process.argv,
+  importMetaMain: import.meta.main,
+  importMetaPath: import.meta.path,
+  keldAppLinkPresent: typeof process.env.KELD_APP_LINK === "string" && process.env.KELD_APP_LINK.length > 0,
+}));
+
+"#;
+    let main_path = project.join("src/main.ts");
+    let main = std::fs::read_to_string(&main_path).expect("read generated main");
+    assert_eq!(
+        main.matches(GUARD).count(),
+        1,
+        "generated main must have one entrypoint guard"
+    );
+    std::fs::write(
+        &main_path,
+        main.replacen(GUARD, &format!("{DIAGNOSTIC}{GUARD}"), 1),
+    )
+    .expect("write diagnostic generated main");
+}
+
 const NO_CLIENT_ADMISSION_CHILD: &str = "created_template_server_admission_without_client_child";
 
 /// The lifecycle wire fixture must report a generated-main launch/admission
@@ -275,6 +305,106 @@ fn created_template_pre_auth_failure_preserves_child_diagnostics() {
         assert!(error.contains("status=Some(23)"), "{error}");
         assert!(error.contains(MARKER), "{error}");
     }
+}
+
+/// Diagnostic-only fixture for the hosted Windows zero-output exit. The three
+/// lifecycle wire tests below remain untouched stock generators, so this
+/// record cannot make their acceptance pass. A false entrypoint flag fails
+/// with the redacted identity record captured through the same file-backed path.
+#[test]
+fn created_template_entrypoint_identity_precedes_the_main_guard() {
+    const PREFIX: &str = "KEL185_ENTRYPOINT_DIAGNOSTIC ";
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_project(dir.path(), "app").expect("create");
+    let project = dir.path().join("app");
+    add_entrypoint_diagnostic(&project);
+
+    let listener = BootstrapListener::bind().expect("bind app-link");
+    let link = listener.app_link();
+    let admission_deadline = Instant::now() + Duration::from_secs(2);
+    let server =
+        thread::spawn(move || accept_generated_main(&listener, admission_deadline).map(|_| ()));
+    let child = spawn_generated_main(&project, &link);
+    let output = wait_for_output(child, Duration::from_secs(4)).expect("bounded diagnostic child");
+    let admission = server.join().expect("diagnostic server thread");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let record = stderr
+        .lines()
+        .find_map(|line| line.strip_prefix(PREFIX))
+        .unwrap_or_else(|| {
+            panic!(
+                "diagnostic record missing from file-backed stderr; child {}",
+                output_diagnostics(&output)
+            )
+        });
+    let record: serde_json::Value = serde_json::from_str(record).unwrap_or_else(|error| {
+        panic!(
+            "invalid entrypoint JSON: {error}; raw_record={record:?}; child {}",
+            output_diagnostics(&output)
+        )
+    });
+    let evidence = || format!("identity={record}; child {}", output_diagnostics(&output));
+    assert_eq!(
+        record["schema"],
+        "kel185-entrypoint-diagnostic/v1",
+        "{}",
+        evidence()
+    );
+    assert_eq!(record["keldAppLinkPresent"], true, "{}", evidence());
+    assert!(
+        record["bunVersion"].as_str().is_some_and(|v| !v.is_empty()),
+        "{}",
+        evidence()
+    );
+    assert!(
+        record["bunRevision"]
+            .as_str()
+            .is_some_and(|v| !v.is_empty()),
+        "{}",
+        evidence()
+    );
+    assert!(
+        record["execPath"].as_str().is_some_and(|v| !v.is_empty()),
+        "{}",
+        evidence()
+    );
+    assert!(
+        record["pid"].as_u64().is_some_and(|pid| pid > 0),
+        "{}",
+        evidence()
+    );
+    assert!(
+        record["cwd"].as_str().is_some_and(|v| !v.is_empty()),
+        "{}",
+        evidence()
+    );
+    assert!(
+        record["argv"].as_array().is_some_and(|v| !v.is_empty()),
+        "{}",
+        evidence()
+    );
+    assert!(
+        record["importMetaPath"]
+            .as_str()
+            .is_some_and(|v| !v.is_empty()),
+        "{}",
+        evidence()
+    );
+    assert_eq!(
+        record["importMetaMain"],
+        true,
+        "generated entrypoint guard would be skipped; {}",
+        evidence()
+    );
+    admission.unwrap_or_else(|error| {
+        panic!(
+            "main=true diagnostic child did not authenticate: {error}; {}",
+            evidence()
+        )
+    });
+    println!("{PREFIX}{record}");
 }
 
 #[test]

--- a/crates/keld-cli/tests/bun_echo.rs
+++ b/crates/keld-cli/tests/bun_echo.rs
@@ -2,8 +2,9 @@
 
 #![allow(clippy::expect_used)] // extra test crate: expect is the assertion oracle
 
+use std::fs::File;
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::mpsc;
 use std::thread;
@@ -13,35 +14,147 @@ use keld_cli::create::create_project;
 use keld_cli::echo_link::EchoServer;
 use keld_ipc::link::{read_frame, write_frame};
 use keld_ipc::{
-    APP_LINK_IO_DEADLINE, AppLinkDeadlines, BootstrapListener, ChannelId, CorrelationId,
+    APP_LINK_IO_DEADLINE, AppLinkDeadlines, BootstrapAdmission, BootstrapListener,
+    BootstrapRejection, BootstrapRejectionObserver, BootstrapStream, ChannelId, CorrelationId,
     ECHO_CHANNEL, EchoRequest, EchoResponse, FrameHeader, FrameKind, LIFECYCLE_CHANNEL,
     LifecycleEvent, LifecycleRequest, LifecycleResponse,
 };
 
-fn wait_for_output(mut child: Child, timeout: Duration) -> Result<Output, String> {
-    let started = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => {
-                return child
-                    .wait_with_output()
-                    .map_err(|error| format!("collect child output: {error}"));
+struct ObservedChild {
+    child: Option<Child>,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+}
+
+impl ObservedChild {
+    fn wait_for_output(mut self, timeout: Duration) -> Result<Output, String> {
+        let child = self.child.as_mut().expect("observed child present");
+        let started = Instant::now();
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) if started.elapsed() < timeout => {
+                    thread::park_timeout(Duration::from_millis(10));
+                }
+                Ok(None) => {
+                    let _ = child.kill();
+                    let status = child
+                        .wait()
+                        .map_err(|error| format!("reap timed-out child: {error}"))?;
+                    self.child.take();
+                    let output = self.output(status)?;
+                    return Err(format!(
+                        "child did not exit within {timeout:?}; stdout={} stderr={}",
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
+                Err(error) => return Err(format!("poll child exit: {error}")),
             }
-            Ok(None) if started.elapsed() < timeout => thread::yield_now(),
-            Ok(None) => {
+        };
+        self.child.take();
+        self.output(status)
+    }
+
+    fn output(&self, status: std::process::ExitStatus) -> Result<Output, String> {
+        Ok(Output {
+            status,
+            stdout: std::fs::read(&self.stdout_path)
+                .map_err(|error| format!("read child stdout: {error}"))?,
+            stderr: std::fs::read(&self.stderr_path)
+                .map_err(|error| format!("read child stderr: {error}"))?,
+        })
+    }
+}
+
+impl Drop for ObservedChild {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            if child.try_wait().is_ok_and(|status| status.is_none()) {
                 let _ = child.kill();
-                let output = child
-                    .wait_with_output()
-                    .map_err(|error| format!("reap timed-out child: {error}"))?;
-                return Err(format!(
-                    "child did not exit within {timeout:?}; stdout={} stderr={}",
-                    String::from_utf8_lossy(&output.stdout),
-                    String::from_utf8_lossy(&output.stderr)
-                ));
             }
-            Err(error) => return Err(format!("poll child exit: {error}")),
+            let _ = child.wait();
         }
     }
+}
+
+fn spawn_observed(command: &mut Command, output_root: &Path) -> ObservedChild {
+    let stdout_path = output_root.join("child.stdout.log");
+    let stderr_path = output_root.join("child.stderr.log");
+    let stdout = File::create(&stdout_path).expect("create child stdout log");
+    let stderr = File::create(&stderr_path).expect("create child stderr log");
+    let child = command
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .expect("spawn observed child");
+    ObservedChild {
+        child: Some(child),
+        stdout_path,
+        stderr_path,
+    }
+}
+
+struct IgnoreBootstrapRejections;
+
+impl BootstrapRejectionObserver for IgnoreBootstrapRejections {
+    fn rejected(&self, _rejection: BootstrapRejection) {}
+}
+
+fn accept_generated_main(
+    listener: &BootstrapListener,
+    deadline: Instant,
+) -> Result<BootstrapStream, String> {
+    match listener.accept_authenticated_until(deadline, &IgnoreBootstrapRejections) {
+        Ok(BootstrapAdmission::Authenticated(stream)) => Ok(stream),
+        Ok(BootstrapAdmission::DeadlineElapsed) => {
+            Err("generated main did not authenticate before the admission deadline".to_owned())
+        }
+        Ok(BootstrapAdmission::Cancelled) => {
+            Err("generated-main admission was cancelled".to_owned())
+        }
+        Err(error) => Err(format!("accept generated-main app-link: {error}")),
+    }
+}
+
+fn wait_for_output(child: ObservedChild, timeout: Duration) -> Result<Output, String> {
+    child.wait_for_output(timeout)
+}
+
+fn output_diagnostics(output: &Output) -> String {
+    format!(
+        "status={:?} stdout={} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn finish_lifecycle_fixture(
+    server: thread::JoinHandle<Result<(), String>>,
+    child: ObservedChild,
+    child_timeout: Duration,
+) -> Result<Output, String> {
+    let child_result = wait_for_output(child, child_timeout);
+    match (server.join(), child_result) {
+        (Ok(Ok(())), output) => output,
+        (Ok(Err(server_error)), Ok(output)) => Err(format!(
+            "wire server failed: {server_error}; child {}",
+            output_diagnostics(&output)
+        )),
+        (Ok(Err(server_error)), Err(child_error)) => {
+            Err(format!("wire server failed: {server_error}; {child_error}"))
+        }
+        (Err(_), Ok(output)) => Err(format!(
+            "wire server panicked; child {}",
+            output_diagnostics(&output)
+        )),
+        (Err(_), Err(child_error)) => Err(format!("wire server panicked; {child_error}")),
+    }
+}
+
+fn fixture_admission_deadline() -> Instant {
+    Instant::now() + Duration::from_secs(10)
 }
 
 fn send_ready_then_reply_to_stock_echo<S: Read + Write>(stream: &mut S) -> CorrelationId {
@@ -81,15 +194,87 @@ fn send_ready_then_reply_to_stock_echo<S: Read + Write>(stream: &mut S) -> Corre
     echo_header.corr
 }
 
-fn spawn_generated_main(project: &Path, link: &str) -> Child {
-    Command::new("bun")
-        .args(["run", "src/main.ts"])
-        .current_dir(project)
-        .env("KELD_APP_LINK", link)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn generated main under Bun")
+fn spawn_generated_main(project: &Path, link: &str) -> ObservedChild {
+    spawn_observed(
+        Command::new("bun")
+            .args(["run", "src/main.ts"])
+            .current_dir(project)
+            .env("KELD_APP_LINK", link),
+        project,
+    )
+}
+
+const NO_CLIENT_ADMISSION_CHILD: &str = "created_template_server_admission_without_client_child";
+
+/// The lifecycle wire fixture must report a generated-main launch/admission
+/// failure instead of leaving its server worker blocked for the test binary's
+/// lifetime. The child isolates the deliberately absent client so the parent
+/// can reap the current unbounded implementation with an independent kill switch.
+#[test]
+fn created_template_server_admission_without_client_is_bounded() {
+    let output_dir = tempfile::tempdir().expect("no-client output tempdir");
+    let test_binary = std::env::current_exe().expect("current bun_echo test binary");
+    let child = spawn_observed(
+        Command::new(test_binary).args([
+            "--exact",
+            NO_CLIENT_ADMISSION_CHILD,
+            "--ignored",
+            "--nocapture",
+        ]),
+        output_dir.path(),
+    );
+
+    let output = wait_for_output(child, Duration::from_secs(2))
+        .expect("no-client admission fixture must terminate with a bounded result");
+    assert!(
+        output.status.success(),
+        "no-client admission fixture failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+#[ignore = "spawned only by the bounded no-client admission parent"]
+fn created_template_server_admission_without_client_child() {
+    let listener = BootstrapListener::bind().expect("bind no-client app-link");
+    let error = accept_generated_main(&listener, Instant::now() + Duration::from_millis(250))
+        .expect_err("no-client admission must report its absolute deadline");
+    assert!(error.contains("admission deadline"), "{error}");
+}
+
+/// A generated main that exits before authenticating must leave its status and
+/// stderr in every KEL-185 lifecycle fixture failure path.
+#[test]
+fn created_template_pre_auth_failure_preserves_child_diagnostics() {
+    const MARKER: &str = "KEL185_PREAUTH_FAILURE";
+
+    for path in ["last-window-closed", "stalled-frame", "early-close"] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        create_project(dir.path(), "app").expect("create");
+        let project = dir.path().join("app");
+        std::fs::write(
+            project.join("src/main.ts"),
+            format!("console.error({MARKER:?}); process.exit(23);\n"),
+        )
+        .expect("write pre-auth failure main");
+
+        let listener = BootstrapListener::bind().expect("bind app-link");
+        let link = listener.app_link();
+        let admission_deadline = Instant::now() + Duration::from_millis(250);
+        let server = thread::spawn(move || {
+            accept_generated_main(&listener, admission_deadline)
+                .map(|_| ())
+                .map_err(|error| format!("{path}: {error}"))
+        });
+        let child = spawn_generated_main(&project, &link);
+
+        let error = finish_lifecycle_fixture(server, child, Duration::from_secs(2))
+            .expect_err("pre-auth failure is not a successful lifecycle session");
+        assert!(error.contains(path), "{error}");
+        assert!(error.contains("status=Some(23)"), "{error}");
+        assert!(error.contains(MARKER), "{error}");
+    }
 }
 
 #[test]
@@ -291,11 +476,9 @@ fn created_template_quits_after_last_window_closed_on_the_same_link() {
 
     let listener = BootstrapListener::bind().expect("bind app-link");
     let link = listener.app_link();
-    let server = thread::spawn(move || {
-        let mut stream = listener
-            .accept_authenticated()
-            .expect("accept app-link")
-            .expect("client must authenticate");
+    let admission_deadline = fixture_admission_deadline();
+    let server = thread::spawn(move || -> Result<(), String> {
+        let mut stream = accept_generated_main(&listener, admission_deadline)?;
         stream
             .set_app_link_deadlines(Some(APP_LINK_IO_DEADLINE))
             .expect("set app-link deadlines");
@@ -368,11 +551,12 @@ fn created_template_quits_after_last_window_closed_on_the_same_link() {
             0,
             "client must close after consuming the Quit Reply"
         );
+        Ok(())
     });
 
     let child = spawn_generated_main(&project, &link);
-    let output = wait_for_output(child, Duration::from_secs(10)).expect("generated main must exit");
-    server.join().expect("wire server");
+    let output = finish_lifecycle_fixture(server, child, Duration::from_secs(10))
+        .expect("generated main must exit");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -401,11 +585,9 @@ fn created_template_rejects_a_stalled_lifecycle_frame() {
 
     let listener = BootstrapListener::bind().expect("bind app-link");
     let link = listener.app_link();
-    let server = thread::spawn(move || {
-        let mut stream = listener
-            .accept_authenticated()
-            .expect("accept app-link")
-            .expect("client must authenticate");
+    let admission_deadline = fixture_admission_deadline();
+    let server = thread::spawn(move || -> Result<(), String> {
+        let mut stream = accept_generated_main(&listener, admission_deadline)?;
         stream
             .set_app_link_deadlines(Some(APP_LINK_IO_DEADLINE))
             .expect("set app-link deadlines");
@@ -436,11 +618,12 @@ fn created_template_rejects_a_stalled_lifecycle_frame() {
             0,
             "timed-out client must close its app-link"
         );
+        Ok(())
     });
 
     let child = spawn_generated_main(&project, &link);
-    let output = wait_for_output(child, Duration::from_secs(10)).expect("bounded client failure");
-    server.join().expect("wire server");
+    let output = finish_lifecycle_fixture(server, child, Duration::from_secs(10))
+        .expect("bounded client failure");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         !output.status.success(),
@@ -459,20 +642,19 @@ fn created_template_reaps_after_early_lifecycle_link_close() {
 
     let listener = BootstrapListener::bind().expect("bind app-link");
     let link = listener.app_link();
-    let server = thread::spawn(move || {
-        let mut stream = listener
-            .accept_authenticated()
-            .expect("accept app-link")
-            .expect("client must authenticate");
+    let admission_deadline = fixture_admission_deadline();
+    let server = thread::spawn(move || -> Result<(), String> {
+        let mut stream = accept_generated_main(&listener, admission_deadline)?;
         stream
             .set_app_link_deadlines(Some(APP_LINK_IO_DEADLINE))
             .expect("set app-link deadlines");
         send_ready_then_reply_to_stock_echo(&mut stream);
+        Ok(())
     });
 
     let child = spawn_generated_main(&project, &link);
-    server.join().expect("wire server");
-    let output = wait_for_output(child, Duration::from_secs(5)).expect("bounded client failure");
+    let output = finish_lifecycle_fixture(server, child, Duration::from_secs(5))
+        .expect("bounded client failure");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!output.status.success(), "early close must fail: {stderr}");
     assert!(stderr.contains("KELD-IPC-001"), "{stderr}");

--- a/crates/keld-cli/tests/bun_echo.rs
+++ b/crates/keld-cli/tests/bun_echo.rs
@@ -195,12 +195,15 @@ fn send_ready_then_reply_to_stock_echo<S: Read + Write>(stream: &mut S) -> Corre
 }
 
 fn spawn_generated_main(project: &Path, link: &str) -> ObservedChild {
+    let project = std::fs::canonicalize(project).expect("canonical generated project");
+    let main = project.join("src/main.ts");
     spawn_observed(
         Command::new("bun")
-            .args(["run", "src/main.ts"])
-            .current_dir(project)
+            .arg("run")
+            .arg(&main)
+            .current_dir(&project)
             .env("KELD_APP_LINK", link),
-        project,
+        &project,
     )
 }
 
@@ -208,6 +211,7 @@ fn add_entrypoint_diagnostic(project: &Path) {
     const GUARD: &str = "if (import.meta.main) {";
     const DIAGNOSTIC: &str = r#"console.error("KEL185_ENTRYPOINT_DIAGNOSTIC " + JSON.stringify({
   schema: "kel185-entrypoint-diagnostic/v1",
+  bunMain: Bun.main,
   bunVersion: Bun.version,
   bunRevision: Bun.revision,
   execPath: process.execPath,
@@ -232,6 +236,61 @@ fn add_entrypoint_diagnostic(project: &Path) {
         main.replacen(GUARD, &format!("{DIAGNOSTIC}{GUARD}"), 1),
     )
     .expect("write diagnostic generated main");
+}
+
+const ENTRYPOINT_DIAGNOSTIC_PREFIX: &str = "KEL185_ENTRYPOINT_DIAGNOSTIC ";
+
+fn capture_entrypoint_identity(project: &Path) -> (Output, Result<(), String>, serde_json::Value) {
+    let listener = BootstrapListener::bind().expect("bind app-link");
+    let link = listener.app_link();
+    let admission_deadline = Instant::now() + Duration::from_secs(2);
+    let server =
+        thread::spawn(move || accept_generated_main(&listener, admission_deadline).map(|_| ()));
+    let child = spawn_generated_main(project, &link);
+    let output = wait_for_output(child, Duration::from_secs(4)).expect("bounded diagnostic child");
+    let admission = server.join().expect("diagnostic server thread");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let record = stderr
+        .lines()
+        .find_map(|line| line.strip_prefix(ENTRYPOINT_DIAGNOSTIC_PREFIX));
+    assert!(
+        record.is_some(),
+        "diagnostic record missing from file-backed stderr; child {}",
+        output_diagnostics(&output)
+    );
+    let record = record.expect("record presence asserted");
+    let parsed = serde_json::from_str(record);
+    assert!(
+        parsed.is_ok(),
+        "invalid entrypoint JSON: {}; raw_record={record:?}; child {}",
+        parsed.as_ref().expect_err("parse failure asserted"),
+        output_diagnostics(&output)
+    );
+    let record = parsed.expect("entrypoint JSON validity asserted");
+    (output, admission, record)
+}
+
+#[cfg(windows)]
+fn windows_short_path(path: &Path) -> PathBuf {
+    let script = path.join("kel185-short-path.cmd");
+    std::fs::write(&script, "@for %%I in (\"%~1\") do @echo %%~sI\r\n")
+        .expect("write short-path query script");
+    let output = Command::new("cmd.exe")
+        .args(["/D", "/C"])
+        .arg(&script)
+        .arg(path)
+        .output()
+        .expect("run GetShortPathName command expansion");
+    assert!(
+        output.status.success(),
+        "short-path query failed: {}",
+        output_diagnostics(&output)
+    );
+    let short = String::from_utf8(output.stdout).expect("short path is UTF-8");
+    let short = short.trim();
+    assert!(!short.is_empty(), "short-path query returned no path");
+    PathBuf::from(short)
 }
 
 const NO_CLIENT_ADMISSION_CHILD: &str = "created_template_server_admission_without_client_child";
@@ -313,38 +372,12 @@ fn created_template_pre_auth_failure_preserves_child_diagnostics() {
 /// with the redacted identity record captured through the same file-backed path.
 #[test]
 fn created_template_entrypoint_identity_precedes_the_main_guard() {
-    const PREFIX: &str = "KEL185_ENTRYPOINT_DIAGNOSTIC ";
-
     let dir = tempfile::tempdir().expect("tempdir");
     create_project(dir.path(), "app").expect("create");
     let project = dir.path().join("app");
     add_entrypoint_diagnostic(&project);
 
-    let listener = BootstrapListener::bind().expect("bind app-link");
-    let link = listener.app_link();
-    let admission_deadline = Instant::now() + Duration::from_secs(2);
-    let server =
-        thread::spawn(move || accept_generated_main(&listener, admission_deadline).map(|_| ()));
-    let child = spawn_generated_main(&project, &link);
-    let output = wait_for_output(child, Duration::from_secs(4)).expect("bounded diagnostic child");
-    let admission = server.join().expect("diagnostic server thread");
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let record = stderr
-        .lines()
-        .find_map(|line| line.strip_prefix(PREFIX))
-        .unwrap_or_else(|| {
-            panic!(
-                "diagnostic record missing from file-backed stderr; child {}",
-                output_diagnostics(&output)
-            )
-        });
-    let record: serde_json::Value = serde_json::from_str(record).unwrap_or_else(|error| {
-        panic!(
-            "invalid entrypoint JSON: {error}; raw_record={record:?}; child {}",
-            output_diagnostics(&output)
-        )
-    });
+    let (output, admission, record) = capture_entrypoint_identity(&project);
     let evidence = || format!("identity={record}; child {}", output_diagnostics(&output));
     assert_eq!(
         record["schema"],
@@ -353,6 +386,11 @@ fn created_template_entrypoint_identity_precedes_the_main_guard() {
         evidence()
     );
     assert_eq!(record["keldAppLinkPresent"], true, "{}", evidence());
+    assert!(
+        record["bunMain"].as_str().is_some_and(|v| !v.is_empty()),
+        "{}",
+        evidence()
+    );
     assert!(
         record["bunVersion"].as_str().is_some_and(|v| !v.is_empty()),
         "{}",
@@ -398,13 +436,59 @@ fn created_template_entrypoint_identity_precedes_the_main_guard() {
         "generated entrypoint guard would be skipped; {}",
         evidence()
     );
-    admission.unwrap_or_else(|error| {
-        panic!(
-            "main=true diagnostic child did not authenticate: {error}; {}",
-            evidence()
-        )
-    });
-    println!("{PREFIX}{record}");
+    assert!(
+        admission.is_ok(),
+        "main=true diagnostic child did not authenticate: {}; {}",
+        admission.as_ref().expect_err("admission failure asserted"),
+        evidence()
+    );
+    println!("{ENTRYPOINT_DIAGNOSTIC_PREFIX}{record}");
+}
+
+/// Runs the real Rust launch/file-capture path against two spellings of the
+/// same generated project. A short-name mismatch must fail with both Bun path
+/// identities before any canonicalization change is considered.
+#[cfg(windows)]
+#[test]
+#[ignore = "requires an explicit Windows temp root with a distinct 8.3 short alias"]
+fn created_template_entrypoint_matches_through_a_short_path_alias() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_project(dir.path(), "app").expect("create");
+    let project = dir.path().join("app");
+    add_entrypoint_diagnostic(&project);
+    let short_project = windows_short_path(&project);
+    assert_ne!(short_project, project, "8.3 alias is unavailable");
+    let canonical_short = std::fs::canonicalize(&short_project);
+    assert!(
+        canonical_short.is_ok(),
+        "canonical short project {short_project:?}: {}",
+        canonical_short
+            .as_ref()
+            .expect_err("canonicalization failure asserted")
+    );
+    assert_eq!(
+        canonical_short.expect("short path canonicalization asserted"),
+        std::fs::canonicalize(&project).expect("canonical long project"),
+        "long and short paths must identify the same project"
+    );
+
+    for (label, path) in [
+        ("long", project.as_path()),
+        ("short", short_project.as_path()),
+    ] {
+        let (output, admission, record) = capture_entrypoint_identity(path);
+        let evidence = format!(
+            "{label} identity={record}; child {}",
+            output_diagnostics(&output)
+        );
+        assert_eq!(record["importMetaMain"], true, "{evidence}");
+        assert_eq!(record["bunMain"], record["importMetaPath"], "{evidence}");
+        assert!(
+            admission.is_ok(),
+            "{label} admission failed: {}; {evidence}",
+            admission.as_ref().expect_err("admission failure asserted")
+        );
+    }
 }
 
 #[test]

--- a/crates/keld-cli/tests/window_phase_crash.rs
+++ b/crates/keld-cli/tests/window_phase_crash.rs
@@ -183,7 +183,7 @@ fn healthy_window_phase_still_exits_zero() {
 /// Regression: status zero is still self-termination when the window path
 /// requires the app to remain alive.
 ///
-/// This is the shipping template with only its parking line changed. The real
+/// This is the shipping template with only its lifecycle-wait line changed. The real
 /// Bun child completes HELLO + echo, prints the real ready marker, then exits
 /// zero before the injected window phase returns. The process-status oracle
 /// proves the host did not cause the exit.
@@ -192,12 +192,12 @@ fn ready_then_exit_zero_fails_the_window_path() {
     let dir = tempfile::tempdir().expect("tempdir");
     let name = format!("z{}", std::process::id());
     let (root, pid_path) = project_with_main_rewrite(dir.path(), &name, |scaffolded| {
-        let parked = "  await new Promise(() => {});";
+        let lifecycle_wait = "    await quitAfterLastWindowClosed(session);";
         assert!(
-            scaffolded.contains(parked),
-            "template shape changed; this fixture edits its parking line"
+            scaffolded.contains(lifecycle_wait),
+            "template shape changed; this fixture edits its lifecycle-wait line"
         );
-        scaffolded.replace(parked, "  process.exit(0);")
+        scaffolded.replace(lifecycle_wait, "    process.exit(0);")
     });
 
     let msg = window_error_after_child_exits(&root, &pid_path);
@@ -216,18 +216,21 @@ fn finally_process_exit_zero_fails_the_window_path() {
     let dir = tempfile::tempdir().expect("tempdir");
     let name = format!("f{}", std::process::id());
     let (root, pid_path) = project_with_main_rewrite(dir.path(), &name, |scaffolded| {
-        let parked = "  await new Promise(() => {});";
+        let lifecycle_wait = "    await quitAfterLastWindowClosed(session);";
         let finally_close = "  session.close();";
         assert!(
-            scaffolded.contains(parked),
-            "template parking shape changed"
+            scaffolded.contains(lifecycle_wait),
+            "template lifecycle-wait shape changed"
         );
         assert!(
             scaffolded.contains(finally_close),
             "template finally shape changed"
         );
         scaffolded
-            .replace(parked, "  throw new Error(\"kel116-finally-boom\");")
+            .replace(
+                lifecycle_wait,
+                "    throw new Error(\"kel116-finally-boom\");",
+            )
             .replace(finally_close, "  session.close();\n  process.exit();")
     });
 
@@ -341,7 +344,7 @@ fn a_later_readiness_wait_does_not_forgive_a_post_ready_crash() {
 /// stdout position is what separates "crashed, then printed" from "printed,
 /// then crashed".
 ///
-/// The fixture is the shipping template with only its parking line changed, so
+/// The fixture is the shipping template with only its lifecycle-wait line changed, so
 /// generation 1 does a real HELLO + CALL and prints the real ready line before
 /// dying. Generation 2 parks *before* the handshake, so exactly one crash
 /// occurs and the supervisor's terminal outcome stays `Stopped` — otherwise the
@@ -355,12 +358,12 @@ fn an_app_that_dies_after_reporting_ready_fails_the_run() {
     let gen_lit = gen_path.display().to_string();
     let main = root.join("src/main.ts");
     let scaffolded = fs::read_to_string(&main).expect("scaffolded main.ts");
-    let parked = "  await new Promise(() => {});";
+    let lifecycle_wait = "    await quitAfterLastWindowClosed(session);";
     assert!(
-        scaffolded.contains(parked),
-        "template shape changed; this fixture edits its parking line"
+        scaffolded.contains(lifecycle_wait),
+        "template shape changed; this fixture edits its lifecycle-wait line"
     );
-    let body = scaffolded.replace(parked, "  process.exit(1);");
+    let body = scaffolded.replace(lifecycle_wait, "    process.exit(1);");
     fs::write(
         &main,
         format!(

--- a/docs/architecture/02-ipc.md
+++ b/docs/architecture/02-ipc.md
@@ -131,9 +131,10 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   `src/main.ts`. The boot compiler stages `src/kipc-transport.ts` when present.
   `@keld/electron` imports that same transport. `DirectedReader` parks
   lifecycle Events while an Echo Reply is awaited so a host `Ready` cannot
-  fail stock echo (KEL-185 consumes Quit on this same stream later). The
-  scaffold speaks only the ungated echo channel and does not decode `ERR`
-  payloads.
+  fail stock echo. The stock scaffold consumes `LastWindowClosed` and sends a
+  correlated `Quit` on this same stream; its persistent reader leaves idle
+  Event waits open but starts the five-second frame deadline at the first byte
+  (KEL-185). The scaffold does not decode `ERR` payloads.
 - **HELLO payload (v2):** exactly 32 bytes — the session token minted by the host
   (KEL-60). It is raw bytes, not postcard. Before token comparison, the receiver
   requires `kind=HELLO`, zero flags/channel/correlation, and declared payload

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -26,7 +26,7 @@ wrapper or packaged application release to install yet.
   |---|---|
   | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
   | Windows | Rust's MSVC build tools and the WebView2 runtime; use an interactive PowerShell session for the qualified `dev`/Ctrl-C path; stock native Close remains incomplete |
-  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; two native-Close/cleanup/relaunch runs passed on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228) at source `a843b32` on Ubuntu 26.04.1 x86_64 / GNOME 50.1 Wayland with Bun 1.4.2 and WebKitGTK 2.52.6; X11 product runs and other distributions remain unverified |
+  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; native Close/cleanup/relaunch qualified on Ubuntu 26.04.1 / GNOME Wayland; X11 product runs and other distributions remain unverified |
 
 The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
 A desktop session and the required Linux containment primitives are separate from
@@ -119,23 +119,24 @@ one. Expected behavior:
 
 4. Check that the host/Bun session and its nonce directory under `.keld/dev` are gone
    before a new run. The linked Windows and Ubuntu quick-start records observed Ctrl-C
-   cleanup. Separately, two untouched stock runs on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228)
-   at source `a843b32` observed native Close cleanup and relaunch in the named Ubuntu
-   environment above; this is not final-rebased-head native proof.
+   cleanup; see [qualified native-Close evidence](#qualified-linux-native-close-evidence)
+   for the separate normal-close path.
 
-**Normal-close evidence is environment- and source-qualified.** The historical
+### Qualified Linux native Close evidence
+
+The historical
 [public Ubuntu/Wayland failure record](https://github.com/gyldlab/keld/issues/167#issuecomment-5575535917)
 reports that clicking the stock app's Close button removed the renderer but left CLI,
 host, Bun, and the launch stage alive beyond an independent 20-second observation.
 The later [Ubuntu quick-start refresh](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
 verified Ctrl-C cleanup and relaunch but did not retry native Close. The stock-app
-correction is in [PR #228](https://github.com/gyldlab/keld/pull/228). Two untouched
+correction is in [PR #228](https://github.com/gyldlab/keld/pull/228). Two untouched stock
 runs on its source `a843b32` passed native Close, cleanup, and relaunch on Ubuntu
-26.04.1 x86_64 with GNOME 50.1 Wayland, Bun 1.4.2, and WebKitGTK 2.52.6: both CLI
-processes exited 0, all 20 observed pidfds exited, and two distinct launch stages were
-absent without forced cleanup. Root will capture fresh native evidence for the final
-rebased PR head before merge. No public Mac device record is cited here, so macOS native
-Close remains unverified. The
+26.04.1 x86_64 with GNOME 50.1 Wayland, Bun 1.4.2, and WebKitGTK 2.52.6. Both CLI
+processes exited 0; 20 observed process identities exited, two distinct launch stages
+were absent, and no forced cleanup was used. This evidence qualifies that source and
+environment only. No public Mac device record is cited here, so macOS native Close
+remains unverified. The
 [final-source Windows run](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
 also leaves stock native Close incomplete; its passing Ctrl-C result does not replace it.
 

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -26,7 +26,7 @@ wrapper or packaged application release to install yet.
   |---|---|
   | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
   | Windows | Rust's MSVC build tools and the WebView2 runtime; use an interactive PowerShell session for the qualified `dev`/Ctrl-C path; stock native Close remains incomplete |
-  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; stock native Close currently fails, and X11 product runs and other distributions remain unverified |
+  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; two native-Close/cleanup/relaunch runs passed on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228) at source `a843b32` on Ubuntu 26.04.1 x86_64 / GNOME 50.1 Wayland with Bun 1.4.2 and WebKitGTK 2.52.6; X11 product runs and other distributions remain unverified |
 
 The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
 A desktop session and the required Linux containment primitives are separate from
@@ -108,7 +108,8 @@ one. Expected behavior:
    project checks.
 2. `dev` opens a native window titled `hello-keld`. Its content says that IPC echo runs
    in the Bun main process.
-3. After inspecting the demo, Ctrl-C requests shutdown. Captured Bun output is
+3. After inspecting the demo, use native Close on the qualified Ubuntu environment
+   above; Ctrl-C remains a separate interrupt-shutdown path. Captured Bun output is
    forwarded at shutdown; do not wait for these lines while the window is open:
 
    ```text
@@ -117,18 +118,24 @@ one. Expected behavior:
    ```
 
 4. Check that the host/Bun session and its nonce directory under `.keld/dev` are gone
-   before a new run. The linked Windows and Ubuntu public records observed Ctrl-C
-   cleanup; it is a separate acceptance case from native window Close.
+   before a new run. The linked Windows and Ubuntu quick-start records observed Ctrl-C
+   cleanup. Separately, two untouched stock runs on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228)
+   at source `a843b32` observed native Close cleanup and relaunch in the named Ubuntu
+   environment above; this is not final-rebased-head native proof.
 
-**Normal-close acceptance is currently incomplete.** The
+**Normal-close evidence is environment- and source-qualified.** The historical
 [public Ubuntu/Wayland failure record](https://github.com/gyldlab/keld/issues/167#issuecomment-5575535917)
 reports that clicking the stock app's Close button removed the renderer but left CLI,
 host, Bun, and the launch stage alive beyond an independent 20-second observation.
 The later [Ubuntu quick-start refresh](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
-verified Ctrl-C cleanup and relaunch but did not retry native Close. The
-[lifecycle issue](https://github.com/gyldlab/keld/issues/176) tracks the stock-app
-correction and its required native-close regression. No public Mac device record is
-cited here, so macOS native Close remains unverified. The
+verified Ctrl-C cleanup and relaunch but did not retry native Close. The stock-app
+correction is in [PR #228](https://github.com/gyldlab/keld/pull/228). Two untouched
+runs on its source `a843b32` passed native Close, cleanup, and relaunch on Ubuntu
+26.04.1 x86_64 with GNOME 50.1 Wayland, Bun 1.4.2, and WebKitGTK 2.52.6: both CLI
+processes exited 0, all 20 observed pidfds exited, and two distinct launch stages were
+absent without forced cleanup. Root will capture fresh native evidence for the final
+rebased PR head before merge. No public Mac device record is cited here, so macOS native
+Close remains unverified. The
 [final-source Windows run](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
 also leaves stock native Close incomplete; its passing Ctrl-C result does not replace it.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -34,7 +34,7 @@ wrapper or packaged application release to install yet.
   |---|---|
   | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
   | Windows | Rust's MSVC build tools and the WebView2 runtime; use an interactive PowerShell session for the qualified `dev`/Ctrl-C path; stock native Close remains incomplete |
-  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; stock native Close currently fails, and X11 product runs and other distributions remain unverified |
+  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; two native-Close/cleanup/relaunch runs passed on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228) at source `a843b32` on Ubuntu 26.04.1 x86_64 / GNOME 50.1 Wayland with Bun 1.4.2 and WebKitGTK 2.52.6; X11 product runs and other distributions remain unverified |
 
 The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
 A desktop session and the required Linux containment primitives are separate from
@@ -116,7 +116,8 @@ one. Expected behavior:
    project checks.
 2. `dev` opens a native window titled `hello-keld`. Its content says that IPC echo runs
    in the Bun main process.
-3. After inspecting the demo, Ctrl-C requests shutdown. Captured Bun output is
+3. After inspecting the demo, use native Close on the qualified Ubuntu environment
+   above; Ctrl-C remains a separate interrupt-shutdown path. Captured Bun output is
    forwarded at shutdown; do not wait for these lines while the window is open:
 
    ```text
@@ -125,18 +126,24 @@ one. Expected behavior:
    ```
 
 4. Check that the host/Bun session and its nonce directory under `.keld/dev` are gone
-   before a new run. The linked Windows and Ubuntu public records observed Ctrl-C
-   cleanup; it is a separate acceptance case from native window Close.
+   before a new run. The linked Windows and Ubuntu quick-start records observed Ctrl-C
+   cleanup. Separately, two untouched stock runs on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228)
+   at source `a843b32` observed native Close cleanup and relaunch in the named Ubuntu
+   environment above; this is not final-rebased-head native proof.
 
-**Normal-close acceptance is currently incomplete.** The
+**Normal-close evidence is environment- and source-qualified.** The historical
 [public Ubuntu/Wayland failure record](https://github.com/gyldlab/keld/issues/167#issuecomment-5575535917)
 reports that clicking the stock app's Close button removed the renderer but left CLI,
 host, Bun, and the launch stage alive beyond an independent 20-second observation.
 The later [Ubuntu quick-start refresh](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
-verified Ctrl-C cleanup and relaunch but did not retry native Close. The
-[lifecycle issue](https://github.com/gyldlab/keld/issues/176) tracks the stock-app
-correction and its required native-close regression. No public Mac device record is
-cited here, so macOS native Close remains unverified. The
+verified Ctrl-C cleanup and relaunch but did not retry native Close. The stock-app
+correction is in [PR #228](https://github.com/gyldlab/keld/pull/228). Two untouched
+runs on its source `a843b32` passed native Close, cleanup, and relaunch on Ubuntu
+26.04.1 x86_64 with GNOME 50.1 Wayland, Bun 1.4.2, and WebKitGTK 2.52.6: both CLI
+processes exited 0, all 20 observed pidfds exited, and two distinct launch stages were
+absent without forced cleanup. Root will capture fresh native evidence for the final
+rebased PR head before merge. No public Mac device record is cited here, so macOS native
+Close remains unverified. The
 [final-source Windows run](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
 also leaves stock native Close incomplete; its passing Ctrl-C result does not replace it.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1339,9 +1339,10 @@ payload:= postcard-encoded schema type (structured) | raw bytes (flags.RAW)
   `src/main.ts`. The boot compiler stages `src/kipc-transport.ts` when present.
   `@keld/electron` imports that same transport. `DirectedReader` parks
   lifecycle Events while an Echo Reply is awaited so a host `Ready` cannot
-  fail stock echo (KEL-185 consumes Quit on this same stream later). The
-  scaffold speaks only the ungated echo channel and does not decode `ERR`
-  payloads.
+  fail stock echo. The stock scaffold consumes `LastWindowClosed` and sends a
+  correlated `Quit` on this same stream; its persistent reader leaves idle
+  Event waits open but starts the five-second frame deadline at the first byte
+  (KEL-185). The scaffold does not decode `ERR` payloads.
 - **HELLO payload (v2):** exactly 32 bytes — the session token minted by the host
   (KEL-60). It is raw bytes, not postcard. Before token comparison, the receiver
   requires `kind=HELLO`, zero flags/channel/correlation, and declared payload

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -34,7 +34,7 @@ wrapper or packaged application release to install yet.
   |---|---|
   | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
   | Windows | Rust's MSVC build tools and the WebView2 runtime; use an interactive PowerShell session for the qualified `dev`/Ctrl-C path; stock native Close remains incomplete |
-  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; two native-Close/cleanup/relaunch runs passed on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228) at source `a843b32` on Ubuntu 26.04.1 x86_64 / GNOME 50.1 Wayland with Bun 1.4.2 and WebKitGTK 2.52.6; X11 product runs and other distributions remain unverified |
+  | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; native Close/cleanup/relaunch qualified on Ubuntu 26.04.1 / GNOME Wayland; X11 product runs and other distributions remain unverified |
 
 The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
 A desktop session and the required Linux containment primitives are separate from
@@ -127,23 +127,24 @@ one. Expected behavior:
 
 4. Check that the host/Bun session and its nonce directory under `.keld/dev` are gone
    before a new run. The linked Windows and Ubuntu quick-start records observed Ctrl-C
-   cleanup. Separately, two untouched stock runs on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228)
-   at source `a843b32` observed native Close cleanup and relaunch in the named Ubuntu
-   environment above; this is not final-rebased-head native proof.
+   cleanup; see [qualified native-Close evidence](#qualified-linux-native-close-evidence)
+   for the separate normal-close path.
 
-**Normal-close evidence is environment- and source-qualified.** The historical
+### Qualified Linux native Close evidence
+
+The historical
 [public Ubuntu/Wayland failure record](https://github.com/gyldlab/keld/issues/167#issuecomment-5575535917)
 reports that clicking the stock app's Close button removed the renderer but left CLI,
 host, Bun, and the launch stage alive beyond an independent 20-second observation.
 The later [Ubuntu quick-start refresh](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
 verified Ctrl-C cleanup and relaunch but did not retry native Close. The stock-app
-correction is in [PR #228](https://github.com/gyldlab/keld/pull/228). Two untouched
+correction is in [PR #228](https://github.com/gyldlab/keld/pull/228). Two untouched stock
 runs on its source `a843b32` passed native Close, cleanup, and relaunch on Ubuntu
-26.04.1 x86_64 with GNOME 50.1 Wayland, Bun 1.4.2, and WebKitGTK 2.52.6: both CLI
-processes exited 0, all 20 observed pidfds exited, and two distinct launch stages were
-absent without forced cleanup. Root will capture fresh native evidence for the final
-rebased PR head before merge. No public Mac device record is cited here, so macOS native
-Close remains unverified. The
+26.04.1 x86_64 with GNOME 50.1 Wayland, Bun 1.4.2, and WebKitGTK 2.52.6. Both CLI
+processes exited 0; 20 observed process identities exited, two distinct launch stages
+were absent, and no forced cleanup was used. This evidence qualifies that source and
+environment only. No public Mac device record is cited here, so macOS native Close
+remains unverified. The
 [final-source Windows run](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
 also leaves stock native Close incomplete; its passing Ctrl-C result does not replace it.
 

--- a/packages/@keld/kipc/src/transport.test.ts
+++ b/packages/@keld/kipc/src/transport.test.ts
@@ -297,6 +297,24 @@ describe("FrameReader chunk queue", () => {
   );
 
   test(
+    "active waiter checks a late malformed header against the deadline first",
+    async () => {
+      const reader = new FrameReader();
+      const pending = reader.readFrame();
+      const malformed = encodeHeader({ kind: FrameKind.Ping, flags: 0, channel: 0, corr: 0, len: 0 });
+      malformed[3] = 99;
+      reader.push(malformed.subarray(0, 1));
+      const started = performance.now();
+      while (performance.now() - started < APP_LINK_IO_DEADLINE_MS + 10) {
+        // Hold the JS turn so the overdue callback cannot decide first.
+      }
+      reader.push(malformed.subarray(1));
+      await expect(pending).rejects.toThrow("KELD-IPC-006");
+    },
+    8_000,
+  );
+
+  test(
     "queued partial frame keeps its first-byte clock before a waiter exists",
     async () => {
       const reader = new FrameReader();

--- a/packages/@keld/kipc/src/transport.test.ts
+++ b/packages/@keld/kipc/src/transport.test.ts
@@ -144,6 +144,221 @@ describe("FrameReader chunk queue", () => {
     expect(frame.header.corr).toBe(1);
   });
 
+  test(
+    "first byte starts one frame deadline that later fragments cannot renew",
+    async () => {
+      const reader = new FrameReader();
+      const pending = reader.readFrame();
+      const header = encodeHeader({
+        kind: FrameKind.Event,
+        flags: 0,
+        channel: LIFECYCLE_CHANNEL,
+        corr: 0,
+        len: 1,
+      });
+      let offset = 0;
+      const started = performance.now();
+      reader.push(header.subarray(offset, ++offset));
+      const drip = setInterval(() => {
+        if (offset < header.length - 1) reader.push(header.subarray(offset, ++offset));
+      }, 400);
+      try {
+        await expect(pending).rejects.toThrow("KELD-IPC-006");
+      } finally {
+        clearInterval(drip);
+      }
+      const elapsed = performance.now() - started;
+      expect(elapsed).toBeGreaterThanOrEqual(APP_LINK_IO_DEADLINE_MS);
+      expect(elapsed).toBeLessThan(APP_LINK_IO_DEADLINE_MS + 2_000);
+    },
+    8_000,
+  );
+
+  test(
+    "deadline census progress survives later arrivals, consumption, and compaction",
+    async () => {
+      const reader = new FrameReader();
+      const batchSize = 1_024;
+      for (let i = 0; i < batchSize; i += 1) {
+        reader.push(encodeFrame(FrameKind.Ping, 17, i + 1, new Uint8Array()));
+      }
+      const originalSubarray = Uint8Array.prototype.subarray;
+      let chunkVisits = 0;
+      Object.defineProperty(Uint8Array.prototype, "subarray", {
+        configurable: true,
+        value(this: Uint8Array, begin?: number, end?: number): Uint8Array {
+          chunkVisits += 1;
+          return originalSubarray.call(this, begin, end);
+        },
+      });
+      try {
+        await new Promise((resolve) => setTimeout(resolve, APP_LINK_IO_DEADLINE_MS + 100));
+        for (let i = 0; i < batchSize; i += 1) {
+          reader.push(encodeFrame(FrameKind.Ping, 17, batchSize + i + 1, new Uint8Array()));
+        }
+        await new Promise((resolve) => setTimeout(resolve, APP_LINK_IO_DEADLINE_MS + 100));
+      } finally {
+        Reflect.deleteProperty(Uint8Array.prototype, "subarray");
+      }
+      expect(Uint8Array.prototype.subarray).toBe(originalSubarray);
+      expect(chunkVisits).toBeLessThanOrEqual(batchSize * 2 + 4);
+      const consumeCount = batchSize + 512;
+      for (let i = 0; i < consumeCount; i += 1) {
+        expect((await reader.readFrame()).header.corr).toBe(i + 1);
+      }
+      expect(reader.pendingChunkCount()).toBe(batchSize * 2 - consumeCount);
+      reader.push(new Uint8Array([0x4b]));
+      await new Promise((resolve) => setTimeout(resolve, APP_LINK_IO_DEADLINE_MS + 100));
+      await expect(reader.readFrame()).rejects.toThrow("KELD-IPC-006");
+    },
+    19_000,
+  );
+
+  test(
+    "arrival is captured before copy and late completion cannot beat a delayed timer",
+    async () => {
+      const reader = new FrameReader();
+      const pending = reader.readFrame();
+      const frame = encodeFrame(FrameKind.Ping, 17, 23, new Uint8Array());
+      const started = performance.now();
+      const constructorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "Uint8Array");
+      if (constructorDescriptor === undefined) throw new Error("global Uint8Array missing");
+      const originalConstructor = globalThis.Uint8Array;
+      let delayCopy = true;
+      const delayedConstructor = new Proxy(originalConstructor, {
+        construct(target, args, newTarget) {
+          if (delayCopy && args[0] instanceof originalConstructor) {
+            delayCopy = false;
+            const copyStarted = performance.now();
+            while (performance.now() - copyStarted < 25) {
+              // Inject copy work after the transport observes callback entry.
+            }
+          }
+          return Reflect.construct(target, args, newTarget);
+        },
+      });
+      Object.defineProperty(globalThis, "Uint8Array", {
+        ...constructorDescriptor,
+        value: delayedConstructor,
+      });
+      try {
+        reader.push(frame.subarray(0, 1));
+      } finally {
+        Object.defineProperty(globalThis, "Uint8Array", constructorDescriptor);
+      }
+      while (performance.now() - started < APP_LINK_IO_DEADLINE_MS + 10) {
+        // Hold the JS turn so the already-due timer callback cannot run first.
+      }
+      reader.push(frame.subarray(1));
+      await expect(pending).rejects.toThrow("KELD-IPC-006");
+    },
+    8_000,
+  );
+
+  test(
+    "wall-clock rollback cannot extend a monotonic frame deadline",
+    async () => {
+      const originalDateNow = Date.now;
+      const reader = new FrameReader();
+      const pending = reader.readFrame();
+      const started = performance.now();
+      try {
+        Date.now = () => -60_000;
+        reader.push(new Uint8Array([0x4b]));
+        await expect(pending).rejects.toThrow("KELD-IPC-006");
+      } finally {
+        Date.now = originalDateNow;
+      }
+      const elapsed = performance.now() - started;
+      expect(elapsed).toBeGreaterThanOrEqual(APP_LINK_IO_DEADLINE_MS - 25);
+      expect(elapsed).toBeLessThan(APP_LINK_IO_DEADLINE_MS + 1_500);
+    },
+    8_000,
+  );
+
+  test(
+    "no-waiter late completion keeps deadline precedence over a later bad header",
+    async () => {
+      const reader = new FrameReader();
+      const frame = encodeFrame(FrameKind.Ping, 17, 23, new Uint8Array());
+      const malformed = encodeHeader({ kind: FrameKind.Ping, flags: 0, channel: 0, corr: 0, len: 0 });
+      malformed[3] = 99;
+      reader.push(frame.subarray(0, 1));
+      const started = performance.now();
+      while (performance.now() - started < APP_LINK_IO_DEADLINE_MS + 10) {
+        // Keep the overdue timer queued until both later inputs are present.
+      }
+      reader.push(frame.subarray(1));
+      reader.push(malformed);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      await expect(reader.readFrame()).rejects.toThrow("KELD-IPC-006");
+    },
+    8_000,
+  );
+
+  test(
+    "queued partial frame keeps its first-byte clock before a waiter exists",
+    async () => {
+      const reader = new FrameReader();
+      const complete = encodeFrame(FrameKind.Ping, 17, 23, new Uint8Array());
+      const partial = encodeHeader({
+        kind: FrameKind.Event,
+        flags: 0,
+        channel: LIFECYCLE_CHANNEL,
+        corr: 0,
+        len: 1,
+      });
+      reader.push(complete);
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      reader.push(partial.subarray(0, 1));
+      const partialArrived = performance.now();
+
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+      expect((await reader.readFrame()).header.kind).toBe(FrameKind.Ping);
+      const waiterStarted = performance.now();
+      await expect(reader.readFrame()).rejects.toThrow("KELD-IPC-006");
+      const failedAt = performance.now();
+      expect(failedAt - partialArrived).toBeGreaterThanOrEqual(APP_LINK_IO_DEADLINE_MS - 25);
+      expect(failedAt - partialArrived).toBeLessThan(APP_LINK_IO_DEADLINE_MS + 1_500);
+      expect(failedAt - waiterStarted).toBeLessThan(APP_LINK_IO_DEADLINE_MS - 500);
+    },
+    8_000,
+  );
+
+  test(
+    "deadline census follows the logical head after in-chunk consumption",
+    async () => {
+      const reader = new FrameReader();
+      const firstPending = reader.readFrame();
+      const first = encodeFrame(FrameKind.Ping, 17, 1, new Uint8Array());
+      const second = encodeFrame(FrameKind.Ping, 17, 2, new Uint8Array());
+      const prefix = new Uint8Array(first.length + 1);
+      prefix.set(first, 0);
+      prefix[first.length] = second[0];
+      reader.push(prefix);
+      expect((await firstPending).header.corr).toBe(1);
+      reader.push(second.subarray(1));
+
+      const originalSubarray = Uint8Array.prototype.subarray;
+      const starts: Array<number | undefined> = [];
+      Object.defineProperty(Uint8Array.prototype, "subarray", {
+        configurable: true,
+        value(this: Uint8Array, begin?: number, end?: number): Uint8Array {
+          starts.push(begin);
+          return originalSubarray.call(this, begin, end);
+        },
+      });
+      try {
+        await new Promise((resolve) => setTimeout(resolve, APP_LINK_IO_DEADLINE_MS + 100));
+      } finally {
+        Reflect.deleteProperty(Uint8Array.prototype, "subarray");
+      }
+      expect(starts[0]).toBe(first.length);
+      expect((await reader.readFrame()).header.corr).toBe(2);
+    },
+    8_000,
+  );
+
   test("Ready before Echo Reply parks; later event receive drains FIFO", async () => {
     const ready = encodeFrame(FrameKind.Event, LIFECYCLE_CHANNEL, 0, new Uint8Array([0x00]));
     const reply = encodeFrame(FrameKind.Reply, ECHO_CHANNEL, 1, new Uint8Array([0x01]));

--- a/packages/@keld/kipc/src/transport.ts
+++ b/packages/@keld/kipc/src/transport.ts
@@ -358,7 +358,9 @@ export function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
  * fragmented max-size frame.
  *
  * One in-flight `readFrame()` only. A second call while a waiter is set is
- * `KELD-IPC-005`; it must not overwrite the waiter.
+ * `KELD-IPC-005`; it must not overwrite the waiter. An idle waiter has no
+ * deadline; its first buffered byte starts one absolute frame deadline that
+ * later chunks cannot renew.
  */
 const CHUNK_COMPACT_THRESHOLD = 1024;
 
@@ -367,12 +369,17 @@ export const MAX_PENDING_CHUNKS = 65_536;
 
 export class FrameReader {
   #chunks: Array<Uint8Array | undefined> = [];
+  #chunkArrivals: Array<number | undefined> = [];
   #chunkIndex = 0;
   #head = 0;
   #length = 0;
+  #censusChunkIndex = 0;
+  #censusOffset = 0;
+  #censusBytes = 0;
   #pending: { resolve: (f: DecodedFrame) => void; reject: (e: Error) => void } | null = null;
   #closed = false;
   #closeError: Error | null = null;
+  #frameDeadline: ReturnType<typeof setTimeout> | undefined;
 
   /** Unread buffered bytes. Independent of how many socket chunks carried them. */
   bufferedBytes(): number {
@@ -388,12 +395,15 @@ export class FrameReader {
   }
 
   push(chunk: Uint8Array): void {
+    const arrivedAt = performance.now();
     if (this.#closed || chunk.byteLength === 0) return;
     // Bun documents the callback value's type but not a retain-after-callback
     // lifetime. Own each queued chunk so a reused/mutated producer buffer
     // cannot rewrite a partially received frame after `push` returns.
     this.#chunks.push(new Uint8Array(chunk));
+    this.#chunkArrivals.push(arrivedAt);
     this.#length += chunk.byteLength;
+    this.#ensureFrameDeadline();
     this.#tryResolve();
     if (!this.#closed && this.#length > HEADER_LEN + MAX_FRAME_LEN) {
       this.fail(
@@ -414,12 +424,17 @@ export class FrameReader {
   }
 
   fail(err: Error): void {
+    this.#clearFrameDeadline();
     this.#closed = true;
     this.#closeError = err;
     this.#chunks = [];
+    this.#chunkArrivals = [];
     this.#chunkIndex = 0;
     this.#head = 0;
     this.#length = 0;
+    this.#censusChunkIndex = 0;
+    this.#censusOffset = 0;
+    this.#censusBytes = 0;
     const pending = this.#pending;
     this.#pending = null;
     pending?.reject(err);
@@ -432,9 +447,7 @@ export class FrameReader {
     let offset = this.#head;
     while (written < n) {
       const chunk = this.#chunks[idx];
-      if (chunk === undefined) {
-        throw kipcError("KELD-IPC-001", "frame reader underrun");
-      }
+      if (chunk === undefined) throw kipcError("KELD-IPC-001", "frame reader underrun");
       const take = Math.min(chunk.byteLength - offset, n - written);
       out.set(chunk.subarray(offset, offset + take), written);
       written += take;
@@ -444,7 +457,27 @@ export class FrameReader {
     return out;
   }
 
+  #arrivalAt(skip: number): number {
+    let idx = this.#chunkIndex;
+    let offset = this.#head;
+    let leftToSkip = skip;
+    while (true) {
+      const chunk = this.#chunks[idx];
+      const arrival = this.#chunkArrivals[idx];
+      if (chunk === undefined || arrival === undefined) {
+        throw kipcError("KELD-IPC-001", "frame reader arrival underrun");
+      }
+      const available = chunk.byteLength - offset;
+      if (leftToSkip < available) return arrival;
+      leftToSkip -= available;
+      idx += 1;
+      offset = 0;
+    }
+  }
+
   #consume(n: number): void {
+    const resetCensus = n > this.#censusBytes;
+    this.#censusBytes = Math.max(0, this.#censusBytes - n);
     let left = n;
     this.#length -= n;
     while (left > 0) {
@@ -455,29 +488,41 @@ export class FrameReader {
       const avail = chunk.byteLength - this.#head;
       if (left < avail) {
         this.#head += left;
-        return;
+        left = 0;
+        break;
       }
       left -= avail;
       // Release consumed bytes immediately and advance the logical queue head
       // without relying on Array.shift() reindexing behavior.
       this.#chunks[this.#chunkIndex] = undefined;
+      this.#chunkArrivals[this.#chunkIndex] = undefined;
       this.#chunkIndex += 1;
       this.#head = 0;
     }
     this.#compactChunks();
+    if (resetCensus) {
+      this.#censusChunkIndex = this.#chunkIndex;
+      this.#censusOffset = this.#head;
+    }
   }
 
   #compactChunks(): void {
     if (this.#chunkIndex === this.#chunks.length) {
       this.#chunks = [];
+      this.#chunkArrivals = [];
       this.#chunkIndex = 0;
+      this.#censusChunkIndex = 0;
+      this.#censusOffset = 0;
       return;
     }
     if (
       this.#chunkIndex >= CHUNK_COMPACT_THRESHOLD &&
       this.#chunkIndex * 2 >= this.#chunks.length
     ) {
+      const removed = this.#chunkIndex;
       this.#chunks = this.#chunks.slice(this.#chunkIndex);
+      this.#chunkArrivals = this.#chunkArrivals.slice(this.#chunkIndex);
+      this.#censusChunkIndex -= removed;
       this.#chunkIndex = 0;
     }
   }
@@ -497,9 +542,22 @@ export class FrameReader {
     }
     const total = HEADER_LEN + header.len;
     if (this.#length < total) return;
+    const startedAt = this.#arrivalAt(0);
+    const completedAt = this.#arrivalAt(total - 1);
+    if (completedAt - startedAt >= APP_LINK_IO_DEADLINE_MS) {
+      this.fail(
+        kipcError(
+          "KELD-IPC-006",
+          "started app-link frame did not finish within the I/O deadline",
+        ),
+      );
+      return;
+    }
     this.#consume(HEADER_LEN);
     const payload = header.len === 0 ? new Uint8Array(0) : this.#copyOut(header.len);
     if (header.len > 0) this.#consume(header.len);
+    this.#clearFrameDeadline();
+    this.#ensureFrameDeadline();
     const pending = this.#pending;
     this.#pending = null;
     pending?.resolve({ header, payload });
@@ -519,8 +577,114 @@ export class FrameReader {
     }
     return new Promise((resolve, reject) => {
       this.#pending = { resolve, reject };
+      this.#ensureFrameDeadline();
       this.#tryResolve();
     });
+  }
+
+  #ensureFrameDeadline(): void {
+    if (this.#censusBytes >= this.#length || this.#frameDeadline !== undefined) return;
+    this.#scheduleFrameDeadline(this.#censusArrival());
+  }
+
+  #censusArrival(): number {
+    const value = this.#chunkArrivals[this.#censusChunkIndex];
+    if (value === undefined) {
+      throw kipcError("KELD-IPC-001", "frame reader deadline census underrun");
+    }
+    return value;
+  }
+
+  #scheduleFrameDeadline(startedAt: number): void {
+    if (this.#frameDeadline !== undefined) return;
+    const remaining = Math.max(0, startedAt + APP_LINK_IO_DEADLINE_MS - performance.now());
+    this.#frameDeadline = setTimeout(() => {
+      this.#frameDeadline = undefined;
+      let incompleteStartedAt: number | undefined;
+      try {
+        incompleteStartedAt = this.#incompleteFrameStartedAt();
+      } catch (err) {
+        this.fail(err instanceof Error ? err : kipcError("KELD-IPC-002", String(err)));
+        return;
+      }
+      if (incompleteStartedAt === undefined) return;
+      if (performance.now() < incompleteStartedAt + APP_LINK_IO_DEADLINE_MS) {
+        this.#scheduleFrameDeadline(incompleteStartedAt);
+        return;
+      }
+      this.fail(
+        kipcError(
+          "KELD-IPC-006",
+          "started app-link frame did not finish within the I/O deadline",
+        ),
+      );
+    }, remaining);
+  }
+
+  #incompleteFrameStartedAt(): number | undefined {
+    let idx = this.#censusChunkIndex;
+    let chunkOffset = this.#censusOffset;
+    let remaining = this.#length - this.#censusBytes;
+
+    const currentArrival = (): number => {
+      const value = this.#chunkArrivals[idx];
+      if (value === undefined) {
+        throw kipcError("KELD-IPC-001", "frame reader deadline census underrun");
+      }
+      return value;
+    };
+
+    const advance = (n: number, copy?: Uint8Array): number => {
+      let left = n;
+      let written = 0;
+      let lastArrival = currentArrival();
+      while (left > 0) {
+        const chunk = this.#chunks[idx];
+        const arrival = this.#chunkArrivals[idx];
+        if (chunk === undefined || arrival === undefined) {
+          throw kipcError("KELD-IPC-001", "frame reader deadline census underrun");
+        }
+        lastArrival = arrival;
+        const take = Math.min(chunk.byteLength - chunkOffset, left);
+        copy?.set(chunk.subarray(chunkOffset, chunkOffset + take), written);
+        written += take;
+        left -= take;
+        chunkOffset += take;
+        if (chunkOffset === chunk.byteLength) {
+          idx += 1;
+          chunkOffset = 0;
+        }
+      }
+      remaining -= n;
+      return lastArrival;
+    };
+
+    const encodedHeader = new Uint8Array(HEADER_LEN);
+    while (remaining > 0) {
+      const startedAt = currentArrival();
+      if (remaining < HEADER_LEN) return startedAt;
+      const headerCompletedAt = advance(HEADER_LEN, encodedHeader);
+      if (headerCompletedAt - startedAt >= APP_LINK_IO_DEADLINE_MS) {
+        throw ioDeadlineExceeded();
+      }
+      const header = decodeHeader(encodedHeader);
+      if (header.len > MAX_FRAME_LEN) throw payloadTooLarge();
+      if (remaining < header.len) return startedAt;
+      const completedAt = header.len === 0 ? headerCompletedAt : advance(header.len);
+      if (completedAt - startedAt >= APP_LINK_IO_DEADLINE_MS) {
+        throw ioDeadlineExceeded();
+      }
+      this.#censusChunkIndex = idx;
+      this.#censusOffset = chunkOffset;
+      this.#censusBytes += HEADER_LEN + header.len;
+    }
+    return undefined;
+  }
+
+  #clearFrameDeadline(): void {
+    if (this.#frameDeadline === undefined) return;
+    clearTimeout(this.#frameDeadline);
+    this.#frameDeadline = undefined;
   }
 }
 

--- a/packages/@keld/kipc/src/transport.ts
+++ b/packages/@keld/kipc/src/transport.ts
@@ -529,6 +529,12 @@ export class FrameReader {
 
   #tryResolve(): void {
     if (!this.#pending || this.#length < HEADER_LEN) return;
+    const startedAt = this.#arrivalAt(0);
+    const headerCompletedAt = this.#arrivalAt(HEADER_LEN - 1);
+    if (headerCompletedAt - startedAt >= APP_LINK_IO_DEADLINE_MS) {
+      this.fail(ioDeadlineExceeded());
+      return;
+    }
     let header: FrameHeader;
     try {
       header = decodeHeader(this.#copyOut(HEADER_LEN));
@@ -542,7 +548,6 @@ export class FrameReader {
     }
     const total = HEADER_LEN + header.len;
     if (this.#length < total) return;
-    const startedAt = this.#arrivalAt(0);
     const completedAt = this.#arrivalAt(total - 1);
     if (completedAt - startedAt >= APP_LINK_IO_DEADLINE_MS) {
       this.fail(


### PR DESCRIPTION
## Summary

The generated stock app kept its session alive after the last native window closed. It now consumes `LastWindowClosed`, sends a correlated `Quit` on its existing authenticated app-link, waits for the reply, and exits cleanly. The shared TypeScript frame reader permits idle event waiting while enforcing one monotonic deadline once a frame begins.

Fixes #176. The Linux quick-start now reflects the qualified native-Close result and retains historical failures and unverified platform boundaries.

## Spec refs

- KEL-185 acceptance; landed KEL-136 shared transport contract.
- `docs/architecture/02-ipc.md`, sections 2 and 7.
- No boundary change: handle, crash, principal, permission and wire-format ownership are unchanged.

## Review gates

- unsafe: none.
- public API: `AppLinkSession.receiveWhileIdle`; existing independent review/refutation evidence and preservation of the reviewed runtime patch are recorded on KEL-185.
- permission model: none.
- dependency addition: none.
- wire protocol: receiver deadline semantics; no frame/version change. Existing review and refutations cover the preserved patch.
- The user explicitly delegates review and eligible merge; no additional routine approval is required.

## Tests

- Exact final head `e4987703812a9c7ebb8d2656b870bbb99f03c730`: full local `just ci` exit 0, including format, warning-denied workspace Clippy, **659 workspace tests passed, 5 explicit skips**, TypeScript, generated docs, pinned rendering, hygiene and cargo-deny. Locked shipping package build also passed.
- [Final hosted CI run 34677454998](https://github.com/gyldlab/keld/actions/runs/34677454998) passed all applicable required checks, including Windows, macOS, Ubuntu and CodeQL.
- Failure-first stock regression exited 101 before the fix. Stock wire tests cover Ready before Echo Reply, idle waiting, Ping, correlated Quit, EOF and child reap; stalled/closed links retain bounded diagnostics.
- Deadline tests cover partial/late-complete frames, monotonic timing, queue compaction and bounded linear census work. Canonical fixture launch preserves explicit Windows 8.3-alias and no-distinct-alias controls.
- Earlier post-squash-ledger and stale shared-target failures are retained with their root-cause corrections; no source/test contract or gate was weakened.

## Platforms

- **Native Linux passed on exact e498770:** Ubuntu 26.04.1 x86_64, GNOME 50.1 Wayland, WebKitGTK 2.52.6, Bun 1.4.2. Two untouched generated-app launches used the native Close button; CLI exits 0/0, all 20 captured process identities exited, both distinct stages disappeared, and relaunch used fresh identities. No forced cleanup. Active/showing/visible frames, actual host PID/start ticks, reciprocal physical Wayland sockets and native Close actions are retained. Screenshot methods were unavailable; no pixel-rendering claim.
- Windows native evidence remains qualified to the previously recorded 237059b source and its unchanged runtime patch; exact final-head hosted Windows checks passed. No new Windows native run is claimed by the Linux operator.
- macOS: final-head CI passed; native Close remains unverified here.
- X11, non-Debian distributions and release packaging remain unverified.

## Perf impact

No host or first-paint performance claim. The deterministic 2,048-frame control bounds deadline-census visits to linear work.
