### PR TITLE
docs(onboarding): reconcile lifecycle evidence

### DIFF
--- a/docs/onboarding/05-development-guide.md
+++ b/docs/onboarding/05-development-guide.md
@@ -41,13 +41,19 @@ Bun app-link output. `cargo build -p keld-cli` alone does not provide the host i
 fresh checkout. `just hello` exercises only the diagnostic backend window.
 
 The [platform surfaces ledger](../engineering/product-status.md#platform-surfaces)
-owns implemented scope. The [final-source Windows record](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
-passes build, native window, interactive Ctrl-C output/cleanup, and relaunch; stock
-native Close remains incomplete. The [Ubuntu refresh](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
-passes its separate Ctrl-C/relaunch rows, while the
+owns implemented scope. The [Windows build/window/Ctrl-C/relaunch record](https://github.com/gyldlab/keld/issues/174#issuecomment-5589117723)
+covers the earlier interrupt path. Stock native Close/cleanup/relaunch is now qualified
+by the [landed-source Windows recheck](https://github.com/gyldlab/keld/issues/174#issuecomment-5644295973):
+two runs exited zero, all 16 captured original process identities were gone, both nonce
+stages were absent at 20 seconds, and no forced cleanup was used. This is a captured
+census on the recorded Windows 11 x64 device, not an exhaustive all-time child census
+or strict/release-profile qualification. For Ubuntu, see the
+[qualified Linux native-Close evidence](./README.md#qualified-linux-native-close-evidence);
+the [Ubuntu refresh](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
+covers separate Ctrl-C/relaunch rows, and the
 [initial Ubuntu run](https://github.com/gyldlab/keld/issues/167#issuecomment-5575535917)
-records the stock native-Close failure. X11 product runs, other distributions, and
-release packaging remain unverified. This source-built demo is not an installer or a
+records a historical stock native-Close failure. X11 product runs, other distributions,
+and release packaging remain unverified. This source-built demo is not an installer or a
 migrated Electron application.
 
 ---

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -148,13 +148,17 @@ The [Windows stock native-Close capture](https://github.com/gyldlab/keld/issues/
 qualifies two runs on source `62f4cc1a71a02db8d3b3a5959f2bbf6ba1a9a0c8`, Windows 11 x64,
 and Bun 1.4.2 revision `1.4.2+744846f84`; both CLI exits were zero, captured process
 identities exited, and both stages were absent at 20 seconds without forced cleanup.
-Complete strict-profile admission and release packaging remain unverified.
+The later [landed-source Windows recheck](https://github.com/gyldlab/keld/issues/174#issuecomment-5644295973)
+rebuilt PR #228's merge commit and confirmed two stock Close/cleanup/relaunch runs with
+zero exits and all 16 captured original process identities gone. No forced cleanup was
+used; this remains a captured census, not an exhaustive all-time child census or
+strict/release-profile qualification. Complete strict-profile admission and release
+packaging remain unverified.
 
 The [newer Linux relaunch/early-interrupt record](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
 tested [PR #184](https://github.com/gyldlab/keld/pull/184) and produced no `KELD-CORE`
-diagnostic while passing cleanup/relaunch observables. That cancellation fix remains a
-separate unmerged candidate, so this documentation change does not claim it landed on
-`main`.
+diagnostic while passing cleanup/relaunch observables. PR #184 has since merged as
+9ad79936f7b999b960846c850c83790306525c17; its cancellation fix is on `main`.
 
 The generated app is the canonical current example. Its `index.html` is the renderer;
 `src/main.ts` contains the app-link client and echo. It is not an Electron migration

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -156,13 +156,17 @@ The [Windows stock native-Close capture](https://github.com/gyldlab/keld/issues/
 qualifies two runs on source `62f4cc1a71a02db8d3b3a5959f2bbf6ba1a9a0c8`, Windows 11 x64,
 and Bun 1.4.2 revision `1.4.2+744846f84`; both CLI exits were zero, captured process
 identities exited, and both stages were absent at 20 seconds without forced cleanup.
-Complete strict-profile admission and release packaging remain unverified.
+The later [landed-source Windows recheck](https://github.com/gyldlab/keld/issues/174#issuecomment-5644295973)
+rebuilt PR #228's merge commit and confirmed two stock Close/cleanup/relaunch runs with
+zero exits and all 16 captured original process identities gone. No forced cleanup was
+used; this remains a captured census, not an exhaustive all-time child census or
+strict/release-profile qualification. Complete strict-profile admission and release
+packaging remain unverified.
 
 The [newer Linux relaunch/early-interrupt record](https://github.com/gyldlab/keld/issues/175#issuecomment-5588845871)
 tested [PR #184](https://github.com/gyldlab/keld/pull/184) and produced no `KELD-CORE`
-diagnostic while passing cleanup/relaunch observables. That cancellation fix remains a
-separate unmerged candidate, so this documentation change does not claim it landed on
-`main`.
+diagnostic while passing cleanup/relaunch observables. PR #184 has since merged as
+9ad79936f7b999b960846c850c83790306525c17; its cancellation fix is on `main`.
 
 The generated app is the canonical current example. Its `index.html` is the renderer;
 `src/main.ts` contains the app-link client and echo. It is not an Electron migration


### PR DESCRIPTION
## Summary

- Update onboarding current-status text to cite the landed-source Windows native-Close recheck, preserving the captured-census and strict/release limits.
- Correct the stale claim that PR #184 remains unmerged; preserve the distinct historical Windows 62f4 capture.

## Spec refs

No boundary change

## Review gates

none

## Tests

- just llms: exit 0; just llms-test: 6 passed; just llms-check: exit 0.
- just ci: exit 0. cargo fmt --all --check; cargo clippy --workspace --all-targets -- -D warnings; cargo nextest run --workspace --profile ci (659 passed, 6 skipped); cargo doc; cargo deny; pinned Mermaid render (9 diagrams); router, hygiene, and TypeScript lanes all passed.

## Platforms

Windows 11 CI ran the full local gate successfully. The linked Windows device result is the landed-source recheck recorded at issue 174 comment 5644295973; this documentation change claims no new product run. The cited result is limited to its captured census and device, with strict-profile and release packaging unqualified. Linux native-Close qualification remains limited to its documented environment; macOS native Close, X11, other distributions, and release packaging remain unverified.

## Perf impact

none

## Linear

KEL-231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated onboarding guidance with Windows 11 native Close/cleanup/relaunch verification across two runs, including successful process cleanup and nonce-stage checks.
  - Clarified that the Windows results represent a captured census, not exhaustive or release-profile qualification.
  - Added Linux native-Close evidence and updated the cancellation record to reflect that the fix is now on the main branch.
  - Synchronized these verification details across the full documentation corpus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->