### PR TITLE
docs: qualify Windows native Close evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ do not establish release support:
 | Platform | Current app-session slice | Qualification still needed |
 |---|---|---|
 | macOS / WKWebView | Native window, app link, recovery, ordered Quit/CLI-loss cleanup | Stock app native Close remains unverified; complete strict profiles and release packaging |
-| Windows / WebView2 | Native window, named-pipe app link, recovery, Ctrl-C cleanup and relaunch | Stock app native Close remains incomplete; remaining strict admission and release packaging |
+| Windows / WebView2 | Native window, named-pipe app link, recovery, Ctrl-C cleanup and relaunch | Stock native Close/cleanup/relaunch qualified on the [Windows 11 x64 capture](https://github.com/gyldlab/keld/issues/174#issuecomment-5644140405); complete strict-profile admission and release packaging remain unverified |
 | Ubuntu/Debian x86_64 / WebKitGTK / Wayland | Window, authenticated link, strict Bun generations, recovery | Native Close/cleanup/relaunch qualified on the [PR #228 candidate](https://github.com/gyldlab/keld/pull/228) for Ubuntu 26.04.1 / GNOME Wayland; X11 product runs, other distributions/architectures, and release packaging remain unverified |
 
 ## Try it
@@ -55,6 +55,11 @@ and the [Ubuntu build/create/doctor/window/Ctrl-C/relaunch run](https://github.c
 Both used Bun 1.4.0; Windows used interactive PowerShell. These dated interrupt runs remain
 separate from native-Close acceptance.
 
+The [Windows stock native-Close capture](https://github.com/gyldlab/keld/issues/174#issuecomment-5644140405)
+qualifies two runs on source `62f4cc1a71a02db8d3b3a5959f2bbf6ba1a9a0c8`, Windows 11 x64,
+and Bun 1.4.2 revision `1.4.2+744846f84`; both CLI exits were zero, captured process
+identities exited, and both stages were absent at 20 seconds without forced cleanup.
+
 The [qualified Linux native-Close evidence](docs/onboarding/README.md#qualified-linux-native-close-evidence)
 for [PR #228](https://github.com/gyldlab/keld/pull/228), source `a843b32`, updates the
 historical failure status for that tested environment only. The earlier
@@ -76,6 +81,7 @@ no npm installation or packaged app release yet.
 - [CI](https://github.com/gyldlab/keld/actions/workflows/ci.yml): current automated
   checks. A CI run and a real desktop acceptance run are different evidence.
 - Public, source-pinned device records: [Windows/WebView2](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723),
+  [Windows native Close](https://github.com/gyldlab/keld/issues/174#issuecomment-5644140405),
   [initial Ubuntu/WebKitGTK](https://github.com/gyldlab/keld/issues/167#issuecomment-5575535917),
   and the [Ubuntu refresh](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871).
   These maintainer-recorded observations preserve their platform limits and do not

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -142,9 +142,8 @@ remains unverified.
 ### Qualified Windows native Close evidence
 
 The earlier
-[Windows stock native-Close attempt](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
-is retained as historical failure evidence; the later passing capture is separately
-qualified here.
+[Windows build/window/Ctrl-C/relaunch record](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
+remains historical and does not establish stock native Close.
 The [Windows stock native-Close capture](https://github.com/gyldlab/keld/issues/174#issuecomment-5644140405)
 qualifies two runs on source `62f4cc1a71a02db8d3b3a5959f2bbf6ba1a9a0c8`, Windows 11 x64,
 and Bun 1.4.2 revision `1.4.2+744846f84`; both CLI exits were zero, captured process

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -25,7 +25,7 @@ wrapper or packaged application release to install yet.
   | Platform | Prerequisites and qualification |
   |---|---|
   | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
-  | Windows | Rust's MSVC build tools and the WebView2 runtime; use an interactive PowerShell session for the qualified `dev`/Ctrl-C path; stock native Close remains incomplete |
+  | Windows | Rust's MSVC build tools and the WebView2 runtime; use an interactive PowerShell session for the source-build/Ctrl-C path; stock native Close/cleanup/relaunch is qualified only for the [Windows 11 x64 capture](https://github.com/gyldlab/keld/issues/174#issuecomment-5644140405) |
   | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; native Close/cleanup/relaunch qualified on Ubuntu 26.04.1 / GNOME Wayland; X11 product runs and other distributions remain unverified |
 
 The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
@@ -119,8 +119,9 @@ one. Expected behavior:
 
 4. Check that the host/Bun session and its nonce directory under `.keld/dev` are gone
    before a new run. The linked Windows and Ubuntu quick-start records observed Ctrl-C
-   cleanup; see [qualified native-Close evidence](#qualified-linux-native-close-evidence)
-   for the separate normal-close path.
+   cleanup; Windows stock native-Close evidence is separately source-qualified below.
+   See [qualified Linux native-Close evidence](#qualified-linux-native-close-evidence)
+   for that environment's normal-close path.
 
 ### Qualified Linux native Close evidence
 
@@ -136,9 +137,19 @@ runs on its source `a843b32` passed native Close, cleanup, and relaunch on Ubunt
 processes exited 0; 20 observed process identities exited, two distinct launch stages
 were absent, and no forced cleanup was used. This evidence qualifies that source and
 environment only. No public Mac device record is cited here, so macOS native Close
-remains unverified. The
-[final-source Windows run](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
-also leaves stock native Close incomplete; its passing Ctrl-C result does not replace it.
+remains unverified.
+
+### Qualified Windows native Close evidence
+
+The earlier
+[Windows stock native-Close attempt](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
+is retained as historical failure evidence; the later passing capture is separately
+qualified here.
+The [Windows stock native-Close capture](https://github.com/gyldlab/keld/issues/174#issuecomment-5644140405)
+qualifies two runs on source `62f4cc1a71a02db8d3b3a5959f2bbf6ba1a9a0c8`, Windows 11 x64,
+and Bun 1.4.2 revision `1.4.2+744846f84`; both CLI exits were zero, captured process
+identities exited, and both stages were absent at 20 seconds without forced cleanup.
+Complete strict-profile admission and release packaging remain unverified.
 
 The [newer Linux relaunch/early-interrupt record](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
 tested [PR #184](https://github.com/gyldlab/keld/pull/184) and produced no `KELD-CORE`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -150,9 +150,8 @@ remains unverified.
 ### Qualified Windows native Close evidence
 
 The earlier
-[Windows stock native-Close attempt](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
-is retained as historical failure evidence; the later passing capture is separately
-qualified here.
+[Windows build/window/Ctrl-C/relaunch record](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
+remains historical and does not establish stock native Close.
 The [Windows stock native-Close capture](https://github.com/gyldlab/keld/issues/174#issuecomment-5644140405)
 qualifies two runs on source `62f4cc1a71a02db8d3b3a5959f2bbf6ba1a9a0c8`, Windows 11 x64,
 and Bun 1.4.2 revision `1.4.2+744846f84`; both CLI exits were zero, captured process

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -33,7 +33,7 @@ wrapper or packaged application release to install yet.
   | Platform | Prerequisites and qualification |
   |---|---|
   | macOS | Apple command-line developer tools (`xcode-select --install` if absent); WKWebView is supplied by macOS |
-  | Windows | Rust's MSVC build tools and the WebView2 runtime; use an interactive PowerShell session for the qualified `dev`/Ctrl-C path; stock native Close remains incomplete |
+  | Windows | Rust's MSVC build tools and the WebView2 runtime; use an interactive PowerShell session for the source-build/Ctrl-C path; stock native Close/cleanup/relaunch is qualified only for the [Windows 11 x64 capture](https://github.com/gyldlab/keld/issues/174#issuecomment-5644140405) |
   | Ubuntu/Debian x86_64, Wayland | GTK3/WebKitGTK 4.1 development libraries, `pkg-config`, a C compiler, and trusted checkout/strict-launch prerequisites below; native Close/cleanup/relaunch qualified on Ubuntu 26.04.1 / GNOME Wayland; X11 product runs and other distributions remain unverified |
 
 The Ubuntu build packages are recorded in the [CI workflow](../../.github/workflows/ci.yml).
@@ -127,8 +127,9 @@ one. Expected behavior:
 
 4. Check that the host/Bun session and its nonce directory under `.keld/dev` are gone
    before a new run. The linked Windows and Ubuntu quick-start records observed Ctrl-C
-   cleanup; see [qualified native-Close evidence](#qualified-linux-native-close-evidence)
-   for the separate normal-close path.
+   cleanup; Windows stock native-Close evidence is separately source-qualified below.
+   See [qualified Linux native-Close evidence](#qualified-linux-native-close-evidence)
+   for that environment's normal-close path.
 
 ### Qualified Linux native Close evidence
 
@@ -144,9 +145,19 @@ runs on its source `a843b32` passed native Close, cleanup, and relaunch on Ubunt
 processes exited 0; 20 observed process identities exited, two distinct launch stages
 were absent, and no forced cleanup was used. This evidence qualifies that source and
 environment only. No public Mac device record is cited here, so macOS native Close
-remains unverified. The
-[final-source Windows run](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
-also leaves stock native Close incomplete; its passing Ctrl-C result does not replace it.
+remains unverified.
+
+### Qualified Windows native Close evidence
+
+The earlier
+[Windows stock native-Close attempt](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
+is retained as historical failure evidence; the later passing capture is separately
+qualified here.
+The [Windows stock native-Close capture](https://github.com/gyldlab/keld/issues/174#issuecomment-5644140405)
+qualifies two runs on source `62f4cc1a71a02db8d3b3a5959f2bbf6ba1a9a0c8`, Windows 11 x64,
+and Bun 1.4.2 revision `1.4.2+744846f84`; both CLI exits were zero, captured process
+identities exited, and both stages were absent at 20 seconds without forced cleanup.
+Complete strict-profile admission and release packaging remain unverified.
 
 The [newer Linux relaunch/early-interrupt record](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
 tested [PR #184](https://github.com/gyldlab/keld/pull/184) and produced no `KELD-CORE`


### PR DESCRIPTION
## Summary

- Update the README and onboarding guide to describe the source-qualified Windows stock native-Close/cleanup/relaunch evidence and keep the earlier Windows Ctrl-C record distinct from native-Close evidence.
- Regenerate the included `llms-full.txt` corpus.

## Spec refs

No boundary change

## Review gates

none

## Tests

- `just llms-test`: passed (8 tests).
- `just llms-check`: passed.
- `DOCKER_CONTEXT=desktop-linux CARGO_BUILD_JOBS=2 NEXTEST_TEST_THREADS=2 CARGO_TARGET_DIR=/home/monish/Desktop/keld/target just ci`: passed; format, warning-denied workspace Clippy, 659 workspace tests passed / 5 configured skips, rustdoc, cargo-deny and all other recipes passed. Full log is retained with the task evidence.

## Platforms

- CI-only documentation update; this Linux worker did not exercise Windows behavior.
- The linked public Windows capture qualifies two stock runs for source `62f4cc1a71a02db8d3b3a5959f2bbf6ba1a9a0c8`, Windows 11 x64, Bun 1.4.2 revision `1.4.2+744846f84`.
- Complete strict-profile admission and release packaging remain unverified. macOS, X11, and other Linux distributions remain unverified as stated in the docs.

## Perf impact

No performance claim.
