### PR TITLE
fix(kipc): use monotonic write deadlines

### DIFF
--- a/packages/@keld/kipc/src/transport.test.ts
+++ b/packages/@keld/kipc/src/transport.test.ts
@@ -562,6 +562,72 @@ describe("DrainSignal / WriteQueue", () => {
     await Promise.all([first, second]);
   });
 
+  test("wall-clock jumps do not expire a progressing write", async () => {
+    const originalDateNow = Date.now;
+    let wallOffsetMs = 0;
+    let writes = 0;
+    let allowCompletion = false;
+    let pending: Promise<void> | undefined;
+    let observeFirstWrite!: () => void;
+    let observeSecondWrite!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      observeFirstWrite = resolve;
+    });
+    const secondWrite = new Promise<void>((resolve) => {
+      observeSecondWrite = resolve;
+    });
+    const beforeWatchdog = async <T>(promise: Promise<T>, stage: string): Promise<T> => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const watchdog = new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`test watchdog expired: ${stage}`)), 500);
+      });
+      try {
+        return await Promise.race([promise, watchdog]);
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
+    };
+    const drain = new DrainSignal();
+    const queue = new WriteQueue(
+      {
+        write(data: Uint8Array): number {
+          writes += 1;
+          if (writes === 1) observeFirstWrite();
+          if (writes === 2) observeSecondWrite();
+          return allowCompletion ? data.length : 0;
+        },
+        end(): void {},
+      },
+      drain,
+    );
+    Date.now = () => originalDateNow() + wallOffsetMs;
+
+    try {
+      const writing = queue.writeFrame(FrameKind.Ping, 0, 0, 1, new Uint8Array());
+      pending = writing;
+      await beforeWatchdog(firstWrite, "first write");
+      expect(writes).toBe(1);
+
+      wallOffsetMs = -60_000;
+      drain.fire();
+      await beforeWatchdog(secondWrite, "second write after rollback");
+      expect(writes).toBe(2);
+
+      wallOffsetMs = 60_000;
+      allowCompletion = true;
+      drain.fire();
+      await expect(
+        beforeWatchdog(writing, "write completion after forward jump"),
+      ).resolves.toBeUndefined();
+      expect(writes).toBe(3);
+    } finally {
+      Date.now = originalDateNow;
+      allowCompletion = true;
+      drain.fire();
+      await pending?.catch(() => undefined);
+    }
+  });
+
   test("a failed mid-frame write poisons later writes", async () => {
     const out: number[] = [];
     let writes = 0;

--- a/packages/@keld/kipc/src/transport.ts
+++ b/packages/@keld/kipc/src/transport.ts
@@ -802,10 +802,10 @@ async function writeOneFrame(
   const frame = new Uint8Array(header.length + payload.length);
   frame.set(header, 0);
   frame.set(payload, header.length);
-  const deadlineAt = Date.now() + APP_LINK_IO_DEADLINE_MS;
+  const deadlineAt = performance.now() + APP_LINK_IO_DEADLINE_MS;
   let offset = 0;
   while (offset < frame.length) {
-    const remaining = deadlineAt - Date.now();
+    const remaining = deadlineAt - performance.now();
     if (remaining <= 0) {
       throw ioDeadlineExceeded();
     }


### PR DESCRIPTION
## Summary

- Keep the canonical TypeScript writer's five-second frame deadline tied to elapsed monotonic time when the wall clock moves.
- Add a failure-first regression that moves `Date.now()` backward and forward across drain wakes while a write makes progress.

## Spec refs

- `docs/architecture/02-ipc.md` §2: v0 app-link I/O deadline and drain-driven writer contract.
- `docs/specs/kel136-generated-ts-app-link-transport.md` §§3–4: one canonical `WriteQueue`, multi-waiter drain, absolute write deadline, serialized writes, and poisoned failure state.
- No boundary change: handle ownership, crash ownership, and principal minting are unchanged.

## Review gates

- unsafe: none
- public API: none
- permission model: none
- dependency addition: none
- wire protocol: none

## Tests

- Failure-first on frozen main `6eacdb01e1965010a7c234e3dbbd8d94a0903bfd`: focused regression selected one test and failed `0 pass / 1 fail` because the progressing write rejected `KELD-IPC-006` before its third socket write.
- `bun test --test-name-pattern "wall-clock jumps do not expire a progressing write" src/transport.test.ts`: `1 pass / 0 fail` on final source.
- Paired final probe: unchanged control and a `-60000 ms` `Date.now()` rollback both rejected `KELD-IPC-006` at approximately `5000 ms`; the pending writes settled and timers were cleared.
- `just ci` on `500cc0b92bb4cc42bcf411e9ced2931b6208be68`: passed, including `cargo fmt --all --check`, warning-denied workspace Clippy, strict TypeScript checks, canonical kipc `38/38`, Electron `32 pass / 10 Windows-inapplicable Unix-peer skips`, generated-doc checks, Rustdoc, Mermaid render checks, hygiene, and `cargo deny check`.
- `cargo nextest run --workspace --profile ci`: `659 passed / 6 skipped / 0 failed`.

## Platforms

- Windows 11 RAMANI, Bun `1.4.2+744846f84`: exercised the actual exported `WriteQueue` and `DrainSignal` with process-local wall-clock replacement, real Bun timers, and a zero-progress mock socket.
- This evidence proves the Bun writer algorithm under controlled wall-time changes. It does not claim a native OS clock adjustment or native socket behavior.
- Portable TypeScript behavior is covered by the repository's Bun lane; Unix-peer Electron cases are locally skipped on Windows and remain CI-owned.

## Perf impact

None claimed. The patch replaces two clock reads in the existing write loop and adds no allocation, queue, copy, runtime, retry, or timeout-policy change.
