### PR TITLE
docs(compat): qualify native addon evidence

### DIFF
--- a/docs/architecture/04-electron-compat.md
+++ b/docs/architecture/04-electron-compat.md
@@ -23,7 +23,7 @@ Keld migrate report — my-electron-app
   ✔ supported now: 42/47 call sites (Tier 1: 38, Tier 2: 4)
   ▲ behavior notes: BrowserWindow.vibrancy (macOS-only effect), sendSync (rate-limited)
   ✘ unsupported: desktopCapturer (2 sites) → tracked keld#77, workaround: docs/compat/capture.md
-  native modules: better-sqlite3 ✔ (N-API prebuilt) · node-pty ▲ (needs bun>=x.y)
+  native modules: better-sqlite3 ▲ (version/runtime/artifact-qualified evidence required) · node-pty ▲ (needs bun>=x.y)
   generated: keld.config.ts · keld.permissions.jsonc · keld.build.ts
   changed:   package.json (scripts, devDeps) · bunfig.toml (alias electron → @keld/electron)
   compat score: 91% — expected to run. `keld dev` to verify.
@@ -160,12 +160,20 @@ does not prove compatibility. These contracts are not live in v0.
 
 ## 5. Native modules policy
 
-Bun's Node-API implementation is the compat path: N-API prebuilds (better-sqlite3,
-sharp, keytar-class) load as-is — **no electron-rebuild treadmill, ever** (host ABI is
-not Node's; only Bun's N-API matters and it's pinned per Keld release). `keld doctor`
-scans `node_modules` for native deps, checks a curated compatibility DB (crowd-sourced,
-CI-verified), and flags known-bad ones with alternatives. Modules that reach into
-Electron internals (rare) are Tier-✘ with documented workarounds.
+Bun's Node-API implementation is the compatibility path, but a package name or an
+N-API source declaration is not a runtime qualification. Each native-addon claim names
+the exact package version, Windows/OS architecture, Bun revision, loaded native-binary
+SHA-256, operation, oracle, and authority profile in `keld.compat.evidence/v1`.
+KEL-215's Windows x64 fixture records that `better-sqlite3` 13.0.3 (Node-API 10)
+passes its SQL/callback/teardown operation on Bun 1.4.2 revision
+`744846f844374847c902b5e7fd59b4342a51ef99` with loaded artifact
+`e21e5efd71fba66578e95b62554d9028064a80dafd7221bf8a8ef155de8d240a`;
+the same fixture records `better-sqlite3` 12.11.1 failing Bun import with
+`ERR_DLOPEN_FAILED`. Neither row generalizes to another package version, artifact,
+architecture, Bun revision, or operation. `keld doctor` guidance therefore reports
+only curated, version-qualified evidence rather than promising that a prebuild loads.
+Modules that reach into Electron internals (rare) are Tier-✘ with documented
+workarounds.
 
 ## 6. Migration corpus (measurement harness)
 

--- a/docs/architecture/04-electron-compat.md
+++ b/docs/architecture/04-electron-compat.md
@@ -170,8 +170,9 @@ passes its SQL/callback/teardown operation on Bun 1.4.2 revision
 `e21e5efd71fba66578e95b62554d9028064a80dafd7221bf8a8ef155de8d240a`;
 the same fixture records `better-sqlite3` 12.11.1 failing Bun import with
 `ERR_DLOPEN_FAILED`. Neither row generalizes to another package version, artifact,
-architecture, Bun revision, or operation. `keld doctor` guidance therefore reports
-only curated, version-qualified evidence rather than promising that a prebuild loads.
+architecture, Bun revision, or operation. Planned `keld doctor` addon guidance will
+report only curated, version-qualified evidence rather than promising that a prebuild
+loads; the current doctor checks do not scan native addons.
 Modules that reach into Electron internals (rare) are Tier-✘ with documented
 workarounds.
 

--- a/docs/architecture/04-electron-compat.md
+++ b/docs/architecture/04-electron-compat.md
@@ -174,8 +174,8 @@ before native binding load fails during first `Database` construction with
 `ERR_DLOPEN_FAILED`. That failed row binds the selected candidate digest
 `707a4b480026ccd1fb8e308d43c7248e779d35eeefa09559ec9bb521bb97bb3b`
 without claiming it loaded successfully. The immutable
-[fixture](https://github.com/gyldlab/keld-benches/tree/70c7d37780f9996a74afd0af48b2d0ff9b728bd5/windows/bun/better-sqlite3-differential)
-and [raw receipt](https://github.com/gyldlab/keld-benches/blob/70c7d37780f9996a74afd0af48b2d0ff9b728bd5/windows/bun/better-sqlite3-differential/results/20260911T215043844Z-3916.windows-x64.raw.json)
+[fixture](https://github.com/gyldlab/keld-benches/tree/5d2db1232c46db6aef0149306a9b766c7a7dd7f1/windows/bun/better-sqlite3-differential)
+and [raw receipt](https://github.com/gyldlab/keld-benches/blob/5d2db1232c46db6aef0149306a9b766c7a7dd7f1/windows/bun/better-sqlite3-differential/results/20260911T221908487Z-3044.windows-x64.raw.json)
 retain the exact commands, exits, runtime queries, outputs, source/lock digests, and
 negative controls. Neither row generalizes to another package version, artifact,
 architecture, Bun revision, or operation. Planned `keld doctor` addon guidance will

--- a/docs/architecture/04-electron-compat.md
+++ b/docs/architecture/04-electron-compat.md
@@ -162,14 +162,22 @@ does not prove compatibility. These contracts are not live in v0.
 
 Bun's Node-API implementation is the compatibility path, but a package name or an
 N-API source declaration is not a runtime qualification. Each native-addon claim names
-the exact package version, Windows/OS architecture, Bun revision, loaded native-binary
-SHA-256, operation, oracle, and authority profile in `keld.compat.evidence/v1`.
+the exact package version, Windows/OS architecture, Bun revision, selected/attempted
+native-binary SHA-256 (plus the loaded digest for successful rows), operation, oracle,
+and authority profile in `keld.compat.evidence/v1`.
 KEL-215's Windows x64 fixture records that `better-sqlite3` 13.0.3 (Node-API 10)
 passes its SQL/callback/teardown operation on Bun 1.4.2 revision
 `744846f844374847c902b5e7fd59b4342a51ef99` with loaded artifact
 `e21e5efd71fba66578e95b62554d9028064a80dafd7221bf8a8ef155de8d240a`;
-the same fixture records `better-sqlite3` 12.11.1 failing Bun import with
-`ERR_DLOPEN_FAILED`. Neither row generalizes to another package version, artifact,
+the same fixture records the `better-sqlite3` 12.11.1 JavaScript require succeeding
+before native binding load fails during first `Database` construction with
+`ERR_DLOPEN_FAILED`. That failed row binds the selected candidate digest
+`707a4b480026ccd1fb8e308d43c7248e779d35eeefa09559ec9bb521bb97bb3b`
+without claiming it loaded successfully. The immutable
+[fixture](https://github.com/gyldlab/keld-benches/tree/70c7d37780f9996a74afd0af48b2d0ff9b728bd5/windows/bun/better-sqlite3-differential)
+and [raw receipt](https://github.com/gyldlab/keld-benches/blob/70c7d37780f9996a74afd0af48b2d0ff9b728bd5/windows/bun/better-sqlite3-differential/results/20260911T215043844Z-3916.windows-x64.raw.json)
+retain the exact commands, exits, runtime queries, outputs, source/lock digests, and
+negative controls. Neither row generalizes to another package version, artifact,
 architecture, Bun revision, or operation. Planned `keld doctor` addon guidance will
 report only curated, version-qualified evidence rather than promising that a prebuild
 loads; the current doctor checks do not scan native addons.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1842,7 +1842,7 @@ Keld migrate report — my-electron-app
   ✔ supported now: 42/47 call sites (Tier 1: 38, Tier 2: 4)
   ▲ behavior notes: BrowserWindow.vibrancy (macOS-only effect), sendSync (rate-limited)
   ✘ unsupported: desktopCapturer (2 sites) → tracked keld#77, workaround: docs/compat/capture.md
-  native modules: better-sqlite3 ✔ (N-API prebuilt) · node-pty ▲ (needs bun>=x.y)
+  native modules: better-sqlite3 ▲ (version/runtime/artifact-qualified evidence required) · node-pty ▲ (needs bun>=x.y)
   generated: keld.config.ts · keld.permissions.jsonc · keld.build.ts
   changed:   package.json (scripts, devDeps) · bunfig.toml (alias electron → @keld/electron)
   compat score: 91% — expected to run. `keld dev` to verify.
@@ -1979,12 +1979,20 @@ does not prove compatibility. These contracts are not live in v0.
 
 ## 5. Native modules policy
 
-Bun's Node-API implementation is the compat path: N-API prebuilds (better-sqlite3,
-sharp, keytar-class) load as-is — **no electron-rebuild treadmill, ever** (host ABI is
-not Node's; only Bun's N-API matters and it's pinned per Keld release). `keld doctor`
-scans `node_modules` for native deps, checks a curated compatibility DB (crowd-sourced,
-CI-verified), and flags known-bad ones with alternatives. Modules that reach into
-Electron internals (rare) are Tier-✘ with documented workarounds.
+Bun's Node-API implementation is the compatibility path, but a package name or an
+N-API source declaration is not a runtime qualification. Each native-addon claim names
+the exact package version, Windows/OS architecture, Bun revision, loaded native-binary
+SHA-256, operation, oracle, and authority profile in `keld.compat.evidence/v1`.
+KEL-215's Windows x64 fixture records that `better-sqlite3` 13.0.3 (Node-API 10)
+passes its SQL/callback/teardown operation on Bun 1.4.2 revision
+`744846f844374847c902b5e7fd59b4342a51ef99` with loaded artifact
+`e21e5efd71fba66578e95b62554d9028064a80dafd7221bf8a8ef155de8d240a`;
+the same fixture records `better-sqlite3` 12.11.1 failing Bun import with
+`ERR_DLOPEN_FAILED`. Neither row generalizes to another package version, artifact,
+architecture, Bun revision, or operation. `keld doctor` guidance therefore reports
+only curated, version-qualified evidence rather than promising that a prebuild loads.
+Modules that reach into Electron internals (rare) are Tier-✘ with documented
+workarounds.
 
 ## 6. Migration corpus (measurement harness)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1989,8 +1989,9 @@ passes its SQL/callback/teardown operation on Bun 1.4.2 revision
 `e21e5efd71fba66578e95b62554d9028064a80dafd7221bf8a8ef155de8d240a`;
 the same fixture records `better-sqlite3` 12.11.1 failing Bun import with
 `ERR_DLOPEN_FAILED`. Neither row generalizes to another package version, artifact,
-architecture, Bun revision, or operation. `keld doctor` guidance therefore reports
-only curated, version-qualified evidence rather than promising that a prebuild loads.
+architecture, Bun revision, or operation. Planned `keld doctor` addon guidance will
+report only curated, version-qualified evidence rather than promising that a prebuild
+loads; the current doctor checks do not scan native addons.
 Modules that reach into Electron internals (rare) are Tier-✘ with documented
 workarounds.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1981,14 +1981,22 @@ does not prove compatibility. These contracts are not live in v0.
 
 Bun's Node-API implementation is the compatibility path, but a package name or an
 N-API source declaration is not a runtime qualification. Each native-addon claim names
-the exact package version, Windows/OS architecture, Bun revision, loaded native-binary
-SHA-256, operation, oracle, and authority profile in `keld.compat.evidence/v1`.
+the exact package version, Windows/OS architecture, Bun revision, selected/attempted
+native-binary SHA-256 (plus the loaded digest for successful rows), operation, oracle,
+and authority profile in `keld.compat.evidence/v1`.
 KEL-215's Windows x64 fixture records that `better-sqlite3` 13.0.3 (Node-API 10)
 passes its SQL/callback/teardown operation on Bun 1.4.2 revision
 `744846f844374847c902b5e7fd59b4342a51ef99` with loaded artifact
 `e21e5efd71fba66578e95b62554d9028064a80dafd7221bf8a8ef155de8d240a`;
-the same fixture records `better-sqlite3` 12.11.1 failing Bun import with
-`ERR_DLOPEN_FAILED`. Neither row generalizes to another package version, artifact,
+the same fixture records the `better-sqlite3` 12.11.1 JavaScript require succeeding
+before native binding load fails during first `Database` construction with
+`ERR_DLOPEN_FAILED`. That failed row binds the selected candidate digest
+`707a4b480026ccd1fb8e308d43c7248e779d35eeefa09559ec9bb521bb97bb3b`
+without claiming it loaded successfully. The immutable
+[fixture](https://github.com/gyldlab/keld-benches/tree/70c7d37780f9996a74afd0af48b2d0ff9b728bd5/windows/bun/better-sqlite3-differential)
+and [raw receipt](https://github.com/gyldlab/keld-benches/blob/70c7d37780f9996a74afd0af48b2d0ff9b728bd5/windows/bun/better-sqlite3-differential/results/20260911T215043844Z-3916.windows-x64.raw.json)
+retain the exact commands, exits, runtime queries, outputs, source/lock digests, and
+negative controls. Neither row generalizes to another package version, artifact,
 architecture, Bun revision, or operation. Planned `keld doctor` addon guidance will
 report only curated, version-qualified evidence rather than promising that a prebuild
 loads; the current doctor checks do not scan native addons.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1993,8 +1993,8 @@ before native binding load fails during first `Database` construction with
 `ERR_DLOPEN_FAILED`. That failed row binds the selected candidate digest
 `707a4b480026ccd1fb8e308d43c7248e779d35eeefa09559ec9bb521bb97bb3b`
 without claiming it loaded successfully. The immutable
-[fixture](https://github.com/gyldlab/keld-benches/tree/70c7d37780f9996a74afd0af48b2d0ff9b728bd5/windows/bun/better-sqlite3-differential)
-and [raw receipt](https://github.com/gyldlab/keld-benches/blob/70c7d37780f9996a74afd0af48b2d0ff9b728bd5/windows/bun/better-sqlite3-differential/results/20260911T215043844Z-3916.windows-x64.raw.json)
+[fixture](https://github.com/gyldlab/keld-benches/tree/5d2db1232c46db6aef0149306a9b766c7a7dd7f1/windows/bun/better-sqlite3-differential)
+and [raw receipt](https://github.com/gyldlab/keld-benches/blob/5d2db1232c46db6aef0149306a9b766c7a7dd7f1/windows/bun/better-sqlite3-differential/results/20260911T221908487Z-3044.windows-x64.raw.json)
 retain the exact commands, exits, runtime queries, outputs, source/lock digests, and
 negative controls. Neither row generalizes to another package version, artifact,
 architecture, Bun revision, or operation. Planned `keld doctor` addon guidance will


### PR DESCRIPTION
## Summary

- Qualifies native-addon compatibility claims by exact package version, Bun revision, Windows architecture, native artifact digest, operation, and authority profile.
- Records `better-sqlite3` 13.0.3 as passing the SQL/callback/error/close workflow on Bun 1.4.2 and 12.11.1 as failing native binding load during first `Database` construction after JavaScript require succeeds.
- Links the immutable KEL-215 Windows fixture and raw receipt at keld-benches commit `5d2db1232c46db6aef0149306a9b766c7a7dd7f1` (PR https://github.com/gyldlab/keld-benches/pull/22).

## Spec refs

`docs/architecture/04-electron-compat.md` §5 and the landed KEL-74 `keld.compat.evidence/v1` contract. No boundary change.

## Review gates

none

## Tests

- `NEXTEST_TEST_THREADS=4 just ci` — exit 0 on `2f7c67bc69deee60240f3178118094de6735aaff`; includes `cargo fmt --all --check`, warning-denied workspace Clippy, full workspace nextest, rustdoc, cargo-deny, generated-doc checks, Mermaid render, Bun suites, and repository inventory gates.
- `just llms` — exit 0.
- `just llms-test` — 6 passed.
- `just llms-check` — exit 0.
- Benches `node --test run.test.cjs` — 8 passed, covering configured observation identity, ABI/runtime metadata, loader-selected candidate attribution, hostile run IDs, existing output refusal, malformed output, runtime/probe launch failures, and coherent fresh publication.
- Real Windows matrix — Bun 13.0.3 exit 0; Bun 12.11.1 expected exit 1 with `ERR_DLOPEN_FAILED`; Node 25.2.1 controls exit 0 for both versions. Raw receipt SHA-256: `054ed687e3bea349b5b6450c6b7d3963fc4ed2fb4df921e0a3f2013bba133c11`.
- No-op-close and unrelated-error mutations — each exit 1.
- Both generated evidence rows passed `keld_compat::evidence::parse_evidence`.

## Platforms

Windows 11 10.0.26200 x64 on RAMANI exercised the real Bun/Node/native-addon operation matrix under `legacy_sandbox_off`. This evidence makes no OS containment claim and does not qualify other OSes, architectures, package versions, runtime revisions, artifacts, or operations.

## Perf impact

none

## Linear

KEL-215
